### PR TITLE
fix: fix SSRF vulnerability in validate_url via DNS resolution

### DIFF
--- a/src/better_telegram_mcp/backends/security.py
+++ b/src/better_telegram_mcp/backends/security.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ipaddress
+import socket
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -39,19 +40,26 @@ def validate_url(url: str) -> None:
     if hostname in ("metadata.google.internal", "metadata.internal"):
         msg = "Access to cloud metadata endpoints is blocked"
         raise SecurityError(msg)
-    # Resolve and check IP
+    # Resolve and check IPs
+    # Not an IP literal -- resolve to prevent SSRF via DNS like 127.0.0.1.nip.io
+    # Block known dangerous hostnames as an early check
+    if hostname in ("localhost", "0.0.0.0"):  # noqa: S104
+        msg = f"Access to {hostname} is blocked"
+        raise SecurityError(msg)
     try:
-        addr = ipaddress.ip_address(hostname)
-        for network in _BLOCKED_NETWORKS:
-            if addr in network:
-                msg = f"Access to internal/private IP {hostname} is blocked"
-                raise SecurityError(msg)
-    except ValueError:
-        # Not an IP literal -- hostname resolution happens at fetch time
-        # Block known dangerous hostnames
-        if hostname in ("localhost", "0.0.0.0"):  # noqa: S104
-            msg = f"Access to {hostname} is blocked"
-            raise SecurityError(msg) from None
+        # Get all IPs for this hostname
+        addr_info = socket.getaddrinfo(hostname, None)
+        for _, _, _, _, sockaddr in addr_info:
+            ip_str = sockaddr[0]
+            addr = ipaddress.ip_address(ip_str)
+            for network in _BLOCKED_NETWORKS:
+                if addr in network:
+                    msg = f"Access to internal/private IP {ip_str} ({hostname}) is blocked"
+                    raise SecurityError(msg)
+    except OSError:
+        # If hostname resolution fails, let it pass security validation
+        # (It will fail later when actually trying to connect)
+        pass
 
 
 def validate_file_path(file_path: str, *, allowed_dir: Path | None = None) -> Path:

--- a/tests/test_backends/test_security.py
+++ b/tests/test_backends/test_security.py
@@ -72,6 +72,22 @@ class TestValidateUrl:
     def test_public_ip_allowed(self):
         validate_url("https://93.184.216.34/image.jpg")
 
+    def test_dns_resolution_blocks_internal(self, monkeypatch):
+        # Mock socket.getaddrinfo to simulate malicious domain resolving to 127.0.0.1
+        monkeypatch.setattr(
+            "socket.getaddrinfo", lambda host, port: [(2, 1, 6, "", ("127.0.0.1", 80))]
+        )
+        with pytest.raises(SecurityError, match="internal/private"):
+            validate_url("http://malicious-domain-resolving-to-local.com/admin")
+
+    def test_dns_resolution_allows_external(self, monkeypatch):
+        # Mock socket.getaddrinfo to simulate benign domain resolving to public IP
+        monkeypatch.setattr(
+            "socket.getaddrinfo",
+            lambda host, port: [(2, 1, 6, "", ("93.184.216.34", 80))],
+        )
+        validate_url("http://example.com/image.jpg")
+
 
 class TestValidateFilePath:
     def test_normal_path_allowed(self):

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "2.0.0"
+version = "3.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The application was using literal IP address and hostname string checks for SSRF protection in `validate_url`, failing to protect against malicious DNS records (e.g., `127.0.0.1.nip.io`) that resolve to private/internal IPs.
🎯 **Impact:** An attacker could bypass the internal IP filter to send requests to local services (SSRF) by setting up a domain that resolves to an internal/private IP.
🔧 **Fix:** Added `socket.getaddrinfo(hostname, None)` to resolve the host during validation. All returned IP addresses are then evaluated against the `_BLOCKED_NETWORKS` list.
✅ **Verification:** Added test cases using `monkeypatch` to mock `socket.getaddrinfo`, simulating a domain resolving to an internal IP to verify it throws a `SecurityError`. Tested manually, run `uv run pytest`, and verified that the formatter passes via `uv run ruff format .` and `uv run ruff check .`.

---
*PR created automatically by Jules for task [15969795179195098882](https://jules.google.com/task/15969795179195098882) started by @n24q02m*