### PR TITLE
feat: prevent event loop blocking by offloading webbrowser.open

### DIFF
--- a/src/better_telegram_mcp/server.py
+++ b/src/better_telegram_mcp/server.py
@@ -152,7 +152,10 @@ async def _lifespan(server: FastMCP) -> AsyncIterator[None]:
             import webbrowser
 
             try:
-                webbrowser.open(_auth_url)
+                # Bolt: webbrowser.open() is a synchronous, blocking call that invokes an external GUI process.
+                # Offloading it to a separate thread prevents blocking the async event loop, ensuring
+                # the MCP server remains responsive to incoming requests during the auth flow.
+                await asyncio.to_thread(webbrowser.open, _auth_url)
             except Exception:
                 pass
 

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "3.1.0"
+version = "3.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
💡 What: Wrapped `webbrowser.open(_auth_url)` in `await asyncio.to_thread()`.
🎯 Why: `webbrowser.open()` is a synchronous call that invokes an external GUI process. Calling it directly within the async `_lifespan` function blocks the main event loop, severely degrading the server's responsiveness during the auth flow.
📊 Impact: Prevents the event loop from blocking for hundreds of milliseconds or more while the browser launches, ensuring the MCP server remains highly responsive to concurrent incoming requests.
🔬 Measurement: Verify by triggering the Telegram authentication flow (without a previously authorized session) and observing that the server continues to handle fast concurrent requests (like ping/info) without latency spikes during browser initialization.

---
*PR created automatically by Jules for task [6753843152271610035](https://jules.google.com/task/6753843152271610035) started by @n24q02m*