### PR TITLE
fix: fix path traversal bypass in security validation

### DIFF
--- a/src/better_telegram_mcp/backends/security.py
+++ b/src/better_telegram_mcp/backends/security.py
@@ -76,8 +76,9 @@ def validate_file_path(file_path: str, *, allowed_dir: Path | None = None) -> Pa
         "/var/log/",
         "/root/",
     )
+    path_str = str(path) if str(path).endswith("/") else str(path) + "/"
     for prefix in _blocked_prefixes:
-        if str(path).startswith(prefix):
+        if path_str.startswith(prefix):
             msg = f"Access to {prefix} is blocked for security"
             raise SecurityError(msg)
     # Block dotfiles in home directories (SSH keys, secrets, etc.)
@@ -114,8 +115,9 @@ def validate_output_dir(output_dir: str, *, base_dir: Path | None = None) -> Pat
         "/boot/",
         "/lib/",
     )
+    path_str = str(path) if str(path).endswith("/") else str(path) + "/"
     for prefix in _blocked_prefixes:
-        if str(path).startswith(prefix):
+        if path_str.startswith(prefix):
             msg = f"Writing to {prefix} is blocked for security"
             raise SecurityError(msg)
     # Block hidden directories

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "3.1.0"
+version = "3.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Path validation checks against blocked directories (e.g., `/etc/`, `/proc/`, etc.) used `str(path).startswith(prefix)`. When users provide exactly `"/etc"`, `Path.resolve()` returns `"/etc"` (without a trailing slash), meaning the validation `"/etc".startswith("/etc/")` evaluates to `False`. This allows an attacker to bypass the directory restriction and access the restricted directories exactly.
🎯 **Impact:** Potential unauthorized read/write access directly into sensitive system directories, allowing path traversal bypassing.
🔧 **Fix:** Automatically appending a trailing slash to the resolved path string (`path_str.endswith("/")`) guarantees exact directory matches are properly evaluated against the blocked prefix strings with trailing slashes. 
✅ **Verification:** Verified locally through testing specific bypass patterns (e.g. `validate_output_dir("/etc")` and `validate_file_path("/usr")`), assuring they are now appropriately caught and blocked. Ran `uv run pytest` successfully across the application without any regressions.

---
*PR created automatically by Jules for task [8853327736818599716](https://jules.google.com/task/8853327736818599716) started by @n24q02m*