### PR TITLE
fix: fix XSS vulnerability in JS string interpolation in auth relay

### DIFF
--- a/auth-relay/server.py
+++ b/auth-relay/server.py
@@ -10,6 +10,7 @@ Domain: better-telegram-mcp.n24q02m.com
 from __future__ import annotations
 
 import html
+import json
 import time
 import uuid
 from collections import defaultdict
@@ -140,7 +141,7 @@ button:disabled{background:#333;color:#666;cursor:not-allowed}
   </div>
 </div>
 <script>
-const TOKEN="TOKEN_PLACEHOLDER";
+const TOKEN=TOKEN_PLACEHOLDER;
 const $=id=>document.getElementById(id);
 function show(id){document.querySelectorAll('.step').forEach(s=>s.classList.remove('active'));$(id).classList.add('active')}
 function st(el,cls,msg){el.className='st '+cls;el.textContent=msg;el.style.display='block'}
@@ -287,7 +288,8 @@ async def auth_page(request: Request) -> HTMLResponse:
         return HTMLResponse("<h1>Session expired</h1>", status_code=404)
 
     # 🛡️ Sentinel: Prevent XSS by escaping dynamic data before insertion
-    page_html = _PAGE.replace("TOKEN_PLACEHOLDER", html.escape(token))
+    # Use json.dumps for TOKEN_PLACEHOLDER to safely inject into JavaScript context
+    page_html = _PAGE.replace("TOKEN_PLACEHOLDER", json.dumps(token))
     page_html = page_html.replace(
         "PHONE_PLACEHOLDER", html.escape(session["phone_masked"])
     )


### PR DESCRIPTION
🎯 **What:** The `TOKEN_PLACEHOLDER` within `auth-relay/server.py` was vulnerable to Cross-Site Scripting (XSS). It was using `html.escape()` while placed directly inside a JavaScript string literal `<script> const TOKEN = "TOKEN_PLACEHOLDER"; ... </script>`. Because the HTML parser does not decode entities inside script blocks, an attacker could potentially inject unescaped JS control characters like single quotes, backslashes, or closing tags if the token content was attacker-controlled.

⚠️ **Risk:** If an attacker crafted a malicious token containing JavaScript syntax, they could break out of the string literal and execute arbitrary JavaScript code in the context of the user's browser viewing the authentication relay page. This could lead to token theft, session hijacking, or other malicious actions against the user's environment.

🛡️ **Solution:** The fix removes `html.escape()` and instead uses `json.dumps()` for the token interpolation, while also removing the surrounding quotes in the JS template (`const TOKEN=TOKEN_PLACEHOLDER;`). `json.dumps()` safely serializes the token string for use in JavaScript, properly escaping quotes, backslashes, and other dangerous characters without causing HTML entity issues.

✅ **Verification:**
- Ran the test suite via `uv run pytest` (All tests passed)
- Visually verified the fix and auth-relay rendering using Playwright frontend UI tests.
- Code review performed and approved the change.

---
*PR created automatically by Jules for task [13217625039648351613](https://jules.google.com/task/13217625039648351613) started by @n24q02m*