### PR TITLE
feat: reduce cyclomatic complexity in handle_chats]

### DIFF
--- a/src/better_telegram_mcp/tools/chats.py
+++ b/src/better_telegram_mcp/tools/chats.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -24,95 +25,115 @@ class ChatOptions(BaseModel):
     topic_name: str | None = Field(default=None, description="Topic name to create")
 
 
+async def _handle_list(backend: TelegramBackend, options: ChatOptions) -> str:
+    results = await backend.list_chats(limit=options.limit)
+    return ok({"chats": results, "count": len(results)})
+
+
+async def _handle_info(backend: TelegramBackend, options: ChatOptions) -> str:
+    if not options.chat_id:
+        return err("'info' requires chat_id")
+    result = await backend.get_chat_info(options.chat_id)
+    return ok(result)
+
+
+async def _handle_create(backend: TelegramBackend, options: ChatOptions) -> str:
+    if not options.title:
+        return err("'create' requires title")
+    result = await backend.create_chat(options.title, is_channel=options.is_channel)
+    return ok(result)
+
+
+async def _handle_join(backend: TelegramBackend, options: ChatOptions) -> str:
+    if not options.link_or_hash:
+        return err("'join' requires link_or_hash")
+    result = await backend.join_chat(options.link_or_hash)
+    return ok({"joined": result})
+
+
+async def _handle_leave(backend: TelegramBackend, options: ChatOptions) -> str:
+    if not options.chat_id:
+        return err("'leave' requires chat_id")
+    result = await backend.leave_chat(options.chat_id)
+    return ok({"left": result})
+
+
+async def _handle_members(backend: TelegramBackend, options: ChatOptions) -> str:
+    if not options.chat_id:
+        return err("'members' requires chat_id")
+    results = await backend.get_members(options.chat_id, limit=options.limit)
+    return ok({"members": results, "count": len(results)})
+
+
+async def _handle_admin(backend: TelegramBackend, options: ChatOptions) -> str:
+    if not options.chat_id or options.user_id is None:
+        return err("'admin' requires chat_id and user_id")
+    result = await backend.promote_admin(
+        options.chat_id, options.user_id, demote=options.demote
+    )
+    action_word = "demoted" if options.demote else "promoted"
+    return ok({action_word: result})
+
+
+async def _handle_settings(backend: TelegramBackend, options: ChatOptions) -> str:
+    if not options.chat_id:
+        return err("'settings' requires chat_id")
+    kwargs: dict[str, Any] = {}
+    if options.title is not None:
+        kwargs["title"] = options.title
+    if options.description is not None:
+        kwargs["description"] = options.description
+    if not kwargs:
+        return err("'settings' requires at least one of: title, description")
+    result = await backend.update_chat_settings(options.chat_id, **kwargs)
+    return ok({"updated": result})
+
+
+async def _handle_topics(backend: TelegramBackend, options: ChatOptions) -> str:
+    if not options.chat_id:
+        return err("'topics' requires chat_id")
+    if not options.topic_action:
+        return err("'topics' requires topic_action")
+    kwargs_t: dict[str, Any] = {}
+    if options.topic_id is not None:
+        kwargs_t["topic_id"] = options.topic_id
+    if options.topic_name is not None:
+        kwargs_t["name"] = options.topic_name
+    result = await backend.manage_topics(
+        options.chat_id, options.topic_action, **kwargs_t
+    )
+    return ok(result)
+
+
+_ACTION_HANDLERS: dict[
+    str, Callable[[TelegramBackend, ChatOptions], Awaitable[str]]
+] = {
+    "list": _handle_list,
+    "info": _handle_info,
+    "create": _handle_create,
+    "join": _handle_join,
+    "leave": _handle_leave,
+    "members": _handle_members,
+    "admin": _handle_admin,
+    "settings": _handle_settings,
+    "topics": _handle_topics,
+}
+
+
 async def handle_chats(
     backend: TelegramBackend,
     action: str,
     options: ChatOptions,
 ) -> str:
     try:
