### PR TITLE
fix: fix SSRF bypass via DNS resolution

### DIFF
--- a/src/better_telegram_mcp/backends/security.py
+++ b/src/better_telegram_mcp/backends/security.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ipaddress
+import socket
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -47,11 +48,25 @@ def validate_url(url: str) -> None:
                 msg = f"Access to internal/private IP {hostname} is blocked"
                 raise SecurityError(msg)
     except ValueError:
-        # Not an IP literal -- hostname resolution happens at fetch time
-        # Block known dangerous hostnames
+        # Not an IP literal -- block known dangerous hostnames
         if hostname in ("localhost", "0.0.0.0"):  # noqa: S104
             msg = f"Access to {hostname} is blocked"
             raise SecurityError(msg) from None
+        # Resolve hostname to check underlying IP addresses
+        try:
+            addr_infos = socket.getaddrinfo(hostname, None)
+            for addr_info in addr_infos:
+                ip_str = addr_info[4][0]
+                try:
+                    resolved_addr = ipaddress.ip_address(ip_str)
+                    for network in _BLOCKED_NETWORKS:
+                        if resolved_addr in network:
+                            msg = f"Access to internal/private IP {ip_str} via {hostname} is blocked"
+                            raise SecurityError(msg)
+                except ValueError:
+                    continue  # Should not happen with getaddrinfo results
+        except socket.gaierror:
+            pass  # Hostname could not be resolved; handled by client during fetch
 
 
 def validate_file_path(file_path: str, *, allowed_dir: Path | None = None) -> Path:

--- a/tests/test_backends/test_security.py
+++ b/tests/test_backends/test_security.py
@@ -72,6 +72,20 @@ class TestValidateUrl:
     def test_public_ip_allowed(self):
         validate_url("https://93.184.216.34/image.jpg")
 
+    def test_dns_ssrf_blocked(self, monkeypatch):
+        import socket
+
+        # Mock getaddrinfo to return a private IP for a public-looking domain
+        def mock_getaddrinfo(host, port, *args, **kwargs):
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 0))]
+
+        monkeypatch.setattr("socket.getaddrinfo", mock_getaddrinfo)
+        with pytest.raises(
+            SecurityError,
+            match="internal/private IP 127.0.0.1 via my-malicious-domain.com is blocked",
+        ):
+            validate_url("http://my-malicious-domain.com/admin")
+
 
 class TestValidateFilePath:
     def test_normal_path_allowed(self):

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "2.0.0"
+version = "3.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `validate_url` function blocked internal IP literals (e.g., `127.0.0.1`) but lacked hostname resolution checking. Attackers could bypass SSRF protections by using public DNS records that resolve to internal IPs (e.g., `127.0.0.1.nip.io`).
🎯 **Impact:** If exploited, attackers could interact with internal network resources (such as loopback, `10.0.0.0/8`, `192.168.0.0/16`, etc.) leading to potential remote code execution or data exposure from internally accessible services. 
🔧 **Fix:** Updated `validate_url` to use `socket.getaddrinfo` to resolve the provided hostname into IP addresses and enforce the existing `_BLOCKED_NETWORKS` check against all resolved underlying IPs.
✅ **Verification:** Added `test_dns_ssrf_blocked` which explicitly mocks `socket.getaddrinfo` to return an internal IP address (`127.0.0.1`) for an ostensibly safe domain, ensuring `SecurityError` is appropriately raised. All security validations and CI test suites pass flawlessly. Also updated Sentinel journal.

---
*PR created automatically by Jules for task [2267615311520742974](https://jules.google.com/task/2267615311520742974) started by @n24q02m*