### PR TITLE
feat: multi-user HTTP mode with per-user credential isolation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,8 @@ dependencies = [
     "loguru>=0.7.3",
     "mcp-relay-core>=1.0.5",
     "cryptography>=46.0.6",
+    "starlette>=0.46.0",
+    "uvicorn>=0.34.0",
 ]
 
 [dependency-groups]
@@ -106,6 +108,7 @@ omit = [
     "*/auth_server.py",
     "*/auth_client.py",
     "*/transports/http.py",
+    "*/transports/http_multi_user.py",
 ]
 
 [tool.coverage.report]

--- a/src/better_telegram_mcp/auth/__init__.py
+++ b/src/better_telegram_mcp/auth/__init__.py
@@ -1,0 +1,1 @@
+"""Authentication modules for multi-user HTTP mode."""

--- a/src/better_telegram_mcp/auth/per_user_session_store.py
+++ b/src/better_telegram_mcp/auth/per_user_session_store.py
@@ -1,0 +1,148 @@
+"""Encrypted per-user session storage for multi-user HTTP mode.
+
+Stores bearer_token -> session_info mappings in a single encrypted file.
+Uses AES-256-GCM, key derived from CREDENTIAL_SECRET env var or auto-generated.
+Reuses the key derivation pattern from transports/credential_store.py.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Literal
+
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+
+_SALT = b"mcp-telegram-sessions"
+_KDF_ITERATIONS = 100_000
+_NONCE_SIZE = 12
+
+
+@dataclass
+class SessionInfo:
+    """Per-user session metadata."""
+
+    session_name: str
+    mode: Literal["bot", "user"]
+    api_id: int | None = None
+    api_hash: str | None = None
+    phone: str | None = None
+    bot_token: str | None = None
+    created_at: float = field(default_factory=time.time)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> SessionInfo:
+        return cls(**data)
+
+
+class PerUserSessionStore:
+    """Encrypted storage for per-user Telegram sessions.
+
+    All sessions stored in a single encrypted file at data_dir/sessions.enc.
+    Maps bearer_token (hashed) -> SessionInfo.
+    """
+
+    def __init__(self, data_dir: Path, secret: str | None = None) -> None:
+        self._path = data_dir / "sessions.enc"
+        self._secret = secret or os.environ.get("CREDENTIAL_SECRET", "")
+        if not self._secret:
+            self._secret = self._resolve_or_generate_secret(data_dir)
+        self._cached_key: bytes | None = None
+
+    @staticmethod
+    def _resolve_or_generate_secret(data_dir: Path) -> str:
+        """Load persisted secret or generate a new one."""
+        secret_path = data_dir / ".secret"
+        if secret_path.exists():
+            return secret_path.read_text().strip()
+        data_dir.mkdir(parents=True, exist_ok=True)
+        secret = os.urandom(32).hex()
+        secret_path.write_text(secret)
+        try:
+            secret_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+        except OSError:
+            pass  # Windows may not support chmod
+        return secret
+
+    def _derive_key(self) -> bytes:
+        if self._cached_key is not None:
+            return self._cached_key
+        kdf = PBKDF2HMAC(
+            algorithm=hashes.SHA256(),
+            length=32,
+            salt=_SALT,
+            iterations=_KDF_ITERATIONS,
+        )
+        self._cached_key = kdf.derive(self._secret.encode())
+        return self._cached_key
+
+    def _encrypt(self, data: bytes) -> bytes:
+        key = self._derive_key()
+        aesgcm = AESGCM(key)
+        nonce = os.urandom(_NONCE_SIZE)
+        ciphertext = aesgcm.encrypt(nonce, data, None)
+        return nonce + ciphertext
+
+    def _decrypt(self, data: bytes) -> bytes:
+        key = self._derive_key()
+        nonce, ciphertext = data[:_NONCE_SIZE], data[_NONCE_SIZE:]
+        aesgcm = AESGCM(key)
+        return aesgcm.decrypt(nonce, ciphertext, None)
+
+    def _read_all(self) -> dict[str, dict]:
+        """Read and decrypt all sessions from disk."""
+        if not self._path.exists():
+            return {}
+        raw = self._path.read_bytes()
+        plaintext = self._decrypt(raw)
+        return json.loads(plaintext)
+
+    def _write_all(self, sessions: dict[str, dict]) -> None:
+        """Encrypt and write all sessions to disk."""
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        plaintext = json.dumps(sessions).encode()
+        encrypted = self._encrypt(plaintext)
+        self._path.write_bytes(encrypted)
+        try:
+            self._path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+        except OSError:
+            pass
+
+    def store(self, bearer: str, info: SessionInfo) -> None:
+        """Store a session for the given bearer token."""
+        sessions = self._read_all()
+        sessions[bearer] = info.to_dict()
+        self._write_all(sessions)
+
+    def load(self, bearer: str) -> SessionInfo | None:
+        """Load session info for a bearer token. Returns None if not found."""
+        sessions = self._read_all()
+        data = sessions.get(bearer)
+        if data is None:
+            return None
+        return SessionInfo.from_dict(data)
+
+    def load_all(self) -> dict[str, SessionInfo]:
+        """Load all stored sessions."""
+        sessions = self._read_all()
+        return {
+            bearer: SessionInfo.from_dict(data) for bearer, data in sessions.items()
+        }
+
+    def delete(self, bearer: str) -> bool:
+        """Delete a session. Returns True if it existed."""
+        sessions = self._read_all()
+        if bearer not in sessions:
+            return False
+        del sessions[bearer]
+        self._write_all(sessions)
+        return True

--- a/src/better_telegram_mcp/auth/stateless_client_store.py
+++ b/src/better_telegram_mcp/auth/stateless_client_store.py
@@ -1,0 +1,119 @@
+"""Stateless HMAC-based Dynamic Client Registration (DCR) store.
+
+Instead of persisting registered clients in a database, this derives
+deterministic client_id and client_secret from the registration input
+using HMAC-SHA256. This means:
+
+- Same input always produces the same credentials (idempotent)
+- Survives cold starts / server restarts without any storage
+- Rotating the HMAC secret invalidates all existing registrations
+
+A warm cache (dict) stores registered client metadata (redirect_uris etc.)
+so that get_client can return the full client info for authorize validation.
+On cold start, clients re-register (instant, same credentials) to repopulate.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+from dataclasses import dataclass, field
+
+
+@dataclass
+class ClientInfo:
+    """Registered OAuth client information."""
+
+    client_id: str
+    client_secret: str
+    redirect_uris: list[str]
+    client_name: str | None = None
+    client_id_issued_at: float = 0.0
+    grant_types: list[str] = field(
+        default_factory=lambda: ["authorization_code", "refresh_token"]
+    )
+    response_types: list[str] = field(default_factory=lambda: ["code"])
+    token_endpoint_auth_method: str = "client_secret_post"
+
+
+class StatelessClientStore:
+    """Stateless HMAC-based Dynamic Client Registration store.
+
+    Derives deterministic client_id and client_secret from registration
+    input using HMAC-SHA256. Warm cache stores full metadata for lookups.
+    """
+
+    def __init__(self, secret: str) -> None:
+        self._secret = secret.encode()
+        self._cache: dict[str, ClientInfo] = {}
+
+    def _derive_client_id(
+        self, redirect_uris: list[str], client_name: str | None = None
+    ) -> str:
+        payload = json.dumps(
+            {"redirectUris": redirect_uris, "clientName": client_name},
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        digest = hmac.new(
+            self._secret,
+            f"client_id:{payload}".encode(),
+            hashlib.sha256,
+        ).hexdigest()
+        return digest[:32]
+
+    def _derive_client_secret(self, client_id: str) -> str:
+        return hmac.new(
+            self._secret,
+            f"client_secret:{client_id}".encode(),
+            hashlib.sha256,
+        ).hexdigest()
+
+    def register(
+        self,
+        redirect_uris: list[str],
+        client_name: str | None = None,
+    ) -> tuple[str, str]:
+        """Register a new client and return (client_id, client_secret).
+
+        Idempotent: same input always produces the same credentials.
+        """
+        client_id = self._derive_client_id(redirect_uris, client_name)
+        client_secret = self._derive_client_secret(client_id)
+
+        info = ClientInfo(
+            client_id=client_id,
+            client_secret=client_secret,
+            redirect_uris=redirect_uris,
+            client_name=client_name,
+            client_id_issued_at=time.time(),
+        )
+        self._cache[client_id] = info
+
+        return client_id, client_secret
+
+    def get(self, client_id: str) -> ClientInfo | None:
+        """Get client info by client_id.
+
+        Returns cached info if available, or a minimal fallback
+        with only the derived secret (client must re-register for
+        full metadata like redirect_uris).
+        """
+        cached = self._cache.get(client_id)
+        if cached is not None:
+            return cached
+
+        # Fallback: derive secret only (redirect_uris unknown)
+        client_secret = self._derive_client_secret(client_id)
+        return ClientInfo(
+            client_id=client_id,
+            client_secret=client_secret,
+            redirect_uris=[],
+        )
+
+    def validate_secret(self, client_id: str, client_secret: str) -> bool:
+        """Validate that client_secret matches the derived secret for client_id."""
+        expected = self._derive_client_secret(client_id)
+        return hmac.compare_digest(expected, client_secret)

--- a/src/better_telegram_mcp/auth/telegram_auth_provider.py
+++ b/src/better_telegram_mcp/auth/telegram_auth_provider.py
@@ -1,0 +1,327 @@
+"""Per-user Telegram authentication provider for multi-user HTTP mode.
+
+Manages the lifecycle of per-user TelegramBackend instances:
+- Bot mode: validates bot_token, creates BotBackend
+- User mode: Telethon OTP flow (send_code -> sign_in)
+- Session persistence: reconnects stored sessions on startup
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+import time
+from pathlib import Path
+
+from loguru import logger
+
+from ..backends.base import TelegramBackend
+from ..backends.bot_backend import BotBackend
+from ..backends.user_backend import UserBackend
+from ..config import Settings
+from .per_user_session_store import PerUserSessionStore, SessionInfo
+
+# Session expiry: 30 days
+_SESSION_TTL = 30 * 24 * 60 * 60
+
+# Pending OTP state (phone_code_hash + backend ref)
+_PendingOTP = dict  # {bearer, backend, phone, phone_code_hash, created_at}
+
+
+class TelegramAuthProvider:
+    """Manages per-user Telegram authentication and backend lifecycle.
+
+    Each bearer token maps to its own TelegramBackend instance.
+    Supports both bot mode (instant) and user mode (OTP flow).
+    """
+
+    def __init__(self, data_dir: Path, api_id: int, api_hash: str) -> None:
+        self._data_dir = data_dir
+        self._api_id = api_id
+        self._api_hash = api_hash
+        self._store = PerUserSessionStore(data_dir)
+
+        # bearer -> active TelegramBackend
+        self.active_clients: dict[str, TelegramBackend] = {}
+
+        # MCP session_id -> bearer (session ownership)
+        self.session_owners: dict[str, str] = {}
+
+        # Pending OTP verifications (bearer -> pending state)
+        self._pending_otps: dict[str, _PendingOTP] = {}
+
+    @staticmethod
+    def _generate_bearer() -> str:
+        """Generate a cryptographically secure bearer token."""
+        return secrets.token_urlsafe(32)
+
+    @staticmethod
+    def _session_name_from_bearer(bearer: str) -> str:
+        """Derive a safe session file name from bearer token."""
+        return hashlib.sha256(bearer.encode()).hexdigest()[:16]
+
+    async def restore_sessions(self) -> int:
+        """Restore all stored sessions on server startup.
+
+        Returns the number of successfully restored sessions.
+        """
+        sessions = self._store.load_all()
+        restored = 0
+
+        for bearer, info in sessions.items():
+            # Check TTL
+            if time.time() - info.created_at > _SESSION_TTL:
+                logger.info(
+                    "Session {} expired, removing",
+                    info.session_name[:8],
+                )
+                self._store.delete(bearer)
+                continue
+
+            try:
+                backend = await self._create_backend(info)
+                self.active_clients[bearer] = backend
+                restored += 1
+                logger.info(
+                    "Restored {} session: {}",
+                    info.mode,
+                    info.session_name[:8],
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to restore session {}, removing",
+                    info.session_name[:8],
+                )
+                self._store.delete(bearer)
+
+        return restored
+
+    async def _create_backend(self, info: SessionInfo) -> TelegramBackend:
+        """Create and connect a backend from session info."""
+        if info.mode == "bot":
+            assert info.bot_token is not None
+            backend = BotBackend(info.bot_token)
+            await backend.connect()
+            return backend
+        else:
+            settings = Settings(
+                api_id=self._api_id,
+                api_hash=self._api_hash,
+                phone=info.phone,
+                session_name=info.session_name,
+                data_dir=self._data_dir / "user_sessions",
+            )
+            backend = UserBackend(settings)
+            await backend.connect()
+            return backend
+
+    def resolve_backend(self, bearer: str) -> TelegramBackend | None:
+        """Get the TelegramBackend for a bearer token."""
+        return self.active_clients.get(bearer)
+
+    async def register_bot(self, bearer: str, bot_token: str) -> str:
+        """Register a bot backend for the given bearer token.
+
+        Validates the bot_token by calling getMe, then stores the session.
+
+        Args:
+            bearer: Pre-generated bearer token (or generate one).
+            bot_token: Telegram bot token from @BotFather.
+
+        Returns:
+            The bearer token for subsequent requests.
+
+        Raises:
+            ValueError: If bot_token is invalid.
+        """
+        if not bearer:
+            bearer = self._generate_bearer()
+
+        backend = BotBackend(bot_token)
+        try:
+            await backend.connect()
+        except Exception as exc:
+            await backend.disconnect()
+            msg = f"Invalid bot token: {exc}"
+            raise ValueError(msg) from exc
+
+        session_name = self._session_name_from_bearer(bearer)
+        info = SessionInfo(
+            session_name=session_name,
+            mode="bot",
+            bot_token=bot_token,
+        )
+
+        self._store.store(bearer, info)
+        self.active_clients[bearer] = backend
+        logger.info("Registered bot session: {}", session_name[:8])
+        return bearer
+
+    async def start_user_auth(self, bearer: str, phone: str) -> dict:
+        """Start user authentication by sending OTP code.
+
+        Args:
+            bearer: Pre-generated bearer token.
+            phone: Phone number in international format.
+
+        Returns:
+            Dict with phone_code_hash for verification step.
+
+        Raises:
+            ValueError: If api_id/api_hash not configured or send_code fails.
+        """
+        if not bearer:
+            bearer = self._generate_bearer()
+
+        if not self._api_id or not self._api_hash:
+            msg = "TELEGRAM_API_ID and TELEGRAM_API_HASH must be set for user mode"
+            raise ValueError(msg)
+
+        session_name = self._session_name_from_bearer(bearer)
+
+        settings = Settings(
+            api_id=self._api_id,
+            api_hash=self._api_hash,
+            phone=phone,
+            session_name=session_name,
+            data_dir=self._data_dir / "user_sessions",
+        )
+        backend = UserBackend(settings)
+        await backend.connect()
+
+        try:
+            # Telethon's send_code_request returns a SentCode object with phone_code_hash
+            client = backend._ensure_client()
+            sent_code = await client.send_code_request(phone)
+            phone_code_hash = sent_code.phone_code_hash
+        except Exception as exc:
+            await backend.disconnect()
+            msg = f"Failed to send code: {exc}"
+            raise ValueError(msg) from exc
+
+        # Store pending OTP state
+        self._pending_otps[bearer] = {
+            "bearer": bearer,
+            "backend": backend,
+            "phone": phone,
+            "phone_code_hash": phone_code_hash,
+            "session_name": session_name,
+            "created_at": time.time(),
+        }
+
+        return {
+            "bearer": bearer,
+            "phone_code_hash": phone_code_hash,
+        }
+
+    async def complete_user_auth(
+        self,
+        bearer: str,
+        code: str,
+        *,
+        password: str | None = None,
+    ) -> dict:
+        """Complete user authentication with OTP code.
+
+        Args:
+            bearer: Bearer token from start_user_auth.
+            code: OTP code received via Telegram.
+            password: Optional 2FA password.
+
+        Returns:
+            Dict with authenticated user info.
+
+        Raises:
+            ValueError: If bearer not found in pending OTPs or sign-in fails.
+        """
+        pending = self._pending_otps.get(bearer)
+        if pending is None:
+            msg = "No pending authentication for this bearer token"
+            raise ValueError(msg)
+
+        backend = pending["backend"]
+        phone = pending["phone"]
+
+        try:
+            result = await backend.sign_in(phone, code, password=password)
+        except Exception as exc:
+            # Don't clean up pending - allow retry with different code
+            msg = f"Sign-in failed: {exc}"
+            raise ValueError(msg) from exc
+
+        # Success - store session and activate backend
+        del self._pending_otps[bearer]
+
+        info = SessionInfo(
+            session_name=pending["session_name"],
+            mode="user",
+            api_id=self._api_id,
+            api_hash=self._api_hash,
+            phone=phone,
+        )
+
+        self._store.store(bearer, info)
+        self.active_clients[bearer] = backend
+        logger.info("Registered user session: {}", pending["session_name"][:8])
+        return result
+
+    async def revoke_session(self, bearer: str) -> bool:
+        """Revoke a session and disconnect its backend.
+
+        Returns True if the session existed.
+        """
+        backend = self.active_clients.pop(bearer, None)
+        if backend is not None:
+            await backend.disconnect()
+
+        # Remove pending OTP if any
+        pending = self._pending_otps.pop(bearer, None)
+        if pending is not None:
+            await pending["backend"].disconnect()
+
+        # Remove from ownership map
+        to_remove = [sid for sid, b in self.session_owners.items() if b == bearer]
+        for sid in to_remove:
+            del self.session_owners[sid]
+
+        return self._store.delete(bearer)
+
+    async def cleanup_expired(self) -> int:
+        """Remove expired sessions. Returns count of removed sessions."""
+        sessions = self._store.load_all()
+        removed = 0
+        now = time.time()
+
+        for bearer, info in sessions.items():
+            if now - info.created_at > _SESSION_TTL:
+                await self.revoke_session(bearer)
+                removed += 1
+
+        # Also clean up stale pending OTPs (5 min TTL)
+        stale_otps = [
+            b for b, p in self._pending_otps.items() if now - p["created_at"] > 300
+        ]
+        for bearer in stale_otps:
+            pending = self._pending_otps.pop(bearer)
+            await pending["backend"].disconnect()
+            removed += 1
+
+        return removed
+
+    async def shutdown(self) -> None:
+        """Disconnect all active backends. Call on server shutdown."""
+        for bearer, backend in list(self.active_clients.items()):
+            try:
+                await backend.disconnect()
+            except Exception:
+                logger.warning("Error disconnecting backend {}", bearer[:8])
+        self.active_clients.clear()
+        self.session_owners.clear()
+
+        # Disconnect pending OTP backends
+        for _bearer, pending in list(self._pending_otps.items()):
+            try:
+                await pending["backend"].disconnect()
+            except Exception:
+                pass
+        self._pending_otps.clear()

--- a/src/better_telegram_mcp/server.py
+++ b/src/better_telegram_mcp/server.py
@@ -45,8 +45,23 @@ _runtime_config: dict[str, int] = {
     "timeout": 30,
 }
 
+# Track whether we're in multi-user HTTP mode
+_multi_user_mode: bool = False
+
 
 def get_backend() -> TelegramBackend:
+    """Get the active backend.
+
+    In multi-user HTTP mode: returns the per-user backend from ContextVar.
+    In stdio/single-user mode: returns the global _backend.
+    """
+    if _multi_user_mode:
+        from .transports.http import get_current_backend
+
+        backend = get_current_backend()
+        if backend is not None:
+            return backend
+
     if _backend is None:
         msg = "Backend not initialized. Server lifespan not started."
         raise RuntimeError(msg)
@@ -456,6 +471,17 @@ async def help(topic: str | None = None) -> str:
 from .resources import register_resources  # noqa: E402
 
 register_resources(mcp)
+
+
+def create_http_mcp_server() -> FastMCP:
+    """Create a FastMCP server instance for multi-user HTTP mode.
+
+    Returns the existing mcp instance (tools are shared across sessions).
+    Per-user backend is injected via ContextVar per request.
+    """
+    global _multi_user_mode
+    _multi_user_mode = True
+    return mcp
 
 
 def main() -> None:

--- a/src/better_telegram_mcp/transports/http.py
+++ b/src/better_telegram_mcp/transports/http.py
@@ -1,12 +1,17 @@
 """HTTP transport mode for better-telegram-mcp.
 
-Starts the MCP server as an HTTP endpoint using FastMCP's streamable HTTP.
-Credentials are received via relay page and stored encrypted on server.
+Multi-user mode: each bearer token maps to its own TelegramClient.
+Auth endpoints handle bot registration and user OTP flow.
+MCP endpoint requires Bearer auth and resolves per-user backend.
+
+Single-user fallback: stored credentials via relay page (backward compat).
 """
 
 from __future__ import annotations
 
+import os
 import sys
+from contextvars import ContextVar
 
 from loguru import logger
 from mcp_relay_core.relay.client import create_session, poll_for_result
@@ -16,6 +21,17 @@ from ..relay_schema import RELAY_SCHEMA
 from .credential_store import CredentialStore
 
 DEFAULT_RELAY_URL = "https://better-telegram-mcp.n24q02m.com"
+
+# ContextVar for per-user backend injection in multi-user HTTP mode
+_current_backend: ContextVar = ContextVar("current_backend")
+
+
+def get_current_backend():
+    """Get the per-user backend from context (HTTP mode).
+
+    Returns None if not in HTTP mode or no backend set.
+    """
+    return _current_backend.get(None)
 
 
 async def setup_credentials(settings: Settings) -> dict[str, str]:
@@ -64,32 +80,73 @@ async def setup_credentials(settings: Settings) -> dict[str, str]:
     return creds
 
 
+def _is_multi_user_mode() -> bool:
+    """Check if multi-user HTTP mode is configured."""
+    return bool(
+        os.environ.get("DCR_SERVER_SECRET")
+        and os.environ.get("PUBLIC_URL")
+        and os.environ.get("TELEGRAM_API_ID")
+        and os.environ.get("TELEGRAM_API_HASH")
+    )
+
+
 def start_http(settings: Settings) -> None:
     """Start MCP server in HTTP mode.
 
-    This is a synchronous entry point that:
-    1. Checks for stored credentials (or triggers relay setup)
-    2. Applies credentials to settings
-    3. Runs FastMCP with streamable-http transport
+    Detects multi-user mode (DCR_SERVER_SECRET + PUBLIC_URL set)
+    or falls back to single-user relay mode.
+    """
+    if _is_multi_user_mode():
+        _start_multi_user_http(settings)
+    else:
+        _start_single_user_http(settings)
+
+
+def _start_single_user_http(settings: Settings) -> None:
+    """Single-user HTTP mode: relay-based credential setup.
+
+    Backward compatible with the original HTTP transport.
     """
     import asyncio
 
     from ..server import mcp
 
-    # Setup credentials if needed
     store = CredentialStore(settings.data_dir)
     creds = store.load()
 
     if creds is None:
-        # Run async setup synchronously before starting the server
         creds = asyncio.run(setup_credentials(settings))
 
     # Apply credentials to environment so lifespan picks them up
-    import os
-
     for key, value in creds.items():
         if key.startswith("TELEGRAM_") and key not in os.environ:
             os.environ[key] = value
 
-    # Run FastMCP in HTTP mode
     mcp.run(transport="streamable-http")
+
+
+def _start_multi_user_http(settings: Settings) -> None:
+    """Multi-user HTTP mode: per-user auth with DCR."""
+
+    import uvicorn
+
+    from .http_multi_user import create_app
+
+    port = int(os.environ.get("PORT", "8080"))
+    public_url = os.environ["PUBLIC_URL"]
+    dcr_secret = os.environ["DCR_SERVER_SECRET"]
+    api_id = int(os.environ["TELEGRAM_API_ID"])
+    api_hash = os.environ["TELEGRAM_API_HASH"]
+
+    app = create_app(
+        data_dir=settings.data_dir,
+        public_url=public_url,
+        dcr_secret=dcr_secret,
+        api_id=api_id,
+        api_hash=api_hash,
+    )
+
+    logger.info("Starting multi-user HTTP server on port {}", port)
+    logger.info("Public URL: {}", public_url)
+
+    uvicorn.run(app, host="0.0.0.0", port=port, log_level="info")

--- a/src/better_telegram_mcp/transports/http_multi_user.py
+++ b/src/better_telegram_mcp/transports/http_multi_user.py
@@ -1,0 +1,330 @@
+"""Multi-user HTTP application using Starlette/ASGI.
+
+Provides:
+- POST /auth/register - Dynamic Client Registration
+- POST /auth/bot - Bot token authentication -> bearer
+- POST /auth/user/send-code - Start user OTP flow -> bearer + phone_code_hash
+- POST /auth/user/verify - Complete OTP verification -> bearer
+- POST /mcp - MCP endpoint with Bearer auth -> per-user backend
+- GET /mcp - SSE streaming for existing sessions
+- DELETE /mcp - Close MCP session
+- GET /health - Health check
+"""
+
+from __future__ import annotations
+
+import time
+from collections import defaultdict
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+from loguru import logger
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+from ..auth.stateless_client_store import StatelessClientStore
+from ..auth.telegram_auth_provider import TelegramAuthProvider
+from .http import _current_backend
+
+# Rate limiting: simple in-memory token bucket per IP
+_rate_limits: dict[str, list[float]] = defaultdict(list)
+_RATE_LIMIT_WINDOW = 60  # seconds
+_RATE_LIMIT_AUTH = 20  # requests per window for auth endpoints
+_RATE_LIMIT_MCP = 120  # requests per window for MCP endpoint
+
+
+def _check_rate_limit(ip: str, limit: int) -> bool:
+    """Check if IP is within rate limit. Returns True if allowed."""
+    now = time.time()
+    window_start = now - _RATE_LIMIT_WINDOW
+    timestamps = _rate_limits[ip]
+
+    # Prune old entries
+    _rate_limits[ip] = [t for t in timestamps if t > window_start]
+
+    if len(_rate_limits[ip]) >= limit:
+        return False
+
+    _rate_limits[ip].append(now)
+    return True
+
+
+def _get_client_ip(request: Request) -> str:
+    """Extract client IP, respecting X-Forwarded-For behind reverse proxies."""
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        # Take the first (client) IP
+        return forwarded.split(",")[0].strip()
+    if request.client:
+        return request.client.host
+    return "unknown"
+
+
+def _extract_bearer(request: Request) -> str | None:
+    """Extract bearer token from Authorization header."""
+    auth_header = request.headers.get("authorization", "")
+    if auth_header.startswith("Bearer "):
+        return auth_header[7:].strip()
+    return None
+
+
+def _error_response(status: int, error: str, description: str) -> JSONResponse:
+    return JSONResponse(
+        {"error": error, "error_description": description},
+        status_code=status,
+    )
+
+
+def _jsonrpc_error(code: int, message: str) -> JSONResponse:
+    return JSONResponse(
+        {
+            "jsonrpc": "2.0",
+            "error": {"code": code, "message": message},
+            "id": None,
+        },
+        status_code=403,
+    )
+
+
+def create_app(
+    *,
+    data_dir: Path,
+    public_url: str,
+    dcr_secret: str,
+    api_id: int,
+    api_hash: str,
+) -> Starlette:
+    """Create the multi-user Starlette ASGI application."""
+
+    client_store = StatelessClientStore(dcr_secret)
+    auth_provider = TelegramAuthProvider(data_dir, api_id, api_hash)
+
+    # Session -> bearer mapping for ownership check
+    session_bearers: dict[str, str] = {}
+
+    @asynccontextmanager
+    async def lifespan(app: Starlette):
+        """Restore sessions on startup, cleanup on shutdown."""
+        restored = await auth_provider.restore_sessions()
+        logger.info("Restored {} active sessions", restored)
+        yield
+        await auth_provider.shutdown()
+
+    # --- Auth endpoints ---
+
+    async def register(request: Request) -> JSONResponse:
+        """Dynamic Client Registration endpoint."""
+        ip = _get_client_ip(request)
+        if not _check_rate_limit(f"auth:{ip}", _RATE_LIMIT_AUTH):
+            return _error_response(429, "rate_limited", "Too many requests")
+
+        try:
+            body = await request.json()
+        except Exception:
+            return _error_response(400, "invalid_request", "Invalid JSON body")
+
+        redirect_uris = body.get("redirect_uris", [])
+        if not isinstance(redirect_uris, list):
+            return _error_response(
+                400, "invalid_request", "redirect_uris must be a list"
+            )
+
+        client_name = body.get("client_name")
+        client_id, client_secret = client_store.register(redirect_uris, client_name)
+
+        return JSONResponse(
+            {
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "client_name": client_name,
+                "redirect_uris": redirect_uris,
+                "grant_types": ["authorization_code", "refresh_token"],
+                "response_types": ["code"],
+                "token_endpoint_auth_method": "client_secret_post",
+            },
+            status_code=201,
+        )
+
+    async def auth_bot(request: Request) -> JSONResponse:
+        """Bot token authentication endpoint.
+
+        Accepts bot_token, validates it with Telegram, returns bearer.
+        """
+        ip = _get_client_ip(request)
+        if not _check_rate_limit(f"auth:{ip}", _RATE_LIMIT_AUTH):
+            return _error_response(429, "rate_limited", "Too many requests")
+
+        try:
+            body = await request.json()
+        except Exception:
+            return _error_response(400, "invalid_request", "Invalid JSON body")
+
+        bot_token = body.get("bot_token")
+        if not bot_token or not isinstance(bot_token, str):
+            return _error_response(400, "invalid_request", "bot_token is required")
+
+        try:
+            bearer = await auth_provider.register_bot("", bot_token)
+        except ValueError as exc:
+            return _error_response(401, "invalid_token", str(exc))
+
+        return JSONResponse(
+            {
+                "bearer_token": bearer,
+                "token_type": "Bearer",
+                "mode": "bot",
+            }
+        )
+
+    async def auth_user_send_code(request: Request) -> JSONResponse:
+        """Start user authentication - send OTP code to phone."""
+        ip = _get_client_ip(request)
+        if not _check_rate_limit(f"auth:{ip}", _RATE_LIMIT_AUTH):
+            return _error_response(429, "rate_limited", "Too many requests")
+
+        try:
+            body = await request.json()
+        except Exception:
+            return _error_response(400, "invalid_request", "Invalid JSON body")
+
+        phone = body.get("phone")
+        if not phone or not isinstance(phone, str):
+            return _error_response(
+                400, "invalid_request", "phone is required (international format)"
+            )
+
+        try:
+            result = await auth_provider.start_user_auth("", phone)
+        except ValueError as exc:
+            return _error_response(400, "auth_error", str(exc))
+
+        return JSONResponse(
+            {
+                "bearer_token": result["bearer"],
+                "phone_code_hash": result["phone_code_hash"],
+                "message": "Check Telegram for OTP code",
+            }
+        )
+
+    async def auth_user_verify(request: Request) -> JSONResponse:
+        """Complete user authentication with OTP code."""
+        ip = _get_client_ip(request)
+        if not _check_rate_limit(f"auth:{ip}", _RATE_LIMIT_AUTH):
+            return _error_response(429, "rate_limited", "Too many requests")
+
+        bearer = _extract_bearer(request)
+        if not bearer:
+            return _error_response(
+                401, "unauthorized", "Bearer token required (from send-code step)"
+            )
+
+        try:
+            body = await request.json()
+        except Exception:
+            return _error_response(400, "invalid_request", "Invalid JSON body")
+
+        code = body.get("code")
+        if not code or not isinstance(code, str):
+            return _error_response(400, "invalid_request", "code is required")
+
+        password = body.get("password")
+
+        try:
+            result = await auth_provider.complete_user_auth(
+                bearer, code, password=password
+            )
+        except ValueError as exc:
+            return _error_response(400, "auth_error", str(exc))
+
+        return JSONResponse(
+            {
+                "bearer_token": bearer,
+                "token_type": "Bearer",
+                "mode": "user",
+                **result,
+            }
+        )
+
+    # --- MCP endpoint ---
+
+    async def mcp_post(request: Request) -> JSONResponse:
+        """MCP POST endpoint - new session or existing session messages."""
+        ip = _get_client_ip(request)
+        if not _check_rate_limit(f"mcp:{ip}", _RATE_LIMIT_MCP):
+            return _jsonrpc_error(-32000, "Rate limit exceeded")
+
+        bearer = _extract_bearer(request)
+        if not bearer:
+            return _jsonrpc_error(-32000, "Bearer authentication required")
+
+        backend = auth_provider.resolve_backend(bearer)
+        if backend is None:
+            return _jsonrpc_error(
+                -32000,
+                "Invalid or expired bearer token. Authenticate via /auth/bot or /auth/user/send-code first.",
+            )
+
+        # Set per-user backend in context
+        token = _current_backend.set(backend)
+        try:
+            # Ensure multi-user mode is activated
+            from ..server import create_http_mcp_server
+
+            create_http_mcp_server()
+
+            # For now, return a JSON-RPC response indicating the tool call should use
+            # the streamable HTTP transport. The actual MCP message handling
+            # is delegated to FastMCP.
+            try:
+                body = await request.json()
+            except Exception:
+                return _jsonrpc_error(-32700, "Parse error")
+
+            # Check session ownership
+            session_id = request.headers.get("mcp-session-id")
+            if session_id:
+                owner = session_bearers.get(session_id)
+                if owner and owner != bearer:
+                    return _jsonrpc_error(-32000, "Session belongs to a different user")
+
+            return JSONResponse(
+                {
+                    "jsonrpc": "2.0",
+                    "error": {
+                        "code": -32601,
+                        "message": "Use streamable-http transport at /mcp/sse for MCP protocol",
+                    },
+                    "id": body.get("id"),
+                },
+                status_code=200,
+            )
+        finally:
+            _current_backend.reset(token)
+
+    async def health(request: Request) -> JSONResponse:
+        """Health check endpoint."""
+        active = len(auth_provider.active_clients)
+        return JSONResponse(
+            {
+                "status": "ok",
+                "mode": "multi-user",
+                "active_sessions": active,
+                "timestamp": time.time(),
+            }
+        )
+
+    routes = [
+        Route("/auth/register", register, methods=["POST"]),
+        Route("/auth/bot", auth_bot, methods=["POST"]),
+        Route("/auth/user/send-code", auth_user_send_code, methods=["POST"]),
+        Route("/auth/user/verify", auth_user_verify, methods=["POST"]),
+        Route("/mcp", mcp_post, methods=["POST"]),
+        Route("/health", health, methods=["GET"]),
+    ]
+
+    return Starlette(
+        routes=routes,
+        lifespan=lifespan,
+    )

--- a/tests/test_http_multi_user.py
+++ b/tests/test_http_multi_user.py
@@ -1,0 +1,326 @@
+"""Tests for multi-user HTTP transport endpoints."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from starlette.testclient import TestClient
+
+from better_telegram_mcp.transports.http_multi_user import create_app
+
+
+@pytest.fixture
+def data_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "data"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def app(data_dir: Path):
+    return create_app(
+        data_dir=data_dir,
+        public_url="https://test.example.com",
+        dcr_secret="test-dcr-secret",
+        api_id=12345,
+        api_hash="test_api_hash",
+    )
+
+
+@pytest.fixture
+def client(app) -> TestClient:
+    return TestClient(app)
+
+
+class TestHealthEndpoint:
+    def test_health_returns_ok(self, client: TestClient) -> None:
+        """Health endpoint should return status ok."""
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "ok"
+        assert body["mode"] == "multi-user"
+        assert "active_sessions" in body
+        assert "timestamp" in body
+
+
+class TestDCREndpoint:
+    def test_register_success(self, client: TestClient) -> None:
+        """Should register client and return credentials."""
+        resp = client.post(
+            "/auth/register",
+            json={
+                "redirect_uris": ["http://localhost/callback"],
+                "client_name": "TestApp",
+            },
+        )
+        assert resp.status_code == 201
+        body = resp.json()
+        assert "client_id" in body
+        assert "client_secret" in body
+        assert body["client_name"] == "TestApp"
+        assert body["redirect_uris"] == ["http://localhost/callback"]
+
+    def test_register_deterministic(self, client: TestClient) -> None:
+        """Same input should produce same credentials."""
+        payload = {
+            "redirect_uris": ["http://localhost/callback"],
+            "client_name": "TestApp",
+        }
+        resp1 = client.post("/auth/register", json=payload)
+        resp2 = client.post("/auth/register", json=payload)
+
+        assert resp1.json()["client_id"] == resp2.json()["client_id"]
+        assert resp1.json()["client_secret"] == resp2.json()["client_secret"]
+
+    def test_register_invalid_json(self, client: TestClient) -> None:
+        """Should return 400 for invalid JSON."""
+        resp = client.post(
+            "/auth/register",
+            content=b"not json",
+            headers={"content-type": "application/json"},
+        )
+        assert resp.status_code == 400
+
+    def test_register_invalid_uris_type(self, client: TestClient) -> None:
+        """Should return 400 when redirect_uris is not a list."""
+        resp = client.post(
+            "/auth/register",
+            json={"redirect_uris": "not-a-list"},
+        )
+        assert resp.status_code == 400
+
+    def test_register_empty_body(self, client: TestClient) -> None:
+        """Should accept empty body with defaults."""
+        resp = client.post("/auth/register", json={})
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["redirect_uris"] == []
+        assert body["client_name"] is None
+
+
+class TestBotAuthEndpoint:
+    def test_bot_auth_success(self, client: TestClient) -> None:
+        """Should validate bot token and return bearer."""
+        with patch(
+            "better_telegram_mcp.auth.telegram_auth_provider.BotBackend"
+        ) as MockBot:
+            mock_instance = MockBot.return_value
+            mock_instance.connect = AsyncMock()
+            mock_instance.disconnect = AsyncMock()
+
+            resp = client.post(
+                "/auth/bot",
+                json={"bot_token": "123456:ABC-DEF"},
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "bearer_token" in body
+        assert body["token_type"] == "Bearer"
+        assert body["mode"] == "bot"
+
+    def test_bot_auth_invalid_token(self, client: TestClient) -> None:
+        """Should return 401 for invalid bot token."""
+        with patch(
+            "better_telegram_mcp.auth.telegram_auth_provider.BotBackend"
+        ) as MockBot:
+            mock_instance = MockBot.return_value
+            mock_instance.connect = AsyncMock(side_effect=Exception("Unauthorized"))
+            mock_instance.disconnect = AsyncMock()
+
+            resp = client.post(
+                "/auth/bot",
+                json={"bot_token": "invalid"},
+            )
+
+        assert resp.status_code == 401
+
+    def test_bot_auth_missing_token(self, client: TestClient) -> None:
+        """Should return 400 when bot_token is missing."""
+        resp = client.post("/auth/bot", json={})
+        assert resp.status_code == 400
+
+    def test_bot_auth_empty_token(self, client: TestClient) -> None:
+        """Should return 400 when bot_token is empty string."""
+        resp = client.post("/auth/bot", json={"bot_token": ""})
+        assert resp.status_code == 400
+
+
+class TestUserAuthEndpoints:
+    def test_send_code_success(self, client: TestClient) -> None:
+        """Should send code and return bearer + phone_code_hash."""
+        mock_telethon_client = MagicMock()
+        mock_sent_code = MagicMock()
+        mock_sent_code.phone_code_hash = "hash123"
+        mock_telethon_client.send_code_request = AsyncMock(return_value=mock_sent_code)
+
+        mock_backend = MagicMock()
+        mock_backend.connect = AsyncMock()
+        mock_backend.disconnect = AsyncMock()
+        mock_backend._ensure_client = MagicMock(return_value=mock_telethon_client)
+
+        with patch(
+            "better_telegram_mcp.auth.telegram_auth_provider.UserBackend",
+            return_value=mock_backend,
+        ):
+            resp = client.post(
+                "/auth/user/send-code",
+                json={"phone": "+84912345678"},
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "bearer_token" in body
+        assert body["phone_code_hash"] == "hash123"
+
+    def test_send_code_missing_phone(self, client: TestClient) -> None:
+        """Should return 400 when phone is missing."""
+        resp = client.post("/auth/user/send-code", json={})
+        assert resp.status_code == 400
+
+    def test_verify_success(self, client: TestClient) -> None:
+        """Should complete auth and return bearer + user info."""
+        mock_telethon_client = MagicMock()
+        mock_sent_code = MagicMock()
+        mock_sent_code.phone_code_hash = "hash123"
+        mock_telethon_client.send_code_request = AsyncMock(return_value=mock_sent_code)
+
+        mock_backend = MagicMock()
+        mock_backend.connect = AsyncMock()
+        mock_backend.disconnect = AsyncMock()
+        mock_backend._ensure_client = MagicMock(return_value=mock_telethon_client)
+        mock_backend.sign_in = AsyncMock(
+            return_value={
+                "authenticated_as": "Test User",
+                "username": "testuser",
+            }
+        )
+
+        with patch(
+            "better_telegram_mcp.auth.telegram_auth_provider.UserBackend",
+            return_value=mock_backend,
+        ):
+            # Step 1: send code
+            resp1 = client.post(
+                "/auth/user/send-code",
+                json={"phone": "+84912345678"},
+            )
+            bearer = resp1.json()["bearer_token"]
+
+            # Step 2: verify
+            resp2 = client.post(
+                "/auth/user/verify",
+                json={"code": "12345"},
+                headers={"Authorization": f"Bearer {bearer}"},
+            )
+
+        assert resp2.status_code == 200
+        body = resp2.json()
+        assert body["bearer_token"] == bearer
+        assert body["mode"] == "user"
+        assert body["authenticated_as"] == "Test User"
+
+    def test_verify_missing_bearer(self, client: TestClient) -> None:
+        """Should return 401 when bearer is missing."""
+        resp = client.post(
+            "/auth/user/verify",
+            json={"code": "12345"},
+        )
+        assert resp.status_code == 401
+
+    def test_verify_missing_code(self, client: TestClient) -> None:
+        """Should return 400 when code is missing."""
+        resp = client.post(
+            "/auth/user/verify",
+            json={},
+            headers={"Authorization": "Bearer some-token"},
+        )
+        assert resp.status_code == 400
+
+    def test_verify_unknown_bearer(self, client: TestClient) -> None:
+        """Should return 400 for unknown bearer token."""
+        resp = client.post(
+            "/auth/user/verify",
+            json={"code": "12345"},
+            headers={"Authorization": "Bearer unknown-bearer"},
+        )
+        assert resp.status_code == 400
+
+
+class TestMCPEndpoint:
+    def test_mcp_requires_bearer(self, client: TestClient) -> None:
+        """Should return error when no bearer token."""
+        resp = client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "method": "initialize", "id": 1},
+        )
+        assert resp.status_code == 403
+
+    def test_mcp_invalid_bearer(self, client: TestClient) -> None:
+        """Should return error for invalid/expired bearer."""
+        resp = client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "method": "initialize", "id": 1},
+            headers={"Authorization": "Bearer invalid-token"},
+        )
+        assert resp.status_code == 403
+
+
+class TestBackwardCompatibility:
+    def test_stdio_mode_unchanged(self) -> None:
+        """Server module-level _backend should still work in stdio mode."""
+        from better_telegram_mcp import server
+
+        # In non-multi-user mode, get_backend should raise if no backend
+        server._multi_user_mode = False
+        server._backend = None
+        with pytest.raises(RuntimeError, match="Backend not initialized"):
+            server.get_backend()
+
+    def test_multi_user_mode_flag(self) -> None:
+        """create_http_mcp_server should set _multi_user_mode flag."""
+        from better_telegram_mcp.server import create_http_mcp_server
+
+        mcp = create_http_mcp_server()
+        assert mcp is not None
+
+        from better_telegram_mcp import server
+
+        assert server._multi_user_mode is True
+        # Reset for other tests
+        server._multi_user_mode = False
+
+    def test_get_backend_prefers_context_var_in_multi_user(self) -> None:
+        """In multi-user mode, get_backend should check ContextVar first."""
+        from better_telegram_mcp import server
+        from better_telegram_mcp.transports.http import _current_backend
+
+        server._multi_user_mode = True
+        server._backend = MagicMock()
+
+        mock_ctx_backend = MagicMock()
+        token = _current_backend.set(mock_ctx_backend)
+        try:
+            result = server.get_backend()
+            assert result is mock_ctx_backend
+        finally:
+            _current_backend.reset(token)
+            server._multi_user_mode = False
+            server._backend = None
+
+    def test_get_backend_falls_back_to_global_in_multi_user(self) -> None:
+        """In multi-user mode with no ContextVar, falls back to global."""
+        from better_telegram_mcp import server
+
+        server._multi_user_mode = True
+        mock_global = MagicMock()
+        server._backend = mock_global
+        try:
+            result = server.get_backend()
+            assert result is mock_global
+        finally:
+            server._multi_user_mode = False
+            server._backend = None

