### PR TITLE
fix: fix XSS in auth relay HTML template

### DIFF
--- a/auth-relay/server.py
+++ b/auth-relay/server.py
@@ -9,6 +9,7 @@ Domain: better-telegram-mcp.n24q02m.com
 
 from __future__ import annotations
 
+import html
 import time
 import uuid
 from collections import defaultdict
@@ -285,9 +286,12 @@ async def auth_page(request: Request) -> HTMLResponse:
     if not session:
         return HTMLResponse("<h1>Session expired</h1>", status_code=404)
 
-    html = _PAGE.replace("TOKEN_PLACEHOLDER", token)
-    html = html.replace("PHONE_PLACEHOLDER", session["phone_masked"])
-    return HTMLResponse(html)
+    # 🛡️ Sentinel: Prevent XSS by escaping dynamic data before insertion
+    page_html = _PAGE.replace("TOKEN_PLACEHOLDER", html.escape(token))
+    page_html = page_html.replace(
+        "PHONE_PLACEHOLDER", html.escape(session["phone_masked"])
+    )
+    return HTMLResponse(page_html)
 
 
 async def auth_send_code(request: Request) -> JSONResponse:

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "3.1.0"
+version = "3.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `auth-relay/server.py` component was manually replacing user-provided dynamic data (`token`, `phone_masked`) into a raw HTML template string (`_PAGE`) without HTML escaping. This could allow an attacker to inject arbitrary HTML or JavaScript (Cross-Site Scripting) if they were able to control the token or phone number input that gets rendered back to the page.
🎯 **Impact:** If exploited, this could allow an attacker to execute malicious scripts in the context of the user's browser viewing the auth relay page, potentially stealing session information or phishing credentials.
🔧 **Fix:** 
1. Imported the `html` standard library module.
2. Renamed the local variable `html` to `page_html` inside `auth_page` to avoid shadowing the standard library module.
3. Wrapped the dynamic values `token` and `session["phone_masked"]` with `html.escape()` during string replacement in the template to sanitize them.
✅ **Verification:**
- Ran the full test suite (`uv run pytest`) ensuring no regressions in local MCP integration.
- Ran formatting checks (`uv run ruff format .` and `uv run ruff check`).
- The code uses `html.escape()` which is the standard Python approach for neutralizing XSS vectors during manual HTML construction.

---
*PR created automatically by Jules for task [610193034664374457](https://jules.google.com/task/610193034664374457) started by @n24q02m*