### PR TITLE
feat: testing improvement get_backend and get_settings coverage]

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -36,6 +36,17 @@ def test_get_backend_not_initialized():
         srv._backend = old
 
 
+def test_get_backend_initialized(mock_backend):
+    import better_telegram_mcp.server as srv
+
+    old = srv._backend
+    try:
+        srv._backend = mock_backend
+        assert get_backend() is mock_backend
+    finally:
+        srv._backend = old
+
+
 def test_get_settings_not_initialized():
     import better_telegram_mcp.server as srv
 
@@ -44,6 +55,18 @@ def test_get_settings_not_initialized():
         srv._settings = None
         with pytest.raises(RuntimeError, match="Settings not initialized"):
             get_settings()
+    finally:
+        srv._settings = old
+
+
+def test_get_settings_initialized():
+    import better_telegram_mcp.server as srv
+
+    old = srv._settings
+    try:
+        mock_settings = MagicMock()
+        srv._settings = mock_settings
+        assert get_settings() is mock_settings
     finally:
         srv._settings = old
 

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "3.2.0b1"
+version = "3.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
🎯 **What:** The `get_backend()` and `get_settings()` getter functions in `server.py` lacked test coverage for their "happy paths" (when they successfully return their initialized singletons).
📊 **Coverage:** Added `test_get_backend_initialized` and `test_get_settings_initialized` to verify that when the respective global variables are populated, the functions return them correctly without raising errors.
✨ **Result:** Enhanced test coverage for `server.py`'s core singleton getter functions, confirming both error and success behaviors are properly tested, increasing codebase robustness.

---
*PR created automatically by Jules for task [14112473722249582659](https://jules.google.com/task/14112473722249582659) started by @n24q02m*