### PR TITLE
feat: avoid intermediate list allocations for history and chats

### DIFF
--- a/src/better_telegram_mcp/backends/user_backend.py
+++ b/src/better_telegram_mcp/backends/user_backend.py
@@ -33,9 +33,8 @@ class UserBackend(TelegramBackend):
 
     @staticmethod
     def _serialize_message(msg: Any) -> dict[str, Any]:
-        sender_id = None
-        if msg.sender_id is not None:
-            sender_id = msg.sender_id
+        # ⚡ Bolt: Cache property access to avoid double computation overhead
+        sender_id = msg.sender_id
         return {
             "message_id": msg.id,
             "text": msg.text or "",
@@ -226,15 +225,19 @@ class UserBackend(TelegramBackend):
         kwargs: dict[str, Any] = {"limit": limit}
         if offset_id is not None:
             kwargs["offset_id"] = offset_id
-        messages = await client.get_messages(chat_id, **kwargs)
-        # Using list comprehension is typically faster than generator
-        return [self._serialize_message(m) for m in messages]
+        # ⚡ Bolt: Use iter_messages to avoid intermediate TotalList allocation and double-iteration
+        return [
+            self._serialize_message(m)
+            async for m in client.iter_messages(chat_id, **kwargs)
+        ]
 
     # --- Chats ---
     async def list_chats(self, *, limit: int = 50) -> list[dict[str, Any]]:
         client = self._ensure_client()
-        dialogs = await client.get_dialogs(limit=limit)
-        return [self._serialize_dialog(d) for d in dialogs]
+        # ⚡ Bolt: Use iter_dialogs to skip intermediate TotalList allocation
+        return [
+            self._serialize_dialog(d) async for d in client.iter_dialogs(limit=limit)
+        ]
 
     async def get_chat_info(self, chat_id: str | int) -> dict[str, Any]:
         client = self._ensure_client()

--- a/tests/test_backends/test_user_backend.py
+++ b/tests/test_backends/test_user_backend.py
@@ -340,7 +340,14 @@ class TestGetHistory:
         from better_telegram_mcp.backends.user_backend import UserBackend
 
         msgs = [_mock_message(msg_id=i) for i in range(5)]
-        mock_client.get_messages = AsyncMock(return_value=msgs)
+
+        async def mock_iter_messages(*args, **kwargs):
+            for m in msgs:
+                yield m
+
+        from unittest.mock import MagicMock
+
+        mock_client.iter_messages = MagicMock(side_effect=mock_iter_messages)
 
         settings = _make_settings(tmp_path)
         backend = UserBackend(settings)
@@ -349,14 +356,20 @@ class TestGetHistory:
         result = await backend.get_history(123, limit=5)
 
         assert len(result) == 5
-        mock_client.get_messages.assert_awaited_once_with(123, limit=5)
+        mock_client.iter_messages.assert_called_once_with(123, limit=5)
 
     async def test_get_history_with_offset(
         self, tmp_path, mock_client, mock_client_class
     ):
         from better_telegram_mcp.backends.user_backend import UserBackend
 
-        mock_client.get_messages = AsyncMock(return_value=[])
+        async def mock_iter_messages_empty(*args, **kwargs):
+            if False:
+                yield None
+
+        from unittest.mock import MagicMock
+
+        mock_client.iter_messages = MagicMock(side_effect=mock_iter_messages_empty)
 
         settings = _make_settings(tmp_path)
         backend = UserBackend(settings)
@@ -364,7 +377,7 @@ class TestGetHistory:
 
         await backend.get_history(123, limit=10, offset_id=50)
 
-        mock_client.get_messages.assert_awaited_once_with(123, limit=10, offset_id=50)
+        mock_client.iter_messages.assert_called_once_with(123, limit=10, offset_id=50)
 
 
 class TestListChats:
@@ -372,7 +385,14 @@ class TestListChats:
         from better_telegram_mcp.backends.user_backend import UserBackend
 
         dialogs = [_mock_dialog(i, f"Chat {i}") for i in range(3)]
-        mock_client.get_dialogs = AsyncMock(return_value=dialogs)
+
+        async def mock_iter_dialogs(*args, **kwargs):
+            for d in dialogs:
+                yield d
+
+        from unittest.mock import MagicMock
+
+        mock_client.iter_dialogs = MagicMock(side_effect=mock_iter_dialogs)
 
         settings = _make_settings(tmp_path)
         backend = UserBackend(settings)
@@ -382,7 +402,7 @@ class TestListChats:
 
         assert len(result) == 3
         assert result[1]["title"] == "Chat 1"
-        mock_client.get_dialogs.assert_awaited_once_with(limit=10)
+        mock_client.iter_dialogs.assert_called_once_with(limit=10)
 
 
 class TestGetChatInfo:

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "1.3.0"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
💡 What: Switched from `get_messages`/`get_dialogs` to `iter_messages`/`iter_dialogs` inside async list comprehensions in `UserBackend` and updated the corresponding mock tests.
🎯 Why: `get_messages()` internally collects all yielded objects into a `TotalList`, forcing an O(N) memory allocation and O(N) iteration, only for our code to immediately iterate over it again to serialize. Using `iter_*` with an async list comprehension skips the intermediate allocation and traverses the data once.
📊 Impact: Measurable reduction in peak memory and fewer CPU cycles per fetch when `limit` is high. O(N) fewer intermediate objects created.
🔬 Measurement: Observe memory footprint via profiler or `tracemalloc` when fetching 1000 items; intermediate `TotalList` of heavy `Message` or `Dialog` objects is no longer allocated.

---
*PR created automatically by Jules for task [5485007167812198858](https://jules.google.com/task/5485007167812198858) started by @n24q02m*