### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF bypass via DNS resolution failure

### DIFF
--- a/src/better_telegram_mcp/backends/security.py
+++ b/src/better_telegram_mcp/backends/security.py
@@ -57,10 +57,11 @@ def validate_url(url: str) -> None:
                 if addr in network:
                     msg = f"Access to internal/private IP {ip_str} ({hostname}) is blocked"
                     raise SecurityError(msg)
-    except OSError:
-        # If hostname resolution fails, let it pass security validation
-        # (It will fail later when actually trying to connect)
-        pass
+    except OSError as e:
+        # If hostname resolution fails, deny access instead of silently passing
+        # to prevent bypassing SSRF checks via transient failures or DNS rebinding
+        msg = f"Failed to resolve hostname {hostname}"
+        raise SecurityError(msg) from e
 
 
 def validate_file_path(file_path: str, *, allowed_dir: Path | None = None) -> Path:

--- a/tests/test_backends/test_security.py
+++ b/tests/test_backends/test_security.py
@@ -106,6 +106,14 @@ class TestValidateUrl:
         )
         validate_url("http://example.com/image.jpg")
 
+    def test_dns_resolution_failure_blocked(self, monkeypatch):
+        def mock_getaddrinfo(*args, **kwargs):
+            raise OSError("Temporary failure in name resolution")
+
+        monkeypatch.setattr("socket.getaddrinfo", mock_getaddrinfo)
+        with pytest.raises(SecurityError, match="Failed to resolve hostname"):
+            validate_url("http://nonexistent.domain.internal/admin")
+
 
 class TestValidateFilePath:
     def test_normal_path_allowed(self):

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "3.2.0"
+version = "3.3.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: SSRF bypass. The `validate_url` function, which prevents SSRF by resolving hostnames and validating IP addresses, previously caught `OSError` during `socket.getaddrinfo` and silently `pass`ed. If a hostname failed DNS resolution (due to transient error, non-existent domain, or environmental differences), the security check succeeded, passing the unvalidated URL to the underlying network client.
🎯 Impact: An attacker could potentially bypass the SSRF protection mechanism by providing a URL that fails to resolve during the validation step but successfully resolves or acts maliciously when actually accessed by the HTTP client later.
🔧 Fix: Changed the `except OSError:` block in `validate_url` to fail-closed by raising a `SecurityError` and explicitly chaining the exception using `from e`. Added a test case simulating DNS failure to ensure the `SecurityError` is raised.
✅ Verification: Ran the full `uv run pytest` suite and verified the new `test_dns_resolution_failure_blocked` test passes, confirming the new behavior. All linting and type checks pass.

---
*PR created automatically by Jules for task [9996530630999985351](https://jules.google.com/task/9996530630999985351) started by @n24q02m*