### PR TITLE
fix: fix SSRF validation bypass on DNS resolution failure

### DIFF
--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,18 @@
+🔒 Sentinel: [HIGH] Fix SSRF validation bypass on DNS resolution failure
+
+### 🚨 Severity
+HIGH - Server-Side Request Forgery (SSRF) protection bypass.
+
+### 💡 Vulnerability
+The `validate_url` function in `src/better_telegram_mcp/backends/security.py` relies on DNS resolution (`socket.getaddrinfo`) to check if a provided hostname resolves to an internal or private IP address. However, if the DNS resolution failed (raising an `OSError`), the function caught the exception and silently passed (`pass`). This "fail-open" behavior allowed attackers to bypass the SSRF protection entirely by providing hostnames that deliberately fail to resolve at the time of validation but might resolve later, or by exploiting differences in how the validation function and the underlying connection library handle malformed URLs/hostnames.
+
+### 🎯 Impact
+An attacker could bypass the internal network IP checks and potentially force the application to make HTTP requests to unauthorized internal services or local endpoints, leading to information disclosure or further exploitation within the internal network.
+
+### 🔧 Fix
+Modified the `try...except OSError` block in `validate_url` to fail closed. Now, if DNS resolution fails, it explicitly raises a `SecurityError("Failed to resolve hostname...")`, completely preventing the validation from passing.
+
+### ✅ Verification
+- Wrote a new unit test `test_dns_resolution_failure_blocks` in `tests/test_backends/test_security.py` that mocks `socket.getaddrinfo` to raise an `OSError` and asserts that `validate_url` correctly raises a `SecurityError`.
+- Ran the full test suite (`uv run pytest`) and confirmed all tests pass.
+- Ensured formatting (`uv run ruff format .`) and linting (`uv run ruff check .`) pass.

--- a/src/better_telegram_mcp/backends/security.py
+++ b/src/better_telegram_mcp/backends/security.py
@@ -57,10 +57,10 @@ def validate_url(url: str) -> None:
                 if addr in network:
                     msg = f"Access to internal/private IP {ip_str} ({hostname}) is blocked"
                     raise SecurityError(msg)
-    except OSError:
-        # If hostname resolution fails, let it pass security validation
-        # (It will fail later when actually trying to connect)
-        pass
+    except OSError as e:
+        # Fail closed on DNS resolution failure to prevent SSRF bypass
+        msg = f"Failed to resolve hostname: {hostname}"
+        raise SecurityError(msg) from e
 
 
 def validate_file_path(file_path: str, *, allowed_dir: Path | None = None) -> Path:

--- a/tests/test_backends/test_security.py
+++ b/tests/test_backends/test_security.py
@@ -106,6 +106,15 @@ class TestValidateUrl:
         )
         validate_url("http://example.com/image.jpg")
 
+    def test_dns_resolution_failure_blocks(self, monkeypatch):
+        # Mock socket.getaddrinfo to raise an OSError
+        def mock_getaddrinfo(host, port, *args, **kwargs):
+            raise OSError("Name or service not known")
+
+        monkeypatch.setattr("socket.getaddrinfo", mock_getaddrinfo)
+        with pytest.raises(SecurityError, match="Failed to resolve hostname"):
+            validate_url("http://does-not-exist.example/image.jpg")
+
 
 class TestValidateFilePath:
     def test_normal_path_allowed(self):

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "3.2.0b1"
+version = "3.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
### 🚨 Severity
HIGH - Server-Side Request Forgery (SSRF) protection bypass.

### 💡 Vulnerability
The `validate_url` function in `src/better_telegram_mcp/backends/security.py` relies on DNS resolution (`socket.getaddrinfo`) to check if a provided hostname resolves to an internal or private IP address. However, if the DNS resolution failed (raising an `OSError`), the function caught the exception and silently passed (`pass`). This "fail-open" behavior allowed attackers to bypass the SSRF protection entirely by providing hostnames that deliberately fail to resolve at the time of validation but might resolve later, or by exploiting differences in how the validation function and the underlying connection library handle malformed URLs/hostnames.

### 🎯 Impact
An attacker could bypass the internal network IP checks and potentially force the application to make HTTP requests to unauthorized internal services or local endpoints, leading to information disclosure or further exploitation within the internal network.

### 🔧 Fix
Modified the `try...except OSError` block in `validate_url` to fail closed. Now, if DNS resolution fails, it explicitly raises a `SecurityError("Failed to resolve hostname...")`, completely preventing the validation from passing.

### ✅ Verification
- Wrote a new unit test `test_dns_resolution_failure_blocks` in `tests/test_backends/test_security.py` that mocks `socket.getaddrinfo` to raise an `OSError` and asserts that `validate_url` correctly raises a `SecurityError`.
- Ran the full test suite (`uv run pytest`) and confirmed all tests pass.
- Ensured formatting (`uv run ruff format .`) and linting (`uv run ruff check .`) pass.

---
*PR created automatically by Jules for task [5209228889310297345](https://jules.google.com/task/5209228889310297345) started by @n24q02m*