### PR TITLE
fix: fix path traversal bypass in security validation

### DIFF
--- a/src/better_telegram_mcp/backends/security.py
+++ b/src/better_telegram_mcp/backends/security.py
@@ -76,8 +76,13 @@ def validate_file_path(file_path: str, *, allowed_dir: Path | None = None) -> Pa
         "/var/log/",
         "/root/",
     )
+
+    path_str = str(path)
+    if not path_str.endswith("/"):
+        path_str += "/"
+
     for prefix in _blocked_prefixes:
-        if str(path).startswith(prefix):
+        if path_str.startswith(prefix):
             msg = f"Access to {prefix} is blocked for security"
             raise SecurityError(msg)
     # Block dotfiles in home directories (SSH keys, secrets, etc.)
@@ -114,8 +119,13 @@ def validate_output_dir(output_dir: str, *, base_dir: Path | None = None) -> Pat
         "/boot/",
         "/lib/",
     )
+
+    path_str = str(path)
+    if not path_str.endswith("/"):
+        path_str += "/"
+
     for prefix in _blocked_prefixes:
-        if str(path).startswith(prefix):
+        if path_str.startswith(prefix):
             msg = f"Writing to {prefix} is blocked for security"
             raise SecurityError(msg)
     # Block hidden directories


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Exact directory matches like `/etc` could bypass the path traversal validation checks. `Path('/etc').resolve()` resolves to `/etc`, and its string representation lacks a trailing slash, so `str(path).startswith('/etc/')` evaluates to `False`. This allowed reading from or writing directly to blocked sensitive directories.
🎯 Impact: Attackers could read sensitive files from blocked directories or write arbitrary files to restricted system directories (like `/etc`), potentially leading to further exploitation or system compromise.
🔧 Fix: Dynamically append a trailing slash to the resolved path string before checking it against the blocked prefixes in `validate_file_path` and `validate_output_dir`.
✅ Verification: Ensure tests pass via `uv run pytest`. The exact paths `/etc` and `/var/log` are now correctly identified and blocked by `SecurityError`.

---
*PR created automatically by Jules for task [2867803744185487224](https://jules.google.com/task/2867803744185487224) started by @n24q02m*