### PR TITLE
[TEST] Missing test for relay_setup _sanitize_error edge case

### DIFF
--- a/src/better_telegram_mcp/auth_server.py
+++ b/src/better_telegram_mcp/auth_server.py
@@ -159,6 +159,14 @@ _CAUSED_BY_RE = re.compile(r"\s*\(caused by \w+\)\s*$", re.IGNORECASE)
 
 _ERROR_SIMPLIFICATIONS: list[tuple[re.Pattern[str], str]] = [
     (
+        re.compile(r"PHONE_NUMBER_INVALID", re.IGNORECASE),
+        "Invalid phone number format",
+    ),
+    (
+        re.compile(r"PHONE_CODE_INVALID", re.IGNORECASE),
+        "Invalid verification code",
+    ),
+    (
         re.compile(r".*password.*required.*", re.IGNORECASE),
         "Two-factor authentication password is required.",
     ),

--- a/src/better_telegram_mcp/relay_setup.py
+++ b/src/better_telegram_mcp/relay_setup.py
@@ -36,6 +36,14 @@ ALL_POSSIBLE_FIELDS = [
 _CAUSED_BY_RE = re.compile(r"\s*\(caused by \w+\)\s*$", re.IGNORECASE)
 _ERROR_SIMPLIFICATIONS: list[tuple[re.Pattern[str], str]] = [
     (
+        re.compile(r"PHONE_NUMBER_INVALID", re.IGNORECASE),
+        "Invalid phone number format",
+    ),
+    (
+        re.compile(r"PHONE_CODE_INVALID", re.IGNORECASE),
+        "Invalid verification code",
+    ),
+    (
         re.compile(r".*password.*required.*", re.IGNORECASE),
         "Two-factor authentication password is required.",
     ),

--- a/tests/test_relay_setup.py
+++ b/tests/test_relay_setup.py
@@ -582,6 +582,12 @@ class TestSanitizeError:
     def test_passthrough_unknown_error(self):
         assert _sanitize_error("Some unknown error") == "Some unknown error"
 
+    def test_phone_number_invalid_exact(self):
+        assert _sanitize_error("PHONE_NUMBER_INVALID") == "Invalid phone number format"
+
+    def test_phone_code_invalid_exact(self):
+        assert _sanitize_error("PHONE_CODE_INVALID") == "Invalid verification code"
+
 
 # --- _needs_2fa_password ---
 

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "3.5.0b1"
+version = "3.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
This PR addresses the missing test coverage and implementation for specific error sanitization edge cases in `relay_setup.py` and `auth_server.py`.

Specifically, it adds:
- Mapping for `PHONE_NUMBER_INVALID` to "Invalid phone number format".
- Mapping for `PHONE_CODE_INVALID` to "Invalid verification code".
- Unit tests in `tests/test_relay_setup.py` to verify these mappings.

The changes ensure that raw Telegram error strings are properly simplified for the user during the relay setup and local auth flows.

---
*PR created automatically by Jules for task [3503283834488178549](https://jules.google.com/task/3503283834488178549) started by @n24q02m*