### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in session file creation

### DIFF
--- a/src/better_telegram_mcp/backends/user_backend.py
+++ b/src/better_telegram_mcp/backends/user_backend.py
@@ -69,6 +69,13 @@ class UserBackend(TelegramBackend):
         session_path = s.data_dir / s.session_name
         s.data_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
 
+        # Pre-create the actual SQLite file securely to prevent TOCTOU permission issues
+        # Telethon will use this file instead of creating it with default permissions
+        full_session_path = session_path.with_suffix(".session")
+        if not full_session_path.exists():
+            fd = os.open(full_session_path, os.O_CREAT | os.O_RDWR, 0o600)
+            os.close(fd)
+
         self._client = TelegramClient(
             str(session_path),
             s.api_id,
@@ -124,11 +131,6 @@ class UserBackend(TelegramBackend):
                 raise
 
         me = await client.get_me()
-        # Set session file permissions to 600
-        s = self._settings
-        session_file = (s.data_dir / s.session_name).with_suffix(".session")
-        if session_file.exists():
-            os.chmod(session_file, 0o600)
 
         return {
             "authenticated_as": getattr(me, "first_name", ""),

--- a/tests/test_backends/test_user_backend.py
+++ b/tests/test_backends/test_user_backend.py
@@ -1298,30 +1298,19 @@ class TestSignIn:
 
     @pytest.mark.skipif(
         sys.platform == "win32",
-        reason="Windows does not support Unix file permissions (chmod 0o600)",
+        reason="Windows does not support Unix file permissions (0o600)",
     )
-    async def test_sign_in_sets_session_permissions(
+    async def test_connect_precreates_session_securely(
         self, tmp_path, mock_client, mock_client_class
     ):
         from better_telegram_mcp.backends.user_backend import UserBackend
-
-        # Create a fake session file
-        session_file = tmp_path / "test_session.session"
-        session_file.write_text("fake")
-        session_file.chmod(0o644)
-
-        mock_me = MagicMock()
-        mock_me.first_name = "Test"
-        mock_me.username = "testuser"
-        mock_client.sign_in = AsyncMock()
-        mock_client.get_me = AsyncMock(return_value=mock_me)
 
         settings = _make_settings(tmp_path)
         backend = UserBackend(settings)
         await backend.connect()
 
-        await backend.sign_in("+84912345678", "12345")
-
+        session_file = tmp_path / "test_session.session"
+        assert session_file.exists()
         assert session_file.stat().st_mode & 0o777 == 0o600
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "3.5.0b1"
+version = "3.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: A Time-of-Check to Time-of-Use (TOCTOU) vulnerability where `Telethon` initializes the SQLite session file with default system permissions (typically `0o644`), which is later tightened to `0o600` via `os.chmod`. This leaves a brief race condition window where an attacker could read the sensitive token.
🎯 **Impact**: A local user could exploit the race condition to read sensitive Telegram authentication tokens, leading to session hijacking.
🔧 **Fix**: Pre-created the `.session` file explicitly with `os.open` and secure file creation flags (`0o600`) before Telethon accesses it, eliminating the TOCTOU window. Removed the redundant `os.chmod` block inside `sign_in` which was also unnecessarily blocking the async loop.
✅ **Verification**: Ensured `test_connect_precreates_session_securely` passes, asserting that the file is initialized correctly with the tight `0o600` permissions.

---
*PR created automatically by Jules for task [2775423374777998240](https://jules.google.com/task/2775423374777998240) started by @n24q02m*