### PR TITLE
feat: reduce arguments in contacts tool]

### DIFF
--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,0 +1,16 @@
+🧹 [Reduce arguments in contacts tool]
+
+🎯 What:
+Refactored the `contacts` tool function in `server.py` to accept a single `args` parameter of type `ContactsArgs` instead of six individual optional arguments. Updated `ContactsArgs` in `tools/contacts.py` to be a Pydantic `BaseModel` instead of a generic `@dataclass`, adding `Field(description=...)` to each property.
+
+💡 Why:
+Functions with many arguments are harder to use, read, and maintain. By passing a config object, the tool signature is drastically simplified. Using Pydantic `BaseModel` with `Field` descriptions ensures that the FastMCP framework can generate a comprehensive JSON schema that helps LLM clients understand exactly what each field does, improving the tool's usability for LLMs without changing its behavior.
+
+✅ Verification:
+- Ensured Pydantic `BaseModel` behaves correctly with the existing code pattern.
+- Successfully ran the entire test suite using `uv run pytest`.
+- Passed linting and formatting checks with `uv run ruff format .` and `uv run ruff check`.
+- Verified that `uv.lock` changes were not inadvertently included.
+
+✨ Result:
+A cleaner `contacts` function signature that is easier to maintain and better described for LLM clients via FastMCP schema generation.

--- a/src/better_telegram_mcp/server.py
+++ b/src/better_telegram_mcp/server.py
@@ -266,24 +266,15 @@ async def media(
 )
 async def contacts(
     action: str,
-    query: str | None = None,
-    phone: str | None = None,
-    first_name: str | None = None,
-    last_name: str | None = None,
-    user_id: int | None = None,
-    unblock: bool = False,
+    args: ContactsArgs | None = None,
 ) -> str:
     """list|search|add|block (user mode only)"""
     if _pending_auth:
         return _auth_required_response()
-    args = ContactsArgs(
-        query=query,
-        phone=phone,
-        first_name=first_name,
-        last_name=last_name,
-        user_id=user_id,
-        unblock=unblock,
-    )
+
+    if args is None:
+        args = ContactsArgs()
+
     return await handle_contacts(
         get_backend(),
         action,

--- a/src/better_telegram_mcp/tools/contacts.py
+++ b/src/better_telegram_mcp/tools/contacts.py
@@ -1,19 +1,24 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from pydantic import BaseModel, Field
 
 from ..backends.base import ModeError, TelegramBackend
 from ..utils.formatting import err, ok, safe_error
 
 
-@dataclass
-class ContactsArgs:
-    query: str | None = None
-    phone: str | None = None
-    first_name: str | None = None
-    last_name: str | None = None
-    user_id: int | None = None
-    unblock: bool = False
+class ContactsArgs(BaseModel):
+    query: str | None = Field(default=None, description="Search query for contacts")
+    phone: str | None = Field(
+        default=None, description="Phone number for adding a contact"
+    )
+    first_name: str | None = Field(
+        default=None, description="First name for adding a contact"
+    )
+    last_name: str | None = Field(
+        default=None, description="Last name for adding a contact"
+    )
+    user_id: int | None = Field(default=None, description="User ID to block/unblock")
+    unblock: bool = Field(default=False, description="Whether to unblock the user")
 
 
 async def handle_contacts(


### PR DESCRIPTION
🎯 **What:**
Refactored the `contacts` tool function in `server.py` to accept a single `args` parameter of type `ContactsArgs` instead of six individual optional arguments. Updated `ContactsArgs` in `tools/contacts.py` to be a Pydantic `BaseModel` instead of a generic `@dataclass`, adding `Field(description=...)` to each property.

💡 **Why:**
Functions with many arguments are harder to use, read, and maintain. By passing a config object, the tool signature is drastically simplified. Using Pydantic `BaseModel` with `Field` descriptions ensures that the FastMCP framework can generate a comprehensive JSON schema that helps LLM clients understand exactly what each field does, improving the tool's usability for LLMs without changing its behavior.

✅ **Verification:**
- Ensured Pydantic `BaseModel` behaves correctly with the existing code pattern.
- Successfully ran the entire test suite using `uv run pytest`.
- Passed linting and formatting checks with `uv run ruff format .` and `uv run ruff check`.
- Verified that `uv.lock` changes were not inadvertently included.

✨ **Result:**
A cleaner `contacts` function signature that is easier to maintain and better described for LLM clients via FastMCP schema generation.

---
*PR created automatically by Jules for task [10718626262494906395](https://jules.google.com/task/10718626262494906395) started by @n24q02m*