### PR TITLE
feat: refactor `handle_media` to use `MediaOptions` struct]

### DIFF
--- a/src/better_telegram_mcp/server.py
+++ b/src/better_telegram_mcp/server.py
@@ -15,7 +15,7 @@ from .tools.chats import ChatOptions, handle_chats
 from .tools.config_tool import handle_config
 from .tools.contacts import ContactsArgs, handle_contacts
 from .tools.help_tool import handle_help
-from .tools.media import handle_media
+from .tools.media import MediaOptions, handle_media
 from .tools.messages import handle_messages
 from .utils.formatting import err
 
@@ -247,11 +247,13 @@ async def media(
     return await handle_media(
         get_backend(),
         action,
-        chat_id=chat_id,
-        file_path_or_url=file_path_or_url,
-        message_id=message_id,
-        caption=caption,
-        output_dir=output_dir,
+        MediaOptions(
+            chat_id=chat_id,
+            file_path_or_url=file_path_or_url,
+            message_id=message_id,
+            caption=caption,
+            output_dir=output_dir,
+        ),
     )
 
 

--- a/src/better_telegram_mcp/tools/media.py
+++ b/src/better_telegram_mcp/tools/media.py
@@ -1,7 +1,24 @@
 from __future__ import annotations
 
+from pydantic import BaseModel, Field
+
 from ..backends.base import ModeError, TelegramBackend
 from ..utils.formatting import err, ok, safe_error
+
+
+class MediaOptions(BaseModel):
+    chat_id: str | int | None = Field(default=None, description="ID of the chat")
+    file_path_or_url: str | None = Field(
+        default=None, description="Path or URL of the file to send"
+    )
+    message_id: int | None = Field(
+        default=None, description="Message ID for downloading"
+    )
+    caption: str | None = Field(default=None, description="Caption for the media")
+    output_dir: str | None = Field(
+        default=None, description="Output directory for download"
+    )
+
 
 _ACTION_TO_MEDIA_TYPE = {
     "send_photo": "photo",
@@ -14,28 +31,26 @@ _ACTION_TO_MEDIA_TYPE = {
 async def handle_media(
     backend: TelegramBackend,
     action: str,
-    *,
-    chat_id: str | int | None = None,
-    file_path_or_url: str | None = None,
-    message_id: int | None = None,
-    caption: str | None = None,
-    output_dir: str | None = None,
+    options: MediaOptions,
 ) -> str:
     try:
         if action in _ACTION_TO_MEDIA_TYPE:
-            if not chat_id or not file_path_or_url:
+            if not options.chat_id or not options.file_path_or_url:
                 return err(f"'{action}' requires chat_id and file_path_or_url")
             media_type = _ACTION_TO_MEDIA_TYPE[action]
             result = await backend.send_media(
-                chat_id, media_type, file_path_or_url, caption=caption
+                options.chat_id,
+                media_type,
+                options.file_path_or_url,
+                caption=options.caption,
             )
             return ok(result)
 
         if action == "download":
-            if not chat_id or message_id is None:
+            if not options.chat_id or options.message_id is None:
                 return err("'download' requires chat_id and message_id")
             path = await backend.download_media(
-                chat_id, message_id, output_dir=output_dir
+                options.chat_id, options.message_id, output_dir=options.output_dir
             )
             return ok({"path": path})
 

--- a/tests/test_tools/test_media.py
+++ b/tests/test_tools/test_media.py
@@ -5,7 +5,7 @@ import json
 import pytest
 
 from better_telegram_mcp.backends.base import ModeError
-from better_telegram_mcp.tools.media import handle_media
+from better_telegram_mcp.tools.media import MediaOptions, handle_media
 
 
 @pytest.mark.asyncio
@@ -14,9 +14,11 @@ async def test_send_photo(mock_backend):
         await handle_media(
             mock_backend,
             "send_photo",
-            chat_id=123,
-            file_path_or_url="https://example.com/photo.jpg",
-            caption="Nice photo",
+            MediaOptions(
+                chat_id=123,
+                file_path_or_url="https://example.com/photo.jpg",
+                caption="Nice photo",
+            ),
         )
     )
     assert result["message_id"] == 3
@@ -31,8 +33,10 @@ async def test_send_file(mock_backend):
         await handle_media(
             mock_backend,
             "send_file",
-            chat_id=123,
-            file_path_or_url="/tmp/doc.pdf",
+            MediaOptions(
+                chat_id=123,
+                file_path_or_url="/tmp/doc.pdf",
+            ),
         )
     )
     assert result["message_id"] == 3
@@ -47,8 +51,10 @@ async def test_send_voice(mock_backend):
         await handle_media(
             mock_backend,
             "send_voice",
-            chat_id=123,
-            file_path_or_url="/tmp/voice.ogg",
+            MediaOptions(
+                chat_id=123,
+                file_path_or_url="/tmp/voice.ogg",
+            ),
         )
     )
     assert result["message_id"] == 3
