### PR TITLE
fix: fix command injection risk in terminal invocation

### DIFF
--- a/src/better_telegram_mcp/server.py
+++ b/src/better_telegram_mcp/server.py
@@ -107,10 +107,13 @@ def _open_auth_terminal(settings: Settings) -> bool:
     if settings.password:
         env["TELEGRAM_PASSWORD"] = settings.password
 
-    if terminal == "gnome-terminal":
+    # SECURITY: Prevent argument/command injection by avoiding shell=True
+    # and properly separating executable commands from terminal arguments.
+    if terminal in ("gnome-terminal", "konsole", "xfce4-terminal", "mate-terminal"):
         cmd = [terminal, "--", sys.executable, auth_script]
     else:
-        cmd = [terminal, "-e", f"{sys.executable} {auth_script}"]
+        # xterm uses -e, which executes the rest of the arguments
+        cmd = [terminal, "-e", sys.executable, auth_script]
 
     try:
         subprocess.Popen(cmd, env=env)  # noqa: S603

--- a/tests/test_auth_terminal.py
+++ b/tests/test_auth_terminal.py
@@ -107,6 +107,7 @@ class TestOpenAuthTerminal:
             cmd = mock_popen.call_args[0][0]
             assert cmd[0] == "xterm"
             assert cmd[1] == "-e"
+            assert len(cmd) == 4
 
     def test_passes_password_env(self):
         from better_telegram_mcp.server import _open_auth_terminal


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: When invoking xterm using `subprocess.Popen`, the authentication script string (`f"{sys.executable} {auth_script}"`) was being passed as a single list element after the `-e` flag. Depending on the environment, file paths with shell meta-characters or spaces could be parsed unsafely by xterm, resulting in potential command or argument injection.
🎯 Impact: An attacker or malicious file path could inject shell commands that execute automatically when the authentication terminal is launched.
🔧 Fix: For `xterm`, separated the elements of the executable into distinct arguments within the list passed to `Popen` (e.g. `['xterm', '-e', sys.executable, auth_script]`). For other popular GTK/Qt terminals (GNOME Terminal, Konsole, XFCE4 Terminal, MATE Terminal), the list separates terminal flags from process execution by using the explicitly safe `--` argument. Added a security comment to the implementation, and a learning entry in `.jules/sentinel.md`. Also updated `test_opens_xterm` in `tests/test_auth_terminal.py`.
✅ Verification: Ran `uv run pytest` which passed, confirming the `Popen` invocation list length correctly matches expected execution arguments.

---
*PR created automatically by Jules for task [17700041210615798597](https://jules.google.com/task/17700041210615798597) started by @n24q02m*