-        match action:
-            case "list":
-                results = await backend.list_chats(limit=options.limit)
-                return ok({"chats": results, "count": len(results)})
+        handler = _ACTION_HANDLERS.get(action)
+        if handler:
+            return await handler(backend, options)
 
-            case "info":
-                if not options.chat_id:
-                    return err("'info' requires chat_id")
-                result = await backend.get_chat_info(options.chat_id)
-                return ok(result)
-
-            case "create":
-                if not options.title:
-                    return err("'create' requires title")
-                result = await backend.create_chat(
-                    options.title, is_channel=options.is_channel
-                )
-                return ok(result)
-
-            case "join":
-                if not options.link_or_hash:
-                    return err("'join' requires link_or_hash")
-                result = await backend.join_chat(options.link_or_hash)
-                return ok({"joined": result})
-
-            case "leave":
-                if not options.chat_id:
-                    return err("'leave' requires chat_id")
-                result = await backend.leave_chat(options.chat_id)
-                return ok({"left": result})
-
-            case "members":
-                if not options.chat_id:
-                    return err("'members' requires chat_id")
-                results = await backend.get_members(
-                    options.chat_id, limit=options.limit
-                )
-                return ok({"members": results, "count": len(results)})
-
-            case "admin":
-                if not options.chat_id or options.user_id is None:
-                    return err("'admin' requires chat_id and user_id")
-                result = await backend.promote_admin(
-                    options.chat_id, options.user_id, demote=options.demote
-                )
-                action_word = "demoted" if options.demote else "promoted"
-                return ok({action_word: result})
-
-            case "settings":
-                if not options.chat_id:
-                    return err("'settings' requires chat_id")
-                kwargs: dict[str, Any] = {}
-                if options.title is not None:
-                    kwargs["title"] = options.title
-                if options.description is not None:
-                    kwargs["description"] = options.description
-                if not kwargs:
-                    return err(
-                        "'settings' requires at least one of: title, description"
-                    )
-                result = await backend.update_chat_settings(options.chat_id, **kwargs)
-                return ok({"updated": result})
-
-            case "topics":
-                if not options.chat_id:
-                    return err("'topics' requires chat_id")
-                if not options.topic_action:
-                    return err("'topics' requires topic_action")
-                kwargs_t: dict[str, Any] = {}
-                if options.topic_id is not None:
-                    kwargs_t["topic_id"] = options.topic_id
-                if options.topic_name is not None:
-                    kwargs_t["name"] = options.topic_name
-                result = await backend.manage_topics(
-                    options.chat_id, options.topic_action, **kwargs_t
-                )
-                return ok(result)
-
-            case _:
-                return err(
-                    f"Unknown action '{action}'. "
-                    "Valid: list|info|create|join|leave|members|admin|settings|topics"
-                )
+        return err(
+            f"Unknown action '{action}'. "
+            "Valid: list|info|create|join|leave|members|admin|settings|topics"
+        )
     except ModeError as e:
         return err(str(e))
     except Exception as e:


### PR DESCRIPTION
🎯 **What:** 
Refactored `handle_chats` in `src/better_telegram_mcp/tools/chats.py` to fix high cyclomatic complexity (C901).

💡 **Why:** 
The original `handle_chats` method had a cyclomatic complexity of 26 due to a large `match` statement handling 9 different actions within a `try/except` block. Extracting each action into smaller, well-named private handler functions and dispatching via a dictionary lookup `_ACTION_HANDLERS` makes the module more readable, easier to test, and simplifies adding or modifying actions in the future without expanding the monolithic function.

✅ **Verification:** 
- Ran `uv run ruff check src/better_telegram_mcp/tools/chats.py` to ensure complexity is resolved.
- Ran `uv run pytest tests/test_tools/test_chats.py` successfully.
- Ran the full test suite `uv run pytest` successfully to ensure no regressions were introduced.

✨ **Result:** 
Eliminated the C901 linting warning and created a cleaner, maintainable dictionary-based dispatch pattern for chat actions.

---
*PR created automatically by Jules for task [3365773438036850526](https://jules.google.com/task/3365773438036850526) started by @n24q02m*