### PR TITLE
fix: fix Rate limiting bypass or DoS via reverse proxy IP

### DIFF
--- a/auth-relay/server.py
+++ b/auth-relay/server.py
@@ -44,6 +44,23 @@ def _check_rate_limit(ip: str) -> bool:
     return True
 
 
+def _get_client_ip(request: Request) -> str:
+    """Extract actual client IP from proxy headers or fallback to client host."""
+    # CF-Connecting-IP is specific to Cloudflare
+    if cf_ip := request.headers.get("CF-Connecting-IP"):
+        return cf_ip.strip()
+
+    # X-Forwarded-For can contain multiple IPs, the first one is the original client
+    if xff := request.headers.get("X-Forwarded-For"):
+        return xff.split(",")[0].strip()
+
+    # X-Real-IP is commonly used by Nginx and other proxies
+    if real_ip := request.headers.get("X-Real-IP"):
+        return real_ip.strip()
+
+    return request.client.host if request.client else "unknown"
+
+
 def _cleanup() -> None:
     global _last_cleanup
     now = time.time()
@@ -204,7 +221,7 @@ $('otp').addEventListener('keydown',e=>{if(e.key==='Enter')verify()});
 
 async def api_create_session(request: Request) -> JSONResponse:
     """MCP local creates a new auth session."""
-    ip = request.client.host if request.client else "unknown"
+    ip = _get_client_ip(request)
     if not _check_rate_limit(ip):
         return JSONResponse({"error": "Rate limited"}, status_code=429)
     _cleanup()
@@ -296,7 +313,7 @@ async def auth_page(request: Request) -> HTMLResponse:
 
 async def auth_send_code(request: Request) -> JSONResponse:
     """User requests OTP send."""
-    ip = request.client.host if request.client else "unknown"
+    ip = _get_client_ip(request)
     if not _check_rate_limit(ip):
         return JSONResponse({"ok": False, "error": "Rate limited. Try again later."})
     token = request.path_params["token"]
@@ -311,7 +328,7 @@ async def auth_send_code(request: Request) -> JSONResponse:
 
 async def auth_verify(request: Request) -> JSONResponse:
     """User submits OTP code."""
-    ip = request.client.host if request.client else "unknown"
+    ip = _get_client_ip(request)
     if not _check_rate_limit(ip):
         return JSONResponse({"ok": False, "error": "Rate limited. Try again later."})
     token = request.path_params["token"]

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "3.2.0b1"
+version = "3.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
🎯 What:
The `auth-relay/server.py` implementation previously relied exclusively on `request.client.host` to perform rate-limiting. This IP extraction approach is vulnerable to a complete bypass or self-inflicted Denial of Service (DoS) when the web application is deployed behind a reverse proxy (like Nginx, Caddy, or Cloudflare). In such setups, `request.client.host` reports the IP address of the reverse proxy itself, forcing all upstream clients to share a single global rate limit, and allowing a malicious actor to effortlessly exhaust the limit for all users.

⚠️ Risk:
Because the relay acts as an unauthenticated external entry point for Telegram OTP sending and verification, an attacker could write a simple script to trigger the global rate limit (30 requests per minute). This effectively locks all other legitimate users out of the authentication process.

🛡️ Solution:
Replaced direct `request.client.host` access with a new `_get_client_ip` helper function. The function inspects standard reverse proxy HTTP headers (`CF-Connecting-IP`, `X-Forwarded-For`, and `X-Real-IP`) in order of precedence to correctly determine the true source IP address of the request, gracefully falling back to `request.client.host` if no such headers are present. This properly segregates the rate limit constraints per client device instead of per reverse proxy instance.

---
*PR created automatically by Jules for task [16081920659253277458](https://jules.google.com/task/16081920659253277458) started by @n24q02m*