### PR TITLE
[TEST] Missing test for safe_error untested public function

### DIFF
--- a/tests/test_utils/test_formatting.py
+++ b/tests/test_utils/test_formatting.py
@@ -100,3 +100,53 @@ def test_safe_error_generic_exceptions():
 
         # Ensure internal details are NOT leaked
         assert str(exc) not in result
+
+
+def test_safe_error_subclasses():
+    # Test that subclasses of allowed exceptions are also allowed
+    class CustomValueError(ValueError):
+        pass
+
+    exc = CustomValueError("Custom message")
+    result = safe_error(exc)
+    parsed = json.loads(result)
+    assert parsed["error"] == "Custom message"
+
+
+def test_safe_error_special_characters():
+    # Test that special characters in messages are handled correctly
+    msg = 'Error with "quotes", \nnew lines, and emoji 🚀'
+    exc = ValueError(msg)
+    result = safe_error(exc)
+    parsed = json.loads(result)
+    assert parsed["error"] == msg
+
+
+def test_safe_error_empty_message():
+    # Test that exceptions with empty messages are handled gracefully
+    exc = ValueError("")
+    result = safe_error(exc)
+    parsed = json.loads(result)
+    assert parsed["error"] == ""
+
+
+def test_safe_error_edge_cases():
+    # Test with AttributeError (not in allowed list)
+    exc = AttributeError("private_attr")
+    result = safe_error(exc)
+    parsed = json.loads(result)
+    assert (
+        parsed["error"]
+        == "AttributeError: Operation failed. Check server logs for details."
+    )
+    assert "private_attr" not in result
+
+    # Test with SystemExit (BaseException subclass)
+    # Even though safe_error(e: Exception) hints Exception, Python allows BaseException.
+    exc = SystemExit(1)
+    result = safe_error(exc)
+    parsed = json.loads(result)
+    assert (
+        parsed["error"]
+        == "SystemExit: Operation failed. Check server logs for details."
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "3.5.0b1"
+version = "3.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
This PR adds comprehensive test cases for the `safe_error` utility in `src/better_telegram_mcp/utils/formatting.py` to ensure robust error sanitization and maintain 100% test coverage.

Enhancements include:
- Test for subclasses of allowed exceptions (e.g., `CustomValueError`).
- Test for exceptions with special characters (emoji, quotes, newlines) to verify JSON serialization.
- Test for exceptions with empty messages.
- Test for generic exceptions (e.g., `AttributeError`) ensuring they are correctly sanitized to avoid leaking internals.
- Test for `BaseException` variants (e.g., `SystemExit`).

---
*PR created automatically by Jules for task [5757870290776706493](https://jules.google.com/task/5757870290776706493) started by @n24q02m*