### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in session file creation

### DIFF
--- a/src/better_telegram_mcp/backends/user_backend.py
+++ b/src/better_telegram_mcp/backends/user_backend.py
@@ -69,6 +69,16 @@ class UserBackend(TelegramBackend):
         session_path = s.data_dir / s.session_name
         s.data_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
 
+        # Pre-create the session file with secure permissions to avoid TOCTOU
+        # vulnerability where Telethon creates it with default insecure permissions
+        # and we later chmod it.
+        actual_session_path = session_path.with_suffix(".session")
+        try:
+            fd = os.open(str(actual_session_path), os.O_CREAT | os.O_WRONLY, 0o600)
+            os.close(fd)
+        except OSError:
+            pass  # Windows might not support this or file might exist
+
         self._client = TelegramClient(
             str(session_path),
             s.api_id,
@@ -124,11 +134,14 @@ class UserBackend(TelegramBackend):
                 raise
 
         me = await client.get_me()
-        # Set session file permissions to 600
+        # Ensure existing session files (created by older versions) are also secured
         s = self._settings
         session_file = (s.data_dir / s.session_name).with_suffix(".session")
         if session_file.exists():
-            os.chmod(session_file, 0o600)
+            try:
+                os.chmod(session_file, 0o600)
+            except OSError:
+                pass
 
         return {
             "authenticated_as": getattr(me, "first_name", ""),

--- a/tests/test_backends/test_user_backend.py
+++ b/tests/test_backends/test_user_backend.py
@@ -1300,12 +1300,38 @@ class TestSignIn:
         sys.platform == "win32",
         reason="Windows does not support Unix file permissions (chmod 0o600)",
     )
-    async def test_sign_in_sets_session_permissions(
+    async def test_connect_sets_session_permissions(
         self, tmp_path, mock_client, mock_client_class
     ):
         from better_telegram_mcp.backends.user_backend import UserBackend
 
-        # Create a fake session file
+        # Remove the session file if it exists so we can test its creation
+        session_file = tmp_path / "test_session.session"
+        if session_file.exists():
+            session_file.unlink()
+
+        mock_me = MagicMock()
+        mock_me.first_name = "Test"
+        mock_me.username = "testuser"
+        mock_client.sign_in = AsyncMock()
+        mock_client.get_me = AsyncMock(return_value=mock_me)
+
+        settings = _make_settings(tmp_path)
+        backend = UserBackend(settings)
+        await backend.connect()
+
+        assert session_file.stat().st_mode & 0o777 == 0o600
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="Windows does not support Unix file permissions (chmod 0o600)",
+    )
+    async def test_sign_in_updates_existing_session_permissions(
+        self, tmp_path, mock_client, mock_client_class
+    ):
+        from better_telegram_mcp.backends.user_backend import UserBackend
+
+        # Create a fake session file with insecure permissions
         session_file = tmp_path / "test_session.session"
         session_file.write_text("fake")
         session_file.chmod(0o644)
@@ -1319,7 +1345,6 @@ class TestSignIn:
         settings = _make_settings(tmp_path)
         backend = UserBackend(settings)
         await backend.connect()
-
         await backend.sign_in("+84912345678", "12345")
 
         assert session_file.stat().st_mode & 0o777 == 0o600

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "3.5.0b1"
+version = "3.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
🚨 **Severity**: HIGH

💡 **Vulnerability**: A Time-of-Check to Time-of-Use (TOCTOU) vulnerability where Telegram session files (`.session`) were created with default (potentially insecure) permissions by the Telethon library and later modified via `os.chmod` in the `sign_in` method. This exposed the session file to unauthorized local access by other processes during the short window between file creation and the `chmod` operation.

🎯 **Impact**: Local attackers with access to the same machine could theoretically read the `.session` file during the brief window it had insecure permissions, potentially compromising the user's Telegram session.

🔧 **Fix**: 
1. Pre-created the `.session` file in `UserBackend.connect` using `os.open` with the `os.O_CREAT` flag and the secure mode `0o600` before handing control over the path to the Telethon library. This guarantees the file is never created with insecure permissions.
2. Updated the `UserBackend.sign_in` method to explicitly `chmod` the file to `0o600` if it already exists, to ensure any legacy session files (created by older, insecure versions) are also properly secured.

✅ **Verification**:
- Added unit tests to `tests/test_backends/test_user_backend.py` to ensure `.session` files are created with `0o600` permissions.
- Added tests to ensure existing legacy session files are corrected to `0o600` permissions during sign in.
- All tests pass (`uv run pytest`).
- Pre-commit checks pass (`uv run ruff check .` and `uv run ruff format .`).

---
*PR created automatically by Jules for task [421902811102630598](https://jules.google.com/task/421902811102630598) started by @n24q02m*