### PR TITLE
fix: fix command injection in terminal execution

### DIFF
--- a/src/better_telegram_mcp/server.py
+++ b/src/better_telegram_mcp/server.py
@@ -107,10 +107,12 @@ def _open_auth_terminal(settings: Settings) -> bool:
     if settings.password:
         env["TELEGRAM_PASSWORD"] = settings.password
 
-    if terminal == "gnome-terminal":
+    if terminal in ["gnome-terminal", "konsole", "xfce4-terminal", "mate-terminal"]:
         cmd = [terminal, "--", sys.executable, auth_script]
+    elif terminal == "xterm":
+        cmd = [terminal, "-e", sys.executable, auth_script]
     else:
-        cmd = [terminal, "-e", f"{sys.executable} {auth_script}"]
+        cmd = [terminal, "-e", sys.executable, auth_script]
 
     try:
         subprocess.Popen(cmd, env=env)  # noqa: S603


### PR DESCRIPTION
🚨 **Severity:** MEDIUM

💡 **Vulnerability:**
The `server.py` used string interpolation (`f"{sys.executable} {auth_script}"`) when executing an auth script in a separate terminal emulator via `subprocess.Popen()`. This implicitly relies on the terminal emulator's shell parsing behavior and poses a command injection risk if the path to the Python executable or the auth script contains spaces or shell-special characters.

🎯 **Impact:**
Subtle command injection or path parsing errors could result in arbitrary code execution or auth script failure depending on the directory paths used to install the application.

🔧 **Fix:**
Refactored the `subprocess.Popen` arguments to be passed as a list of independent strings instead of a single concatenated string. Standardized the argument handling for the specified terminal emulators (e.g., using `--` for `gnome-terminal`, `konsole`, `xfce4-terminal`, and `mate-terminal`, and using `-e` for `xterm`).

✅ **Verification:**
Verified the change via `uv run ruff check .` and `uv run pytest`. The code change does not introduce regressions and improves the robustness and security of the subprocess execution.

---
*PR created automatically by Jules for task [18088780984872627262](https://jules.google.com/task/18088780984872627262) started by @n24q02m*