### PR TITLE
[FIX] Missing Rate Limiting on Local Auth Server

### DIFF
--- a/src/better_telegram_mcp/auth_server.py
+++ b/src/better_telegram_mcp/auth_server.py
@@ -11,6 +11,8 @@ import asyncio
 import html
 import re
 import socket
+import time
+from collections import defaultdict
 from typing import TYPE_CHECKING
 
 from loguru import logger
@@ -209,10 +211,34 @@ class AuthServer:
         self._backend = backend
         self._settings = settings
         self._auth_complete = asyncio.Event()
+
         self._auth_name: str = ""
         self._uvicorn_server: object | None = None
+        self._rate_limits: dict[str, list[float]] = defaultdict(list)
         self.port: int = 0
         self.url: str = ""
+
+    def _get_client_ip(self, request: Request) -> str:
+        """Safely extract client IP, respecting reverse proxies if headers are present."""
+        # Sentinel: Prioritize cf-connecting-ip then x-forwarded-for to prevent spoofing
+        if "cf-connecting-ip" in request.headers:
+            return request.headers["cf-connecting-ip"]
+        if "x-forwarded-for" in request.headers:
+            return request.headers["x-forwarded-for"].split(",")[0].strip()
+        return request.client.host if request.client else "unknown"
+
+    def _check_rate_limit(self, ip: str, limit: int = 5, window: int = 60) -> bool:
+        """Check if IP is within rate limit. Returns True if allowed."""
+        now = time.time()
+        window_start = now - window
+        timestamps = self._rate_limits[ip]
+
+        # Prune old entries
+        self._rate_limits[ip] = [t for t in timestamps if t > window_start]
+        if len(self._rate_limits[ip]) >= limit:
+            return False
+        self._rate_limits[ip].append(now)
+        return True
 
     def _make_app(self) -> Starlette:
         async def index(request: Request) -> HTMLResponse:
@@ -232,6 +258,15 @@ class AuthServer:
             return JSONResponse(data)
 
         async def send_code(request: Request) -> JSONResponse:
+            ip = self._get_client_ip(request)
+            if not self._check_rate_limit(f"send_code:{ip}"):
+                return JSONResponse(
+                    {
+                        "ok": False,
+                        "error": "Too many attempts. Please try again later.",
+                    },
+                    status_code=429,
+                )
             phone = self._settings.phone
             if not phone:
                 return JSONResponse(
@@ -244,6 +279,15 @@ class AuthServer:
                 return JSONResponse({"ok": False, "error": _sanitize_error(str(e))})
 
         async def verify(request: Request) -> JSONResponse:
+            ip = self._get_client_ip(request)
+            if not self._check_rate_limit(f"verify:{ip}"):
+                return JSONResponse(
+                    {
+                        "ok": False,
+                        "error": "Too many attempts. Please try again later.",
+                    },
+                    status_code=429,
+                )
             try:
                 body = await request.json()
             except Exception:

--- a/tests/test_auth_server.py
+++ b/tests/test_auth_server.py
@@ -1,0 +1,52 @@
+import pytest
+from starlette.testclient import TestClient
+from unittest.mock import AsyncMock, MagicMock
+from better_telegram_mcp.auth_server import AuthServer
+
+@pytest.fixture
+def mock_backend():
+    backend = AsyncMock()
+    backend.is_authorized.return_value = False
+    backend.sign_in.return_value = {"authenticated_as": "Test User"}
+    backend.send_code.return_value = None
+    return backend
+
+@pytest.fixture
+def mock_settings():
+    settings = MagicMock()
+    settings.phone = "+1234567890"
+    return settings
+
+def test_verify_rate_limiting(mock_backend, mock_settings):
+    server = AuthServer(mock_backend, mock_settings)
+    app = server._make_app()
+    client = TestClient(app)
+
+    # First 5 attempts should succeed
+    for _ in range(5):
+        response = client.post("/verify", json={"code": "12345"})
+        assert response.status_code == 200
+        assert response.json()["ok"] is True
+
+    # 6th attempt should be rate limited
+    response = client.post("/verify", json={"code": "12345"})
+    assert response.status_code == 429
+    assert response.json()["ok"] is False
+    assert "Too many attempts" in response.json()["error"]
+
+def test_send_code_rate_limiting(mock_backend, mock_settings):
+    server = AuthServer(mock_backend, mock_settings)
+    app = server._make_app()
+    client = TestClient(app)
+
+    # First 5 attempts should succeed
+    for _ in range(5):
+        response = client.post("/send-code")
+        assert response.status_code == 200
+        assert response.json()["ok"] is True
+
+    # 6th attempt should be rate limited
+    response = client.post("/send-code")
+    assert response.status_code == 429
+    assert response.json()["ok"] is False
+    assert "Too many attempts" in response.json()["error"]

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "3.5.0b1"
+version = "3.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
This PR implements rate limiting for the `/send-code` and `/verify` endpoints of the local authentication server. It uses an in-memory sliding window (5 requests per 60 seconds) and respects reverse proxy headers (`cf-connecting-ip` and `x-forwarded-for`) for accurate client identification.

- Added `_rate_limits` state to `AuthServer`.
- Implemented `_get_client_ip` and `_check_rate_limit`.
- Updated endpoints to return `429 Too Many Requests` on breach.
- Added comprehensive unit tests.

---
*PR created automatically by Jules for task [12082427722139970183](https://jules.google.com/task/12082427722139970183) started by @n24q02m*