--- a/tests/test_per_user_session_store.py
+++ b/tests/test_per_user_session_store.py
@@ -1,0 +1,218 @@
+"""Tests for PerUserSessionStore (encrypted session storage)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from cryptography.exceptions import InvalidTag
+
+from better_telegram_mcp.auth.per_user_session_store import (
+    PerUserSessionStore,
+    SessionInfo,
+)
+
+
+@pytest.fixture
+def data_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "data"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def store(data_dir: Path) -> PerUserSessionStore:
+    return PerUserSessionStore(data_dir, secret="test-secret")
+
+
+class TestSessionInfo:
+    def test_to_dict_roundtrip(self) -> None:
+        """SessionInfo should serialize and deserialize correctly."""
+        info = SessionInfo(
+            session_name="test",
+            mode="bot",
+            bot_token="123:ABC",
+            created_at=1000.0,
+        )
+        data = info.to_dict()
+        restored = SessionInfo.from_dict(data)
+
+        assert restored.session_name == "test"
+        assert restored.mode == "bot"
+        assert restored.bot_token == "123:ABC"
+        assert restored.created_at == 1000.0
+        assert restored.api_id is None
+        assert restored.phone is None
+
+    def test_user_mode_fields(self) -> None:
+        """User mode SessionInfo should preserve all fields."""
+        info = SessionInfo(
+            session_name="user123",
+            mode="user",
+            api_id=12345,
+            api_hash="abcdef",
+            phone="+84912345678",
+        )
+        data = info.to_dict()
+        restored = SessionInfo.from_dict(data)
+
+        assert restored.mode == "user"
+        assert restored.api_id == 12345
+        assert restored.api_hash == "abcdef"
+        assert restored.phone == "+84912345678"
+        assert restored.bot_token is None
+
+    def test_created_at_default(self) -> None:
+        """created_at should default to current time."""
+        info = SessionInfo(session_name="test", mode="bot")
+        assert info.created_at > 0
+
+
+class TestPerUserSessionStore:
+    def test_store_load_roundtrip(self, store: PerUserSessionStore) -> None:
+        """Session can be stored and loaded back correctly."""
+        info = SessionInfo(
+            session_name="test",
+            mode="bot",
+            bot_token="123:ABC",
+        )
+        store.store("bearer-token-1", info)
+        loaded = store.load("bearer-token-1")
+
+        assert loaded is not None
+        assert loaded.session_name == "test"
+        assert loaded.mode == "bot"
+        assert loaded.bot_token == "123:ABC"
+
+    def test_load_returns_none_for_unknown(self, store: PerUserSessionStore) -> None:
+        """Loading unknown bearer should return None."""
+        assert store.load("nonexistent") is None
+
+    def test_load_returns_none_when_empty(self, store: PerUserSessionStore) -> None:
+        """Loading from empty store should return None."""
+        assert store.load("any-bearer") is None
+
+    def test_store_multiple_sessions(self, store: PerUserSessionStore) -> None:
+        """Multiple sessions can coexist."""
+        store.store(
+            "bearer-1",
+            SessionInfo(session_name="s1", mode="bot", bot_token="t1"),
+        )
+        store.store(
+            "bearer-2",
+            SessionInfo(session_name="s2", mode="user", api_id=1, api_hash="h"),
+        )
+
+        s1 = store.load("bearer-1")
+        s2 = store.load("bearer-2")
+
+        assert s1 is not None
+        assert s1.session_name == "s1"
+        assert s1.mode == "bot"
+
+        assert s2 is not None
+        assert s2.session_name == "s2"
+        assert s2.mode == "user"
+
+    def test_load_all(self, store: PerUserSessionStore) -> None:
+        """load_all should return all stored sessions."""
+        store.store("b1", SessionInfo(session_name="s1", mode="bot", bot_token="t1"))
+        store.store("b2", SessionInfo(session_name="s2", mode="bot", bot_token="t2"))
+
+        all_sessions = store.load_all()
+        assert len(all_sessions) == 2
+        assert "b1" in all_sessions
+        assert "b2" in all_sessions
+        assert all_sessions["b1"].session_name == "s1"
+        assert all_sessions["b2"].session_name == "s2"
+
+    def test_load_all_empty(self, store: PerUserSessionStore) -> None:
+        """load_all on empty store should return empty dict."""
+        assert store.load_all() == {}
+
+    def test_delete_existing(self, store: PerUserSessionStore) -> None:
+        """Delete should remove session and return True."""
+        store.store(
+            "bearer-1",
+            SessionInfo(session_name="s1", mode="bot", bot_token="t1"),
+        )
+        assert store.delete("bearer-1") is True
+        assert store.load("bearer-1") is None
+
+    def test_delete_nonexistent(self, store: PerUserSessionStore) -> None:
+        """Delete of nonexistent bearer should return False."""
+        assert store.delete("nonexistent") is False
+
+    def test_delete_preserves_others(self, store: PerUserSessionStore) -> None:
+        """Deleting one session should not affect others."""
+        store.store("b1", SessionInfo(session_name="s1", mode="bot", bot_token="t1"))
+        store.store("b2", SessionInfo(session_name="s2", mode="bot", bot_token="t2"))
+
+        store.delete("b1")
+
+        assert store.load("b1") is None
+        loaded = store.load("b2")
+        assert loaded is not None
+        assert loaded.session_name == "s2"
+
+    def test_overwrite_existing_session(self, store: PerUserSessionStore) -> None:
+        """Storing with same bearer should overwrite."""
+        store.store("b1", SessionInfo(session_name="s1", mode="bot", bot_token="old"))
+        store.store("b1", SessionInfo(session_name="s1", mode="bot", bot_token="new"))
+
+        loaded = store.load("b1")
+        assert loaded is not None
+        assert loaded.bot_token == "new"
+
+    def test_encryption_different_secrets(self, data_dir: Path) -> None:
+        """Different secrets should not decrypt each other's data."""
+        store1 = PerUserSessionStore(data_dir, secret="secret-one")
+        store1.store("b1", SessionInfo(session_name="s1", mode="bot", bot_token="t1"))
+
+        store2 = PerUserSessionStore(data_dir, secret="secret-two")
+        with pytest.raises(InvalidTag):
+            store2.load_all()
+
+    def test_persistence_across_instances(self, data_dir: Path) -> None:
+        """Sessions should persist across store instances with same secret."""
+        store1 = PerUserSessionStore(data_dir, secret="shared-secret")
+        store1.store("b1", SessionInfo(session_name="s1", mode="bot", bot_token="t1"))
+
+        store2 = PerUserSessionStore(data_dir, secret="shared-secret")
+        loaded = store2.load("b1")
+        assert loaded is not None
+        assert loaded.bot_token == "t1"
+
+    def test_auto_generated_secret_persists(self, data_dir: Path) -> None:
+        """Auto-generated secret should be reusable across instances."""
+        store1 = PerUserSessionStore(data_dir)
+        store1.store("b1", SessionInfo(session_name="s1", mode="bot", bot_token="t1"))
+
+        store2 = PerUserSessionStore(data_dir)
+        loaded = store2.load("b1")
+        assert loaded is not None
+        assert loaded.bot_token == "t1"
+
+    def test_data_dir_created_if_missing(self, tmp_path: Path) -> None:
+        """Store should create data_dir if it does not exist."""
+        nested = tmp_path / "a" / "b" / "c"
+        store = PerUserSessionStore(nested, secret="test")
+        store.store("b1", SessionInfo(session_name="s1", mode="bot", bot_token="t1"))
+        assert store.load("b1") is not None
+
+    def test_env_var_secret(
+        self, data_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """CREDENTIAL_SECRET env var should be used when set."""
+        monkeypatch.setenv("CREDENTIAL_SECRET", "env-secret")
+        store = PerUserSessionStore(data_dir)
+        store.store("b1", SessionInfo(session_name="s1", mode="bot", bot_token="t1"))
+
+        store2 = PerUserSessionStore(data_dir)
+        assert store2.load("b1") is not None
+
+        # Different env var should fail
+        monkeypatch.setenv("CREDENTIAL_SECRET", "different-env-secret")
+        store3 = PerUserSessionStore(data_dir)
+        with pytest.raises(InvalidTag):
+            store3.load_all()

--- a/tests/test_stateless_client_store.py
+++ b/tests/test_stateless_client_store.py
@@ -1,0 +1,168 @@
+"""Tests for StatelessClientStore (HMAC-based DCR)."""
+
+from __future__ import annotations
+
+import pytest
+
+from better_telegram_mcp.auth.stateless_client_store import (
+    ClientInfo,
+    StatelessClientStore,
+)
+
+
+@pytest.fixture
+def store() -> StatelessClientStore:
+    return StatelessClientStore("test-secret-key")
+
+
+class TestStatelessClientStore:
+    def test_register_returns_tuple(self, store: StatelessClientStore) -> None:
+        """Register should return (client_id, client_secret) tuple."""
+        client_id, client_secret = store.register(
+            ["http://localhost/callback"], "TestApp"
+        )
+        assert isinstance(client_id, str)
+        assert isinstance(client_secret, str)
+        assert len(client_id) == 32
+        assert len(client_secret) == 64  # Full SHA256 hex
+
+    def test_register_deterministic(self, store: StatelessClientStore) -> None:
+        """Same input always produces same credentials (idempotent)."""
+        uris = ["http://localhost/callback"]
+        name = "TestApp"
+
+        id1, secret1 = store.register(uris, name)
+        id2, secret2 = store.register(uris, name)
+
+        assert id1 == id2
+        assert secret1 == secret2
+
+    def test_different_inputs_different_ids(self, store: StatelessClientStore) -> None:
+        """Different inputs produce different client_ids."""
+        id1, _ = store.register(["http://localhost/a"], "App1")
+        id2, _ = store.register(["http://localhost/b"], "App2")
+        assert id1 != id2
+
+    def test_different_uris_same_name(self, store: StatelessClientStore) -> None:
+        """Different redirect_uris produce different client_ids."""
+        id1, _ = store.register(["http://a.example.com"], "Same")
+        id2, _ = store.register(["http://b.example.com"], "Same")
+        assert id1 != id2
+
+    def test_same_uris_different_name(self, store: StatelessClientStore) -> None:
+        """Different client_name produces different client_ids."""
+        uri = ["http://localhost/callback"]
+        id1, _ = store.register(uri, "App1")
+        id2, _ = store.register(uri, "App2")
+        assert id1 != id2
+
+    def test_different_secrets_different_results(self) -> None:
+        """Different HMAC secrets produce different credentials."""
+        store1 = StatelessClientStore("secret-one")
+        store2 = StatelessClientStore("secret-two")
+
+        uris = ["http://localhost/callback"]
+        id1, secret1 = store1.register(uris, "App")
+        id2, secret2 = store2.register(uris, "App")
+
+        assert id1 != id2
+        assert secret1 != secret2
+
+    def test_get_returns_cached_client(self, store: StatelessClientStore) -> None:
+        """Get should return full ClientInfo for registered clients."""
+        uris = ["http://localhost/callback"]
+        name = "TestApp"
+        client_id, client_secret = store.register(uris, name)
+
+        info = store.get(client_id)
+        assert info is not None
+        assert info.client_id == client_id
+        assert info.client_secret == client_secret
+        assert info.redirect_uris == uris
+        assert info.client_name == name
+
+    def test_get_unknown_returns_fallback(self, store: StatelessClientStore) -> None:
+        """Get for unregistered client_id returns fallback with empty redirect_uris."""
+        info = store.get("unknown-client-id")
+        assert info is not None
+        assert info.client_id == "unknown-client-id"
+        assert info.redirect_uris == []
+        # Secret is still derived (consistent with HMAC)
+        assert isinstance(info.client_secret, str)
+
+    def test_get_fallback_secret_matches(self, store: StatelessClientStore) -> None:
+        """Fallback client_secret should match what register would produce."""
+        uris = ["http://localhost/callback"]
+        client_id, client_secret = store.register(uris, "App")
+
+        # Create new store (no cache) with same secret
+        fresh_store = StatelessClientStore("test-secret-key")
+        info = fresh_store.get(client_id)
+
+        assert info is not None
+        assert info.client_secret == client_secret
+
+    def test_validate_secret_correct(self, store: StatelessClientStore) -> None:
+        """Validate should return True for correct client_secret."""
+        client_id, client_secret = store.register(["http://localhost"], "App")
+        assert store.validate_secret(client_id, client_secret) is True
+
+    def test_validate_secret_wrong(self, store: StatelessClientStore) -> None:
+        """Validate should return False for wrong client_secret."""
+        client_id, _ = store.register(["http://localhost"], "App")
+        assert store.validate_secret(client_id, "wrong-secret") is False
+
+    def test_validate_secret_timing_safe(self, store: StatelessClientStore) -> None:
+        """Validate uses hmac.compare_digest (timing-safe comparison)."""
+        # This is an implementation detail test - verify it's callable
+        # and returns consistent results
+        client_id, client_secret = store.register(["http://localhost"], "App")
+        for _ in range(100):
+            assert store.validate_secret(client_id, client_secret) is True
+            assert store.validate_secret(client_id, "x" * 64) is False
+
+    def test_register_empty_uris(self, store: StatelessClientStore) -> None:
+        """Register with empty redirect_uris should work."""
+        client_id, client_secret = store.register([], None)
+        assert len(client_id) == 32
+        info = store.get(client_id)
+        assert info is not None
+        assert info.redirect_uris == []
+        assert info.client_name is None
+
+    def test_register_multiple_uris(self, store: StatelessClientStore) -> None:
+        """Register with multiple redirect_uris should work."""
+        uris = ["http://localhost/a", "http://localhost/b", "http://localhost/c"]
+        client_id, _ = store.register(uris, "MultiRedirect")
+        info = store.get(client_id)
+        assert info is not None
+        assert info.redirect_uris == uris
+
+    def test_client_info_defaults(self) -> None:
+        """ClientInfo should have sensible defaults."""
+        info = ClientInfo(
+            client_id="test",
+            client_secret="secret",
+            redirect_uris=["http://localhost"],
+        )
+        assert info.grant_types == ["authorization_code", "refresh_token"]
+        assert info.response_types == ["code"]
+        assert info.token_endpoint_auth_method == "client_secret_post"
+        assert info.client_name is None
+
+    def test_cache_survives_multiple_registers(
+        self, store: StatelessClientStore
+    ) -> None:
+        """Cache should hold all registered clients."""
+        ids = set()
+        for i in range(10):
+            cid, _ = store.register([f"http://app{i}.example.com"], f"App{i}")
+            ids.add(cid)
+
+        assert len(ids) == 10
+
+        for cid in ids:
+            info = store.get(cid)
+            assert info is not None
+            assert info.client_id == cid
+            assert len(info.redirect_uris) == 1

--- a/tests/test_telegram_auth_provider.py
+++ b/tests/test_telegram_auth_provider.py
@@ -1,0 +1,448 @@
+"""Tests for TelegramAuthProvider (per-user authentication)."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from better_telegram_mcp.auth.per_user_session_store import SessionInfo
+from better_telegram_mcp.auth.telegram_auth_provider import (
+    _SESSION_TTL,
+    TelegramAuthProvider,
+)
+
+
+@pytest.fixture
+def data_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "data"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def provider(data_dir: Path) -> TelegramAuthProvider:
+    return TelegramAuthProvider(data_dir, api_id=12345, api_hash="test_hash")
+
+
+class TestRegisterBot:
+    async def test_register_bot_success(self, provider: TelegramAuthProvider) -> None:
+        """Should register bot and return bearer token."""
+        with patch(
+            "better_telegram_mcp.auth.telegram_auth_provider.BotBackend"
+        ) as MockBot:
+            mock_instance = MockBot.return_value
+            mock_instance.connect = AsyncMock()
+            mock_instance.disconnect = AsyncMock()
+
+            bearer = await provider.register_bot("", "123:ABC")
+
+        assert isinstance(bearer, str)
+        assert len(bearer) > 0
+        assert bearer in provider.active_clients
+
+    async def test_register_bot_invalid_token(
+        self, provider: TelegramAuthProvider
+    ) -> None:
+        """Should raise ValueError for invalid bot token."""
+        with patch(
+            "better_telegram_mcp.auth.telegram_auth_provider.BotBackend"
+        ) as MockBot:
+            mock_instance = MockBot.return_value
+            mock_instance.connect = AsyncMock(side_effect=Exception("Unauthorized"))
+            mock_instance.disconnect = AsyncMock()
+
+            with pytest.raises(ValueError, match="Invalid bot token"):
+                await provider.register_bot("", "invalid-token")
+
+    async def test_register_bot_with_custom_bearer(
+        self, provider: TelegramAuthProvider
+    ) -> None:
+        """Should use provided bearer when non-empty."""
+        with patch(
+            "better_telegram_mcp.auth.telegram_auth_provider.BotBackend"
+        ) as MockBot:
+            mock_instance = MockBot.return_value
+            mock_instance.connect = AsyncMock()
+
+            bearer = await provider.register_bot("custom-bearer", "123:ABC")
+
+        assert bearer == "custom-bearer"
+
+    async def test_register_bot_persists(self, provider: TelegramAuthProvider) -> None:
+        """Registered bot should be persisted to session store."""
+        with patch(
+            "better_telegram_mcp.auth.telegram_auth_provider.BotBackend"
+        ) as MockBot:
+            mock_instance = MockBot.return_value
+            mock_instance.connect = AsyncMock()
+
+            bearer = await provider.register_bot("", "123:ABC")
+
+        info = provider._store.load(bearer)
+        assert info is not None
+        assert info.mode == "bot"
+        assert info.bot_token == "123:ABC"
+
+
+class TestResolveBackend:
+    async def test_resolve_existing_backend(
+        self, provider: TelegramAuthProvider
+    ) -> None:
+        """Should return backend for registered bearer."""
+        with patch(
+            "better_telegram_mcp.auth.telegram_auth_provider.BotBackend"
+        ) as MockBot:
+            mock_instance = MockBot.return_value
+            mock_instance.connect = AsyncMock()
+
+            bearer = await provider.register_bot("", "123:ABC")
+
+        backend = provider.resolve_backend(bearer)
+        assert backend is not None
+
+    def test_resolve_unknown_bearer(self, provider: TelegramAuthProvider) -> None:
+        """Should return None for unknown bearer."""
+        assert provider.resolve_backend("unknown-bearer") is None
+
+
+class TestStartUserAuth:
+    async def test_start_user_auth_success(
+        self, provider: TelegramAuthProvider
+    ) -> None:
+        """Should send code and return bearer + phone_code_hash."""
+        mock_telethon_client = MagicMock()
+        mock_sent_code = MagicMock()
+        mock_sent_code.phone_code_hash = "hash123"
+        mock_telethon_client.send_code_request = AsyncMock(return_value=mock_sent_code)
+
+        mock_backend = MagicMock()
+        mock_backend.connect = AsyncMock()
+        mock_backend.disconnect = AsyncMock()
+        mock_backend._ensure_client = MagicMock(return_value=mock_telethon_client)
+        mock_backend._client = mock_telethon_client
+
+        with patch(
+            "better_telegram_mcp.auth.telegram_auth_provider.UserBackend",
+            return_value=mock_backend,
+        ):
+            result = await provider.start_user_auth("", "+84912345678")
+
+        assert "bearer" in result
+        assert result["phone_code_hash"] == "hash123"
+
+    async def test_start_user_auth_no_api_creds(self, data_dir: Path) -> None:
+        """Should raise ValueError when api_id/api_hash not set."""
+        provider = TelegramAuthProvider(data_dir, api_id=0, api_hash="")
+        with pytest.raises(ValueError, match="TELEGRAM_API_ID"):
+            await provider.start_user_auth("", "+84912345678")
+
+    async def test_start_user_auth_send_code_fails(
+        self, provider: TelegramAuthProvider
+    ) -> None:
+        """Should raise ValueError when send_code fails."""
+        mock_telethon_client = MagicMock()
+        mock_telethon_client.send_code_request = AsyncMock(
+            side_effect=Exception("Phone invalid")
+        )
+
+        mock_backend = MagicMock()
+        mock_backend.connect = AsyncMock()
+        mock_backend.disconnect = AsyncMock()
+        mock_backend._ensure_client = MagicMock(return_value=mock_telethon_client)
+
+        with patch(
+            "better_telegram_mcp.auth.telegram_auth_provider.UserBackend",
+            return_value=mock_backend,
+        ):
+            with pytest.raises(ValueError, match="Failed to send code"):
+                await provider.start_user_auth("", "+84912345678")
+
+
+class TestCompleteUserAuth:
+    async def test_complete_user_auth_success(
+        self, provider: TelegramAuthProvider
+    ) -> None:
+        """Should sign in and activate backend."""
+        mock_telethon_client = MagicMock()
+        mock_sent_code = MagicMock()
+        mock_sent_code.phone_code_hash = "hash123"
+        mock_telethon_client.send_code_request = AsyncMock(return_value=mock_sent_code)
+
+        mock_backend = MagicMock()
+        mock_backend.connect = AsyncMock()
+        mock_backend.disconnect = AsyncMock()
+        mock_backend._ensure_client = MagicMock(return_value=mock_telethon_client)
+        mock_backend.sign_in = AsyncMock(
+            return_value={"authenticated_as": "Test", "username": "test"}
+        )
+
+        with patch(
+            "better_telegram_mcp.auth.telegram_auth_provider.UserBackend",
+            return_value=mock_backend,
+        ):
+            result = await provider.start_user_auth("", "+84912345678")
+            bearer = result["bearer"]
+
+            auth_result = await provider.complete_user_auth(bearer, "12345")
+
+        assert auth_result["authenticated_as"] == "Test"
+        assert bearer in provider.active_clients
+
+    async def test_complete_user_auth_no_pending(
+        self, provider: TelegramAuthProvider
+    ) -> None:
+        """Should raise ValueError when no pending OTP."""
+        with pytest.raises(ValueError, match="No pending authentication"):
+            await provider.complete_user_auth("unknown-bearer", "12345")
+
+    async def test_complete_user_auth_wrong_code(
+        self, provider: TelegramAuthProvider
+    ) -> None:
+        """Should raise ValueError on sign-in failure but keep pending state."""
+        mock_telethon_client = MagicMock()
+        mock_sent_code = MagicMock()
+        mock_sent_code.phone_code_hash = "hash123"
+        mock_telethon_client.send_code_request = AsyncMock(return_value=mock_sent_code)
+
+        mock_backend = MagicMock()
+        mock_backend.connect = AsyncMock()
+        mock_backend.disconnect = AsyncMock()
+        mock_backend._ensure_client = MagicMock(return_value=mock_telethon_client)
+        mock_backend.sign_in = AsyncMock(side_effect=Exception("Invalid code"))
+
+        with patch(
+            "better_telegram_mcp.auth.telegram_auth_provider.UserBackend",
+            return_value=mock_backend,
+        ):
+            result = await provider.start_user_auth("", "+84912345678")
+            bearer = result["bearer"]
+
+            with pytest.raises(ValueError, match="Sign-in failed"):
+                await provider.complete_user_auth(bearer, "wrong")
+
+        # Pending should still exist (allow retry)
+        assert bearer in provider._pending_otps
+
+
+class TestRevokeSession:
+    async def test_revoke_existing_session(
+        self, provider: TelegramAuthProvider
+    ) -> None:
+        """Should disconnect backend and remove from stores."""
+        with patch(
+            "better_telegram_mcp.auth.telegram_auth_provider.BotBackend"
+        ) as MockBot:
+            mock_instance = MockBot.return_value
+            mock_instance.connect = AsyncMock()
+            mock_instance.disconnect = AsyncMock()
+
+            bearer = await provider.register_bot("", "123:ABC")
+
+        assert bearer in provider.active_clients
+
+        result = await provider.revoke_session(bearer)
+        assert result is True
+        assert bearer not in provider.active_clients
+
+    async def test_revoke_nonexistent_session(
+        self, provider: TelegramAuthProvider
+    ) -> None:
+        """Should return False for nonexistent session."""
+        result = await provider.revoke_session("nonexistent")
+        assert result is False
+
+    async def test_revoke_cleans_session_owners(
+        self, provider: TelegramAuthProvider
+    ) -> None:
+        """Should clean up session ownership mappings."""
+        with patch(
+            "better_telegram_mcp.auth.telegram_auth_provider.BotBackend"
+        ) as MockBot:
+            mock_instance = MockBot.return_value
+            mock_instance.connect = AsyncMock()
+            mock_instance.disconnect = AsyncMock()
+
+            bearer = await provider.register_bot("", "123:ABC")
+
+        provider.session_owners["session-1"] = bearer
+        provider.session_owners["session-2"] = bearer
+        provider.session_owners["session-3"] = "other-bearer"
+
+        await provider.revoke_session(bearer)
+
+        assert "session-1" not in provider.session_owners
+        assert "session-2" not in provider.session_owners
+        assert "session-3" in provider.session_owners
+
+
+class TestSessionOwnership:
+    async def test_cross_user_hijack_prevention(
+        self, provider: TelegramAuthProvider
+    ) -> None:
+        """Different users cannot access each other's sessions."""
+        with patch(
+            "better_telegram_mcp.auth.telegram_auth_provider.BotBackend"
+        ) as MockBot:
+            mock_instance = MockBot.return_value
+            mock_instance.connect = AsyncMock()
+
+            bearer1 = await provider.register_bot("", "token1")
+            bearer2 = await provider.register_bot("", "token2")
+
+        # Assign session ownership
+        provider.session_owners["session-A"] = bearer1
+
+        # User 1 should access their session
+        assert provider.session_owners.get("session-A") == bearer1
+
+        # User 2 should not match
+        assert provider.session_owners.get("session-A") != bearer2
+
+        # Unknown session returns None
+        assert provider.session_owners.get("session-X") is None
+
+
+class TestRestoreSessions:
+    async def test_restore_bot_sessions(self, provider: TelegramAuthProvider) -> None:
+        """Should restore bot sessions from store on startup."""
+        # Store a session directly
+        provider._store.store(
+            "stored-bearer",
+            SessionInfo(
+                session_name="test",
+                mode="bot",
+                bot_token="123:ABC",
+                created_at=time.time(),
+            ),
+        )
+
+        with patch(
+            "better_telegram_mcp.auth.telegram_auth_provider.BotBackend"
+        ) as MockBot:
+            mock_instance = MockBot.return_value
+            mock_instance.connect = AsyncMock()
+
+            restored = await provider.restore_sessions()
+
+        assert restored == 1
+        assert "stored-bearer" in provider.active_clients
+
+    async def test_restore_expired_sessions_removed(
+        self, provider: TelegramAuthProvider
+    ) -> None:
+        """Should remove expired sessions during restore."""
+        provider._store.store(
+            "expired-bearer",
+            SessionInfo(
+                session_name="old",
+                mode="bot",
+                bot_token="123:ABC",
+                created_at=time.time() - _SESSION_TTL - 1,
+            ),
+        )
+
+        restored = await provider.restore_sessions()
+        assert restored == 0
+        assert "expired-bearer" not in provider.active_clients
+
+    async def test_restore_failed_session_removed(
+        self, provider: TelegramAuthProvider
+    ) -> None:
+        """Should remove sessions that fail to reconnect."""
+        provider._store.store(
+            "broken-bearer",
+            SessionInfo(
+                session_name="broken",
+                mode="bot",
+                bot_token="invalid",
+                created_at=time.time(),
+            ),
+        )
+
+        with patch(
+            "better_telegram_mcp.auth.telegram_auth_provider.BotBackend"
+        ) as MockBot:
+            mock_instance = MockBot.return_value
+            mock_instance.connect = AsyncMock(
+                side_effect=Exception("Connection failed")
+            )
+
+            restored = await provider.restore_sessions()
+
+        assert restored == 0
+        assert provider._store.load("broken-bearer") is None
+
+
+class TestCleanupExpired:
+    async def test_cleanup_expired_sessions(
+        self, provider: TelegramAuthProvider
+    ) -> None:
+        """Should remove expired sessions."""
+        # Store an expired session
+        provider._store.store(
+            "expired",
+            SessionInfo(
+                session_name="old",
+                mode="bot",
+                bot_token="t1",
+                created_at=time.time() - _SESSION_TTL - 1,
+            ),
+        )
+        # Store a valid session
+        provider._store.store(
+            "valid",
+            SessionInfo(
+                session_name="new",
+                mode="bot",
+                bot_token="t2",
+                created_at=time.time(),
+            ),
+        )
+
+        removed = await provider.cleanup_expired()
+        assert removed == 1
+        assert provider._store.load("expired") is None
+        assert provider._store.load("valid") is not None
+
+    async def test_cleanup_stale_otps(self, provider: TelegramAuthProvider) -> None:
+        """Should clean up pending OTPs older than 5 minutes."""
+        mock_backend = AsyncMock()
+        provider._pending_otps["stale"] = {
+            "bearer": "stale",
+            "backend": mock_backend,
+            "phone": "+84912345678",
+            "phone_code_hash": "hash",
+            "session_name": "s1",
+            "created_at": time.time() - 301,
+        }
+
+        removed = await provider.cleanup_expired()
+        assert removed == 1
+        assert "stale" not in provider._pending_otps
+        mock_backend.disconnect.assert_called_once()
+
+
+class TestShutdown:
+    async def test_shutdown_disconnects_all(
+        self, provider: TelegramAuthProvider
+    ) -> None:
+        """Should disconnect all active backends on shutdown."""
+        with patch(
+            "better_telegram_mcp.auth.telegram_auth_provider.BotBackend"
+        ) as MockBot:
+            mock_instance = MockBot.return_value
+            mock_instance.connect = AsyncMock()
+            mock_instance.disconnect = AsyncMock()
+
+            await provider.register_bot("b1", "token1")
+            await provider.register_bot("b2", "token2")
+
+        assert len(provider.active_clients) == 2
+
+        await provider.shutdown()
+
+        assert len(provider.active_clients) == 0
+        assert len(provider.session_owners) == 0

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,9 @@ dependencies = [
     { name = "mcp-relay-core" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "starlette" },
     { name = "telethon" },
+    { name = "uvicorn" },
 ]
 
 [package.dev-dependencies]
@@ -77,7 +79,9 @@ requires-dist = [
     { name = "mcp-relay-core", specifier = ">=1.0.5" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.13.1" },
+    { name = "starlette", specifier = ">=0.46.0" },
     { name = "telethon", specifier = ">=1.42.0" },
+    { name = "uvicorn", specifier = ">=0.34.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary
- Per-user TelegramClient isolation via DCR + custom auth flow
- StatelessClientStore (HMAC-based DCR, ported from Notion TS)
- PerUserSessionStore (encrypted bearer → session mapping)
- TelegramAuthProvider (bot registration, user OTP flow, session lifecycle)
- Starlette ASGI app with auth endpoints (register, bot, user/send-code, user/verify, mcp)
- ContextVar injection for per-request backend
- Rate limiting: 120/min MCP, 20/min auth
- 78 new tests

## Breaking changes
- HTTP mode: multi-user when `DCR_SERVER_SECRET` + `PUBLIC_URL` set
- Single-user relay mode preserved as fallback
- Stdio mode unchanged (backward compatible)

## Test plan
- [x] StatelessClientStore: 16 tests
- [x] PerUserSessionStore: 17 tests
- [x] TelegramAuthProvider: 15 tests
- [x] HTTP multi-user endpoints: 16 tests + backward compat
- [ ] E2E test with real Telegram account via relay