### PR TITLE
fix: fix Server-Side Request Forgery (SSRF) bypass via DNS resolution

### DIFF
--- a/src/better_telegram_mcp/backends/security.py
+++ b/src/better_telegram_mcp/backends/security.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ipaddress
+import socket
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -52,6 +53,21 @@ def validate_url(url: str) -> None:
         if hostname in ("localhost", "0.0.0.0"):  # noqa: S104
             msg = f"Access to {hostname} is blocked"
             raise SecurityError(msg) from None
+        # Try to resolve the hostname and check its IPs
+        try:
+            addr_info = socket.getaddrinfo(hostname, None)
+            for info in addr_info:
+                ip = info[4][0]
+                try:
+                    resolved_addr = ipaddress.ip_address(ip)
+                    for network in _BLOCKED_NETWORKS:
+                        if resolved_addr in network:
+                            msg = f"Access to internal/private IP {ip} (resolved from {hostname}) is blocked"
+                            raise SecurityError(msg)
+                except ValueError:
+                    pass
+        except socket.gaierror:
+            pass
 
 
 def validate_file_path(file_path: str, *, allowed_dir: Path | None = None) -> Path:

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "1.3.0"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The URL validation logic designed to prevent Server-Side Request Forgery (SSRF) only checked if the hostname was explicitly formed as an internal IP literal (e.g., `127.0.0.1`) or the exact strings `"localhost"` / `"0.0.0.0"`. It failed to resolve DNS, allowing attackers to bypass the check by providing hostnames that resolve to internal IPs (like `127.0.0.1.nip.io`).
🎯 Impact: An attacker could bypass the SSRF protection to make the server perform requests to internal or private IP addresses, potentially exposing sensitive internal services or data.
🔧 Fix: Updated the `validate_url` function in `src/better_telegram_mcp/backends/security.py` to perform DNS resolution (`socket.getaddrinfo`) on the hostname during validation. The resolved IPs are then checked against the `_BLOCKED_NETWORKS` list.
✅ Verification: Tested the new logic locally with a custom python script resolving `127.0.0.1.nip.io` and confirmed it successfully raises a `SecurityError`. Also verified that existing tests (`uv run pytest`) still pass. Journal entry recorded in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [1294066862735424554](https://jules.google.com/task/1294066862735424554) started by @n24q02m*