### PR TITLE
[TEST] Missing test for format err untested public function

### DIFF
--- a/tests/test_utils/test_formatting.py
+++ b/tests/test_utils/test_formatting.py
@@ -100,3 +100,30 @@ def test_safe_error_generic_exceptions():
 
         # Ensure internal details are NOT leaked
         assert str(exc) not in result
+
+
+def test_err_empty_message():
+    message = ""
+    result = err(message)
+    assert result == '{"error": ""}'
+
+    parsed = json.loads(result)
+    assert parsed["error"] == message
+
+
+def test_err_special_characters():
+    message = r"Quote: \", Backslash: \\, Newline: \n, Tab: \t"
+    result = err(message)
+
+    # json.dumps escapes quotes and backslashes
+    parsed = json.loads(result)
+    assert parsed["error"] == message
+
+
+def test_err_long_message():
+    message = "A" * 10000
+    result = err(message)
+
+    parsed = json.loads(result)
+    assert parsed["error"] == message
+    assert len(parsed["error"]) == 10000


### PR DESCRIPTION
Added comprehensive tests for the `err` function in `src/better_telegram_mcp/utils/formatting.py`.

Changes include:
- `test_err_empty_message`: Verifies that an empty error message is correctly serialized as `{"error": ""}`.
- `test_err_special_characters`: Confirms that special characters like quotes, backslashes, and newlines are properly escaped by `json.dumps`.
- `test_err_long_message`: Ensures that the function can handle large input strings without issue.

All tests passed, and code coverage for `src/better_telegram_mcp/utils/formatting.py` is now 100%. Verified that no regressions were introduced to the rest of the project.

---
*PR created automatically by Jules for task [3367206656363678560](https://jules.google.com/task/3367206656363678560) started by @n24q02m*