### PR TITLE
[SECURITY] Hardcoded Salt for PBKDF2HMAC

### DIFF
--- a/src/better_telegram_mcp/transports/credential_store.py
+++ b/src/better_telegram_mcp/transports/credential_store.py
@@ -15,7 +15,7 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 
-_SALT = b"mcp-telegram-creds"
+_LEGACY_SALT = b"mcp-telegram-creds"
 _KDF_ITERATIONS = 100_000
 _NONCE_SIZE = 12
 
@@ -29,11 +29,35 @@ class CredentialStore:
 
     def __init__(self, data_dir: Path, secret: str | None = None) -> None:
         self._path = data_dir / "credentials.enc"
+        self._salt_path = data_dir / ".salt"
         self._secret = secret or os.environ.get("CREDENTIAL_SECRET", "")
         if not self._secret:
             self._secret = self._resolve_or_generate_secret(data_dir)
+
+        self._salt = self._resolve_salt()
+
         # ⚡ Bolt: Cache derived key to avoid repeated 100k iteration PBKDF2 (~60ms) overhead
         self._cached_key: bytes | None = None
+
+    def _resolve_salt(self) -> bytes:
+        """Load persisted salt, fallback to legacy, or generate new one."""
+        if self._salt_path.exists():
+            return self._salt_path.read_bytes()
+
+        # Backward compatibility: if we have credentials but no salt file,
+        # we must be using the legacy salt.
+        if self._path.exists():
+            return _LEGACY_SALT
+
+        # New installation: generate random salt
+        salt = os.urandom(16)
+        self._salt_path.parent.mkdir(parents=True, exist_ok=True)
+        self._salt_path.write_bytes(salt)
+        try:
+            self._salt_path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0o600
+        except OSError:
+            pass
+        return salt
 
     @staticmethod
     def _resolve_or_generate_secret(data_dir: Path) -> str:
@@ -56,7 +80,7 @@ class CredentialStore:
         kdf = PBKDF2HMAC(
             algorithm=hashes.SHA256(),
             length=32,
-            salt=_SALT,
+            salt=self._salt,
             iterations=_KDF_ITERATIONS,
         )
         self._cached_key = kdf.derive(self._secret.encode())
@@ -65,6 +89,18 @@ class CredentialStore:
     def store(self, credentials: dict[str, str]) -> None:
         """Encrypt and save credentials."""
         self._path.parent.mkdir(parents=True, exist_ok=True)
+
+        # If we are still using the legacy salt, migrate to a new random one now
+        if self._salt == _LEGACY_SALT:
+            new_salt = os.urandom(16)
+            self._salt_path.write_bytes(new_salt)
+            try:
+                self._salt_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+            except OSError:
+                pass
+            self._salt = new_salt
+            self._cached_key = None  # Force re-derivation
+
         key = self._derive_key()
         aesgcm = AESGCM(key)
         nonce = os.urandom(_NONCE_SIZE)

--- a/tests/test_credential_store.py
+++ b/tests/test_credential_store.py
@@ -146,3 +146,65 @@ class TestCredentialStore:
         store = CredentialStore(tmp_path)
         # Store writing triggers credential chmod
         store.store({"api_id": "123"})
+
+    def test_random_salt_generation(self, data_dir: Path) -> None:
+        """New installation should generate a random salt file."""
+        store = CredentialStore(data_dir, secret="test-secret")
+        salt_path = data_dir / ".salt"
+        assert salt_path.exists()
+        salt = salt_path.read_bytes()
+        assert len(salt) == 16
+        assert store._salt == salt
+
+    def test_auto_generated_salt_persists(self, data_dir: Path) -> None:
+        """Salt should be saved and reused across instances."""
+        CredentialStore(data_dir)
+        salt = (data_dir / ".salt").read_bytes()
+
+        store2 = CredentialStore(data_dir)
+        assert store2._salt == salt
+
+    def test_legacy_salt_migration(self, data_dir: Path) -> None:
+        """Should load legacy data and migrate to new salt on store."""
+        import json
+        import os
+
+        from cryptography.hazmat.primitives import hashes
+        from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+        from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+
+        secret = "legacy-secret"
+        legacy_salt = b"mcp-telegram-creds"
+        creds = {"token": "legacy-token"}
+
+        # 1. Manually create legacy encrypted file
+        kdf = PBKDF2HMAC(
+            algorithm=hashes.SHA256(),
+            length=32,
+            salt=legacy_salt,
+            iterations=100_000,
+        )
+        key = kdf.derive(secret.encode())
+        aesgcm = AESGCM(key)
+        nonce = os.urandom(12)
+        ciphertext = aesgcm.encrypt(nonce, json.dumps(creds).encode(), None)
+        (data_dir / "credentials.enc").write_bytes(nonce + ciphertext)
+
+        # 2. Load with CredentialStore (should fallback to legacy salt)
+        store = CredentialStore(data_dir, secret=secret)
+        assert store._salt == legacy_salt
+        assert store.load() == creds
+        assert not (data_dir / ".salt").exists()
+
+        # 3. Store new data (should trigger migration)
+        new_creds = {"token": "new-token"}
+        store.store(new_creds)
+
+        assert (data_dir / ".salt").exists()
+        assert store._salt != legacy_salt
+        assert store.load() == new_creds
+
+        # 4. Verify new instances use the new salt
+        store2 = CredentialStore(data_dir, secret=secret)
+        assert store2._salt == store._salt
+        assert store2.load() == new_creds

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "3.5.0b1"
+version = "3.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
🎯 What:
Replaced the hardcoded salt `b"mcp-telegram-creds"` in `CredentialStore` with a randomly generated, per-installation 16-byte salt stored in a `.salt` file within the data directory.

⚠️ Risk:
Using a static salt for all installations makes derived keys more susceptible to pre-computation attacks. A unique, random salt ensures that identical secrets result in different derived keys across different installations.

🛡️ Solution:
- Added `_resolve_salt` to `CredentialStore` to load, fallback to legacy, or generate a new salt.
- Updated `_derive_key` to use the instance-specific salt.
- Implemented an automatic migration path in `store()`: if the legacy salt is detected, it generates a new random salt and re-encrypts the credentials.

Verification:
- Added `test_random_salt_generation` to verify new installs get a random salt.
- Added `test_auto_generated_salt_persists` to ensure the salt is reused.
- Added `test_legacy_salt_migration` to verify that existing data can be read and is transparently migrated to a secure salt on the next write.
- All 15 tests in `tests/test_credential_store.py` passed.
- Full test suite (506 tests) passed.

---
*PR created automatically by Jules for task [12342208087825525850](https://jules.google.com/task/12342208087825525850) started by @n24q02m*