### PR TITLE
[TEST] Missing test for auth_server _find_free_port exception handling

### DIFF
--- a/src/better_telegram_mcp/auth_server.py
+++ b/src/better_telegram_mcp/auth_server.py
@@ -191,9 +191,14 @@ def _sanitize_error(msg: str) -> str:
 
 
 def _find_free_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]
+    """Find an available TCP port on localhost."""
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            s.bind(("127.0.0.1", 0))
+            return int(s.getsockname()[1])
+    except OSError as e:
+        raise RuntimeError("Could not find a free port") from e
 
 
 def _mask_phone(phone: str) -> str:

--- a/tests/test_auth_server.py
+++ b/tests/test_auth_server.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+from better_telegram_mcp.auth_server import _find_free_port
+
+
+def test_find_free_port_error(monkeypatch):
+    """Test that _find_free_port raises RuntimeError when socket.bind fails."""
+
+    class MockSocket:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+        def bind(self, addr):
+            raise OSError("mock bind error")
+
+        def setsockopt(self, *args, **kwargs):
+            pass
+
+        def getsockname(self):
+            return ("127.0.0.1", 0)
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(socket, "socket", MockSocket)
+
+    with pytest.raises(RuntimeError, match="Could not find a free port"):
+        _find_free_port()
+
+
+def test_find_free_port_success(monkeypatch):
+    """Test that _find_free_port returns the port number on success."""
+
+    class MockSocket:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+        def bind(self, addr):
+            pass
+
+        def setsockopt(self, *args, **kwargs):
+            pass
+
+        def getsockname(self):
+            return ("127.0.0.1", 8888)
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(socket, "socket", MockSocket)
+
+    assert _find_free_port() == 8888

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "3.5.0b1"
+version = "3.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
This PR adds test coverage for the `_find_free_port` function in `auth_server.py`, specifically targeting the case where a port cannot be bound.

### Changes:
- **`src/better_telegram_mcp/auth_server.py`**:
    - Updated `_find_free_port` to wrap socket binding in a `try...except OSError` block.
    - Now raises a `RuntimeError` when binding fails, as suggested in the task.
    - Added `socket.SO_REUSEADDR` to the socket options.
- **`tests/test_auth_server.py`**:
    - New test file with `test_find_free_port_error` (using `monkeypatch` to simulate `OSError`) and `test_find_free_port_success`.

### Verification:
- Ran `uv run pytest tests/test_auth_server.py` (2 passed).
- Ran full test suite `uv run pytest` (461 passed).
- Ran `uv run ruff check .` and `uv run ty check` (all passed).

---
*PR created automatically by Jules for task [8833329270402569128](https://jules.google.com/task/8833329270402569128) started by @n24q02m*