### PR TITLE
fix: fix XSS vulnerability in local auth server

### DIFF
--- a/src/better_telegram_mcp/auth_server.py
+++ b/src/better_telegram_mcp/auth_server.py
@@ -8,6 +8,7 @@ status page when authenticated.
 from __future__ import annotations
 
 import asyncio
+import html
 import re
 import socket
 from typing import TYPE_CHECKING
@@ -216,8 +217,9 @@ class AuthServer:
     def _make_app(self) -> Starlette:
         async def index(request: Request) -> HTMLResponse:
             phone = self._settings.phone or "unknown"
-            html = _PAGE.replace("PHONE", _mask_phone(phone))
-            return HTMLResponse(html)
+            # 🛡️ Sentinel: Prevent XSS by escaping dynamic data before insertion
+            page_html = _PAGE.replace("PHONE", html.escape(_mask_phone(phone)))
+            return HTMLResponse(page_html)
 
         async def status_endpoint(request: Request) -> JSONResponse:
             try:


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The local `auth_server.py` inserts the user's `TELEGRAM_PHONE` configuration directly into a raw HTML template string via `.replace("PHONE", ...)` without applying HTML escaping.
🎯 Impact: While the vector requires the user to set a malicious value in their environment configuration, this still represents an injection vulnerability where arbitrary HTML/JS could be executed in the local browser context when rendering the auth page.
🔧 Fix: Imported the standard library `html` module and wrapped the phone variable with `html.escape()` prior to insertion. Renamed the local `html` variable to `page_html` to prevent module shadowing.
✅ Verification: Tested via `uv run pytest` and verified no formatting regressions via `uv run ruff check .` and `uv run ruff format --check .`. Code review also passed successfully.

---
*PR created automatically by Jules for task [14697384174838832479](https://jules.google.com/task/14697384174838832479) started by @n24q02m*