### PR TITLE
fix: add IPv4-mapped IPv6 to SSRF blocklist

### DIFF
--- a/src/better_telegram_mcp/backends/security.py
+++ b/src/better_telegram_mcp/backends/security.py
@@ -21,6 +21,7 @@ _BLOCKED_NETWORKS = [
     ipaddress.ip_network("192.168.0.0/16"),
     ipaddress.ip_network("169.254.0.0/16"),
     ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("::ffff:0:0/96"),
     ipaddress.ip_network("fc00::/7"),
     ipaddress.ip_network("fe80::/10"),
 ]

--- a/tests/test_backends/test_security.py
+++ b/tests/test_backends/test_security.py
@@ -61,6 +61,24 @@ class TestValidateUrl:
         with pytest.raises(SecurityError, match="internal/private"):
             validate_url("http://[::1]/")
 
+    def test_ipv4_mapped_ipv6_loopback_blocked(self, monkeypatch):
+        """IPv4-mapped IPv6 like ::ffff:127.0.0.1 must be blocked (issue #42)."""
+        monkeypatch.setattr(
+            "socket.getaddrinfo",
+            lambda host, port: [(10, 1, 6, "", ("::ffff:127.0.0.1", 80, 0, 0))],
+        )
+        with pytest.raises(SecurityError, match="internal/private"):
+            validate_url("http://ipv4mapped.attacker.com/")
+
+    def test_ipv4_mapped_ipv6_private_blocked(self, monkeypatch):
+        """IPv4-mapped IPv6 like ::ffff:10.0.0.1 must be blocked (issue #42)."""
+        monkeypatch.setattr(
+            "socket.getaddrinfo",
+            lambda host, port: [(10, 1, 6, "", ("::ffff:10.0.0.1", 80, 0, 0))],
+        )
+        with pytest.raises(SecurityError, match="internal/private"):
+            validate_url("http://ipv4mapped-private.attacker.com/")
+
     def test_zero_ip_blocked(self):
         with pytest.raises(SecurityError, match="blocked"):
             validate_url("http://0.0.0.0/")  # noqa: S104


### PR DESCRIPTION
## Summary
- Add `::ffff:0:0/96` to `_BLOCKED_NETWORKS` to prevent SSRF bypass via IPv4-mapped IPv6 addresses (e.g., `::ffff:127.0.0.1`)
- Add 2 tests: loopback and private network via IPv4-mapped IPv6

## Test plan
- [x] `test_ipv4_mapped_ipv6_loopback_blocked` -- verifies `::ffff:127.0.0.1` is blocked
- [x] `test_ipv4_mapped_ipv6_private_blocked` -- verifies `::ffff:10.0.0.1` is blocked
- [x] Full test suite passes (290 tests)

Closes #42