### PR TITLE
[TEST] Missing test for validate_url exception

### DIFF
--- a/tests/test_backends/test_security.py
+++ b/tests/test_backends/test_security.py
@@ -109,12 +109,20 @@ class TestValidateUrl:
         validate_url("http://example.com/image.jpg")
 
     def test_dns_resolution_failure_blocked(self, monkeypatch):
+        """Test that DNS resolution failure (OSError) is caught and re-raised as SecurityError."""
+
         def mock_getaddrinfo(*args, **kwargs):
             raise OSError("Temporary failure in name resolution")
 
         monkeypatch.setattr("socket.getaddrinfo", mock_getaddrinfo)
-        with pytest.raises(SecurityError, match="Failed to resolve hostname"):
+        with pytest.raises(
+            SecurityError, match="Failed to resolve hostname"
+        ) as exc_info:
             validate_url("http://nonexistent.domain.internal/admin")
+
+        # Verify the original OSError is chained
+        assert isinstance(exc_info.value.__cause__, OSError)
+        assert str(exc_info.value.__cause__) == "Temporary failure in name resolution"
 
 
 class TestValidateFilePath:
@@ -201,6 +209,13 @@ class TestValidateOutputDir:
         base = tmp_path / "downloads"
         with pytest.raises(SecurityError, match="must be within"):
             validate_output_dir(str(data), base_dir=base)
+
+    def test_base_dir_ok(self, tmp_path):
+        """Test that output path is allowed if it is within base_dir."""
+        data = tmp_path / "downloads" / "data.txt"
+        base = tmp_path / "downloads"
+        result = validate_output_dir(str(data), base_dir=base)
+        assert result == data.resolve()
 
     @pytest.mark.skipif(_IS_WINDOWS, reason="Unix-only blocked paths")
     def test_var_spool_blocked(self):

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "3.5.0b1"
+version = "3.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
This PR adds missing test coverage for the `better_telegram_mcp.backends.security` module.

### Changes
- Updated `test_dns_resolution_failure_blocked` to verify that the `SecurityError` correctly chains the underlying `OSError` (using `from e`).
- Added `test_base_dir_ok` to `TestValidateOutputDir` to cover the branch where an output path is successfully validated against a `base_dir`.

### Verification
- Achieved 100% statement and branch coverage for `src/better_telegram_mcp/backends/security.py`.
- Ran the full test suite (`uv run pytest`) and confirmed all 460 tests pass.
- Verified with `ruff` and `ty`.

---
*PR created automatically by Jules for task [377326236050862117](https://jules.google.com/task/377326236050862117) started by @n24q02m*