### PR TITLE
fix: refactor config tool dispatch]

### DIFF
--- a/src/better_telegram_mcp/tools/config_tool.py
+++ b/src/better_telegram_mcp/tools/config_tool.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 from ..backends.base import TelegramBackend
 from ..utils.formatting import err, ok, safe_error
 
 
-async def _handle_status(backend: TelegramBackend) -> str:
+async def _handle_status(backend: TelegramBackend, **kwargs: Any) -> str:
     from ..server import _auth_url, _pending_auth, _runtime_config
 
     connected = await backend.is_connected()
@@ -23,7 +24,7 @@ async def _handle_status(backend: TelegramBackend) -> str:
     return ok(result)
 
 
-def _handle_set(**kwargs: Any) -> str:
+async def _handle_set(backend: TelegramBackend, **kwargs: Any) -> str:
     from ..server import _runtime_config
 
     updated: dict[str, int] = {}
@@ -36,9 +37,16 @@ def _handle_set(**kwargs: Any) -> str:
     return ok({"updated": updated, "current": _runtime_config})
 
 
-async def _handle_cache_clear(backend: TelegramBackend) -> str:
+async def _handle_cache_clear(backend: TelegramBackend, **kwargs: Any) -> str:
     await backend.clear_cache()
     return ok({"message": "Cache cleared."})
+
+
+_HANDLERS: dict[str, Callable[..., Awaitable[str]]] = {
+    "status": _handle_status,
+    "set": _handle_set,
+    "cache_clear": _handle_cache_clear,
+}
 
 
 async def handle_config(
@@ -47,14 +55,9 @@ async def handle_config(
     **kwargs: Any,
 ) -> str:
     try:
-        match action:
-            case "status":
-                return await _handle_status(backend)
-            case "set":
-                return _handle_set(**kwargs)
-            case "cache_clear":
-                return await _handle_cache_clear(backend)
-            case _:
-                return err(f"Unknown action '{action}'. Valid: status|set|cache_clear")
+        handler = _HANDLERS.get(action)
+        if not handler:
+            return err(f"Unknown action '{action}'. Valid: status|set|cache_clear")
+        return await handler(backend=backend, **kwargs)
     except Exception as e:
         return safe_error(e)


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
The `handle_config` function in `src/better_telegram_mcp/tools/config_tool.py` was getting too long due to a `match` statement for handling different tool actions (`status`, `set`, `cache_clear`).

💡 **Why:** How this improves maintainability
Using a `match` statement for action dispatching can lead to high cyclomatic complexity (Ruff C901), making the code harder to read and extend. By standardizing handler function signatures and refactoring the logic to use dictionary-based dispatch (`_HANDLERS`), adding new actions in the future only requires appending to the dictionary without modifying the core logic of `handle_config`.

✅ **Verification:** How you confirmed the change is safe
- Executed `uv run pytest tests/test_tools/test_config_tool.py` to ensure all functionality is preserved.
- Executed the full test suite with `uv run pytest`.
- Ran format and lint checks (`uv run ruff format .` and `uv run ruff check`).
- Ensured uniform `async def <name>(backend: TelegramBackend, **kwargs: Any) -> str` signature for all internal config handler functions.

✨ **Result:** The improvement achieved
The `handle_config` function is now significantly shorter and follows the preferred dictionary-dispatch pattern, enhancing modularity and readibility.

---
*PR created automatically by Jules for task [338616357566798845](https://jules.google.com/task/338616357566798845) started by @n24q02m*