### PR TITLE
🔒 Fix insecure bind to 0.0.0.0 in multi-user HTTP transport

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,8 @@ ENV PATH="/app/.venv/bin:$PATH" \
     PYTHONPATH=/app/src \
     PYTHONUNBUFFERED=1 \
     TELEGRAM_DATA_DIR=/data \
-    TRANSPORT_MODE=stdio
+    TRANSPORT_MODE=stdio \
+    HOST=0.0.0.0
 
 EXPOSE 8080
 

--- a/src/better_telegram_mcp/transports/http.py
+++ b/src/better_telegram_mcp/transports/http.py
@@ -151,4 +151,6 @@ def _start_multi_user_http(settings: Settings) -> None:
     logger.info("Starting multi-user HTTP server on port {}", port)
     logger.info("Public URL: {}", public_url)
 
-    uvicorn.run(app, host="0.0.0.0", port=port, log_level="info")
+    # 🛡️ Sentinel: Default to 127.0.0.1 for safety, override via HOST env var (e.g. for Docker)
+    host = os.environ.get("HOST", "127.0.0.1")
+    uvicorn.run(app, host=host, port=port, log_level="info")

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "3.5.0b1"
+version = "3.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
🎯 What
Fixed insecure server binding (0.0.0.0) in the multi-user HTTP transport. The binding is now configurable via the `HOST` environment variable, defaulting to `127.0.0.1` for local safety.

⚠️ Risk
Hardcoded `0.0.0.0` binding could expose the relay server to external networks, potentially allowing unauthorized access to MCP endpoints.

🛡️ Solution
- Replaced hardcoded `host="0.0.0.0"` in `src/better_telegram_mcp/transports/http.py` with `os.environ.get("HOST", "127.0.0.1")`.
- Added `ENV HOST=0.0.0.0` to the `Dockerfile` to ensure the application remains reachable within containerized deployments while being secure by default in local development.
- Verified changes with `uv run ruff check` and the full test suite (`uv run pytest`).

Note: The vulnerability mentioned in `auth-relay/server.py` was found and addressed in `src/better_telegram_mcp/transports/http.py`, as the former directory appears to have been integrated into the main package.

---
*PR created automatically by Jules for task [9658331323048570719](https://jules.google.com/task/9658331323048570719) started by @n24q02m*