@@ -63,8 +69,10 @@ async def test_send_video(mock_backend):
         await handle_media(
             mock_backend,
             "send_video",
-            chat_id=123,
-            file_path_or_url="/tmp/video.mp4",
+            MediaOptions(
+                chat_id=123,
+                file_path_or_url="/tmp/video.mp4",
+            ),
         )
     )
     assert result["message_id"] == 3
@@ -75,14 +83,18 @@ async def test_send_video(mock_backend):
 
 @pytest.mark.asyncio
 async def test_send_photo_missing_params(mock_backend):
-    result = json.loads(await handle_media(mock_backend, "send_photo", chat_id=123))
+    result = json.loads(
+        await handle_media(mock_backend, "send_photo", MediaOptions(chat_id=123))
+    )
     assert "error" in result
 
     result = json.loads(
         await handle_media(
             mock_backend,
             "send_photo",
-            file_path_or_url="https://example.com/photo.jpg",
+            MediaOptions(
+                file_path_or_url="https://example.com/photo.jpg",
+            ),
         )
     )
     assert "error" in result
@@ -94,9 +106,11 @@ async def test_download(mock_backend):
         await handle_media(
             mock_backend,
             "download",
-            chat_id=123,
-            message_id=10,
-            output_dir="/tmp",
+            MediaOptions(
+                chat_id=123,
+                message_id=10,
+                output_dir="/tmp",
+            ),
         )
     )
     assert result["path"] == "/tmp/file.jpg"
@@ -104,16 +118,20 @@ async def test_download(mock_backend):
 
 @pytest.mark.asyncio
 async def test_download_missing_params(mock_backend):
-    result = json.loads(await handle_media(mock_backend, "download", chat_id=123))
+    result = json.loads(
+        await handle_media(mock_backend, "download", MediaOptions(chat_id=123))
+    )
     assert "error" in result
 
-    result = json.loads(await handle_media(mock_backend, "download", message_id=10))
+    result = json.loads(
+        await handle_media(mock_backend, "download", MediaOptions(message_id=10))
+    )
     assert "error" in result
 
 
 @pytest.mark.asyncio
 async def test_unknown_action(mock_backend):
-    result = json.loads(await handle_media(mock_backend, "unknown"))
+    result = json.loads(await handle_media(mock_backend, "unknown", MediaOptions()))
     assert "error" in result
     assert "Unknown action" in result["error"]
 
@@ -125,8 +143,10 @@ async def test_mode_error(mock_backend):
         await handle_media(
             mock_backend,
             "send_photo",
-            chat_id=123,
-            file_path_or_url="https://example.com/photo.jpg",
+            MediaOptions(
+                chat_id=123,
+                file_path_or_url="https://example.com/photo.jpg",
+            ),
         )
     )
     assert "error" in result
@@ -137,7 +157,9 @@ async def test_mode_error(mock_backend):
 async def test_general_exception(mock_backend):
     mock_backend.download_media.side_effect = RuntimeError("disk full")
     result = json.loads(
-        await handle_media(mock_backend, "download", chat_id=123, message_id=10)
+        await handle_media(
+            mock_backend, "download", MediaOptions(chat_id=123, message_id=10)
+        )
     )
     assert "error" in result
     assert "RuntimeError" in result["error"]

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "2.0.0"
+version = "3.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
🎯 **What:** Replaced the numerous keyword arguments in `handle_media` (in `src/better_telegram_mcp/tools/media.py`) with a single Pydantic `BaseModel` called `MediaOptions`.
💡 **Why:** Functions with many arguments are harder to read, use, and test. Using a configuration object (struct) improves the code health, readability, and future extensibility of the `media` tool logic.
✅ **Verification:** Verified by running `uv run pytest` successfully against the complete test suite. `uv run ruff check .`, `uv run ruff format .`, and `uv run ty check` were also used to ensure code style, formatting, and type-checking correctness without regressing functionality.
✨ **Result:** The `handle_media` function now expects a single `MediaOptions` object. This makes its usage in `server.py` and test cases cleaner and easier to maintain.

---
*PR created automatically by Jules for task [16240831134309270736](https://jules.google.com/task/16240831134309270736) started by @n24q02m*