### PR TITLE
feat: reduce cyclomatic complexity in handle_messages]

### DIFF
--- a/src/better_telegram_mcp/tools/messages.py
+++ b/src/better_telegram_mcp/tools/messages.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -9,80 +10,100 @@ from ..backends.base import ModeError, TelegramBackend
 from ..utils.formatting import err, ok, safe_error
 
 
+async def _handle_send(backend: TelegramBackend, args: MessagesArgs) -> str:
+    if not args.chat_id or not args.text:
+        return err("'send' requires chat_id and text")
+    result = await backend.send_message(
+        args.chat_id,
+        args.text,
+        reply_to=args.reply_to,
+        parse_mode=args.parse_mode,
+    )
+    return ok(result)
+
+
+async def _handle_edit(backend: TelegramBackend, args: MessagesArgs) -> str:
+    if not args.chat_id or args.message_id is None or not args.text:
+        return err("'edit' requires chat_id, message_id, and text")
+    result = await backend.edit_message(
+        args.chat_id, args.message_id, args.text, parse_mode=args.parse_mode
+    )
+    return ok(result)
+
+
+async def _handle_delete(backend: TelegramBackend, args: MessagesArgs) -> str:
+    if not args.chat_id or args.message_id is None:
+        return err("'delete' requires chat_id and message_id")
+    result = await backend.delete_message(args.chat_id, args.message_id)
+    return ok({"deleted": result})
+
+
+async def _handle_forward(backend: TelegramBackend, args: MessagesArgs) -> str:
+    if not args.from_chat or not args.to_chat or args.message_id is None:
+        return err("'forward' requires from_chat, to_chat, and message_id")
+    result = await backend.forward_message(
+        args.from_chat, args.to_chat, args.message_id
+    )
+    return ok(result)
+
+
+async def _handle_pin(backend: TelegramBackend, args: MessagesArgs) -> str:
+    if not args.chat_id or args.message_id is None:
+        return err("'pin' requires chat_id and message_id")
+    result = await backend.pin_message(args.chat_id, args.message_id)
+    return ok({"pinned": result})
+
+
+async def _handle_react(backend: TelegramBackend, args: MessagesArgs) -> str:
+    if not args.chat_id or args.message_id is None or not args.emoji:
+        return err("'react' requires chat_id, message_id, and emoji")
+    result = await backend.react_to_message(args.chat_id, args.message_id, args.emoji)
+    return ok({"reacted": result})
+
+
+async def _handle_search(backend: TelegramBackend, args: MessagesArgs) -> str:
+    if not args.query:
+        return err("'search' requires query")
+    results = await backend.search_messages(
+        args.query, chat_id=args.chat_id, limit=args.limit
+    )
+    return ok({"messages": results, "count": len(results)})
+
+
+async def _handle_history(backend: TelegramBackend, args: MessagesArgs) -> str:
+    if not args.chat_id:
+        return err("'history' requires chat_id")
+    results = await backend.get_history(
+        args.chat_id, limit=args.limit, offset_id=args.offset_id
+    )
+    return ok({"messages": results, "count": len(results)})
+
+
+_ACTION_HANDLERS: dict[
+    str, Callable[[TelegramBackend, MessagesArgs], Awaitable[str]]
+] = {
+    "send": _handle_send,
+    "edit": _handle_edit,
+    "delete": _handle_delete,
+    "forward": _handle_forward,
+    "pin": _handle_pin,
+    "react": _handle_react,
+    "search": _handle_search,
+    "history": _handle_history,
+}
+
+
 async def handle_messages(
     backend: TelegramBackend,
     args: MessagesArgs,
 ) -> str:
     try:
