### PR TITLE
[FIX] Missing Rate Limiting on Local Auth Server

### DIFF
--- a/src/better_telegram_mcp/auth_server.py
+++ b/src/better_telegram_mcp/auth_server.py
@@ -11,6 +11,7 @@ import asyncio
 import html
 import re
 import socket
+import time
 from typing import TYPE_CHECKING
 
 from loguru import logger
@@ -205,6 +206,10 @@ def _mask_phone(phone: str) -> str:
 class AuthServer:
     """Local web server for OTP authentication (TELEGRAM_AUTH_URL=local)."""
 
+    # Rate limiting constants
+    MAX_VERIFY_ATTEMPTS = 5
+    VERIFY_COOLDOWN_SECONDS = 60
+
     def __init__(self, backend: TelegramBackend, settings: Settings):
         self._backend = backend
         self._settings = settings
@@ -213,6 +218,8 @@ class AuthServer:
         self._uvicorn_server: object | None = None
         self.port: int = 0
         self.url: str = ""
+        self._verify_attempts: int = 0
+        self._last_verify_time: float = 0.0
 
     def _make_app(self) -> Starlette:
         async def index(request: Request) -> HTMLResponse:
@@ -244,6 +251,27 @@ class AuthServer:
                 return JSONResponse({"ok": False, "error": _sanitize_error(str(e))})
 
         async def verify(request: Request) -> JSONResponse:
+            # Check rate limit
+            now = time.time()
+            if (
+                self._verify_attempts >= self.MAX_VERIFY_ATTEMPTS
+                and (now - self._last_verify_time) < self.VERIFY_COOLDOWN_SECONDS
+            ):
+                wait_time = int(
+                    self.VERIFY_COOLDOWN_SECONDS - (now - self._last_verify_time)
+                )
+                return JSONResponse(
+                    {
+                        "ok": False,
+                        "error": f"Too many attempts. Please wait {wait_time} seconds.",
+                    },
+                    status_code=429,
+                )
+
+            # Reset attempts if cooldown has passed
+            if (now - self._last_verify_time) >= self.VERIFY_COOLDOWN_SECONDS:
+                self._verify_attempts = 0
+
             try:
                 body = await request.json()
             except Exception:
@@ -261,8 +289,12 @@ class AuthServer:
                 result = await self._backend.sign_in(phone, code, password=password)
                 self._auth_name = result.get("authenticated_as", "User")
                 self._auth_complete.set()
+                self._verify_attempts = 0  # Reset on success
                 return JSONResponse({"ok": True, "name": self._auth_name})
             except Exception as e:
+                self._verify_attempts += 1
+                self._last_verify_time = time.time()
+
                 error_msg = str(e)
                 needs_password = any(
                     kw in error_msg.lower()

--- a/tests/test_auth_server_rate_limit.py
+++ b/tests/test_auth_server_rate_limit.py
@@ -1,0 +1,72 @@
+import pytest
+import time
+from starlette.testclient import TestClient
+from unittest.mock import AsyncMock, MagicMock
+from better_telegram_mcp.auth_server import AuthServer
+from better_telegram_mcp.config import Settings
+
+@pytest.fixture
+def mock_backend():
+    backend = MagicMock()
+    backend.is_authorized = AsyncMock(return_value=False)
+    backend.send_code = AsyncMock()
+    backend.sign_in = AsyncMock(side_effect=Exception("Invalid code"))
+    return backend
+
+@pytest.fixture
+def settings():
+    s = Settings()
+    s.phone = "+1234567890"
+    return s
+
+def test_verify_rate_limit(mock_backend, settings):
+    server = AuthServer(mock_backend, settings)
+    # Speed up cooldown for testing
+    server.MAX_VERIFY_ATTEMPTS = 3
+    server.VERIFY_COOLDOWN_SECONDS = 2
+
+    app = server._make_app()
+    client = TestClient(app)
+
+    # First 3 attempts should fail with "Invalid OTP code"
+    for _ in range(3):
+        response = client.post("/verify", json={"code": "12345"})
+        assert response.status_code == 200
+        assert response.json()["ok"] is False
+        assert "Invalid OTP code" in response.json()["error"]
+
+    # 4th attempt should be rate limited (429)
+    response = client.post("/verify", json={"code": "12345"})
+    assert response.status_code == 429
+    assert "Too many attempts" in response.json()["error"]
+
+    # Wait for cooldown
+    time.sleep(2.1)
+
+    # After cooldown, should be able to try again
+    response = client.post("/verify", json={"code": "12345"})
+    assert response.status_code == 200
+    assert response.json()["ok"] is False
+    assert "Invalid OTP code" in response.json()["error"]
+
+def test_verify_reset_on_success(mock_backend, settings):
+    server = AuthServer(mock_backend, settings)
+    server.MAX_VERIFY_ATTEMPTS = 3
+
+    app = server._make_app()
+    client = TestClient(app)
+
+    # 2 failures
+    for _ in range(2):
+        client.post("/verify", json={"code": "wrong"})
+
+    assert server._verify_attempts == 2
+
+    # 1 success
+    mock_backend.sign_in = AsyncMock(return_value={"authenticated_as": "User"})
+    response = client.post("/verify", json={"code": "correct"})
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+
+    # Reset to 0
+    assert server._verify_attempts == 0

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "3.5.0b1"
+version = "3.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
🔐 [FIX] Missing Rate Limiting on Local Auth Server

🎯 What:
Added in-memory rate limiting to the `/verify` endpoint in the local authentication server.

⚠️ Risk:
Unauthorized users could brute-force OTP codes or 2FA passwords if no rate limiting was present.

🛡️ Solution:
Implemented a simple rate limiter in `AuthServer` that tracks failed verification attempts.
- Maximum attempts: 5
- Cooldown period: 60 seconds
- Returns HTTP 429 (Too Many Requests) when limits are exceeded.
- Resets attempt counter on successful sign-in.

Verified with new unit tests in `tests/test_auth_server_rate_limit.py`.

---
*PR created automatically by Jules for task [369538241304671729](https://jules.google.com/task/369538241304671729) started by @n24q02m*