-        match args.action:
-            case "send":
-                if not args.chat_id or not args.text:
-                    return err("'send' requires chat_id and text")
-                result = await backend.send_message(
-                    args.chat_id,
-                    args.text,
-                    reply_to=args.reply_to,
-                    parse_mode=args.parse_mode,
-                )
-                return ok(result)
+        handler = _ACTION_HANDLERS.get(args.action)
+        if handler is None:
+            valid_actions = "|".join(_ACTION_HANDLERS.keys())
+            return err(f"Unknown action '{args.action}'. Valid: {valid_actions}")
 
-            case "edit":
-                if not args.chat_id or args.message_id is None or not args.text:
-                    return err("'edit' requires chat_id, message_id, and text")
-                result = await backend.edit_message(
-                    args.chat_id, args.message_id, args.text, parse_mode=args.parse_mode
-                )
-                return ok(result)
-
-            case "delete":
-                if not args.chat_id or args.message_id is None:
-                    return err("'delete' requires chat_id and message_id")
-                result = await backend.delete_message(args.chat_id, args.message_id)
-                return ok({"deleted": result})
-
-            case "forward":
-                if not args.from_chat or not args.to_chat or args.message_id is None:
-                    return err("'forward' requires from_chat, to_chat, and message_id")
-                result = await backend.forward_message(
-                    args.from_chat, args.to_chat, args.message_id
-                )
-                return ok(result)
-
-            case "pin":
-                if not args.chat_id or args.message_id is None:
-                    return err("'pin' requires chat_id and message_id")
-                result = await backend.pin_message(args.chat_id, args.message_id)
-                return ok({"pinned": result})
-
-            case "react":
-                if not args.chat_id or args.message_id is None or not args.emoji:
-                    return err("'react' requires chat_id, message_id, and emoji")
-                result = await backend.react_to_message(
-                    args.chat_id, args.message_id, args.emoji
-                )
-                return ok({"reacted": result})
-
-            case "search":
-                if not args.query:
-                    return err("'search' requires query")
-                results = await backend.search_messages(
-                    args.query, chat_id=args.chat_id, limit=args.limit
-                )
-                return ok({"messages": results, "count": len(results)})
-
-            case "history":
-                if not args.chat_id:
-                    return err("'history' requires chat_id")
-                results = await backend.get_history(
-                    args.chat_id, limit=args.limit, offset_id=args.offset_id
-                )
-                return ok({"messages": results, "count": len(results)})
-
-            case _:
-                return err(
-                    f"Unknown action '{args.action}'. "
-                    "Valid: send|edit|delete|forward|pin|react|search|history"
-                )
+        return await handler(backend, args)
     except ModeError as e:
         return err(str(e))
     except Exception as e:


### PR DESCRIPTION
🎯 **What:** The code health issue addressed is the high cyclomatic complexity (Ruff C901 error) in the `handle_messages` function inside `src/better_telegram_mcp/tools/messages.py`. The function previously used a massive `match/case` statement for routing actions to their respective implementations, resulting in a complexity score of 19 > 10.

💡 **Why:** Splitting this massive block into small, action-specific handler functions (`_handle_send`, `_handle_edit`, etc.) and utilizing a dictionary (`_ACTION_HANDLERS`) for mapping actions dramatically reduces cyclomatic complexity. This makes the code much easier to read, test, debug, and maintain, as each function now focuses on a single responsibility. Adding a new feature only requires adding a new localized function and a dictionary entry.

✅ **Verification:**
1. Ran `uv run ruff format .` followed by `uv run ruff check --select C901 src/better_telegram_mcp/tools/messages.py` locally to confirm the cyclomatic complexity issue was fully resolved. 
2. Ran the full test suite (`uv run pytest`) resulting in 278 passed tests, explicitly guaranteeing that this shared logic restructuring did not break any existing `messages` MCP tool functionality.

✨ **Result:** A much cleaner, flattened execution path. Cyclomatic complexity dropped well below the threshold, and the underlying behavior of the API remains identical to its previous state.

---
*PR created automatically by Jules for task [16429465785938786817](https://jules.google.com/task/16429465785938786817) started by @n24q02m*