### PR TITLE
[TEST] Missing test for auth_server start exception handling

### DIFF
--- a/src/better_telegram_mcp/auth_server.py
+++ b/src/better_telegram_mcp/auth_server.py
@@ -287,19 +287,23 @@ class AuthServer:
         """Start the auth server. Returns the URL."""
         import uvicorn
 
-        self.port = _find_free_port()
-        self.url = f"http://127.0.0.1:{self.port}"
+        port = _find_free_port()
+        self.port = port
+        self.url = f"http://127.0.0.1:{port}"
 
-        app = self._make_app()
-        config = uvicorn.Config(
-            app, host="127.0.0.1", port=self.port, log_level="warning"
-        )
-        server = uvicorn.Server(config)
-        asyncio.create_task(server.serve())
-        self._uvicorn_server = server
-        await asyncio.sleep(0.3)
-        logger.info("Auth server started at {}", self.url)
-        return self.url
+        try:
+            app = self._make_app()
+            config = uvicorn.Config(
+                app, host="127.0.0.1", port=port, log_level="warning"
+            )
+            server = uvicorn.Server(config)
+            asyncio.create_task(server.serve())
+            self._uvicorn_server = server
+            await asyncio.sleep(0.3)
+            logger.info("Auth server started at {}", self.url)
+            return self.url
+        except OSError as e:
+            raise RuntimeError(f"Could not start server on port {port}: {e}") from e
 
     async def wait_for_auth(self) -> None:
         """Block until authentication is complete."""

--- a/tests/test_auth_server.py
+++ b/tests/test_auth_server.py
@@ -1,0 +1,77 @@
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from better_telegram_mcp.auth_server import AuthServer
+from better_telegram_mcp.config import Settings
+
+
+@pytest.fixture
+def settings():
+    return Settings(api_id=123, api_hash="abc", phone="+1234567890")
+
+
+@pytest.fixture
+def auth_server(mock_backend, settings):
+    return AuthServer(mock_backend, settings)
+
+
+async def test_auth_server_start_success(auth_server):
+    """Test successful server start."""
+    with patch("uvicorn.Server") as mock_server_cls:
+        mock_server = mock_server_cls.return_value
+
+        # Make serve return a coroutine
+        async def mock_serve():
+            pass
+
+        mock_server.serve.side_effect = mock_serve
+
+        url = await auth_server.start()
+
+        assert auth_server.port > 0
+        assert url == f"http://127.0.0.1:{auth_server.port}"
+        assert auth_server._uvicorn_server == mock_server
+        mock_server.serve.assert_called_once()
+
+        # Cleanup
+        await auth_server.stop()
+        assert auth_server._uvicorn_server is None
+
+
+async def test_auth_server_start_oserror(auth_server, monkeypatch):
+    """Test server start failure due to OSError (e.g. port busy)."""
+
+    def mock_find_free_port():
+        return 80
+
+    monkeypatch.setattr(
+        "better_telegram_mcp.auth_server._find_free_port", mock_find_free_port
+    )
+
+    with patch("uvicorn.Server") as mock_server_cls:
+        # Mock Server creation to raise OSError
+        mock_server_cls.side_effect = OSError("Address already in use")
+
+        with pytest.raises(RuntimeError) as excinfo:
+            await auth_server.start()
+
+        assert "Could not start server on port 80" in str(excinfo.value)
+        assert "Address already in use" in str(excinfo.value)
+
+
+async def test_auth_server_stop_no_server(auth_server):
+    """Test stopping when no server is running."""
+    await auth_server.stop()
+    assert auth_server._uvicorn_server is None
+
+
+async def test_auth_server_wait_for_auth(auth_server):
+    """Test wait_for_auth event."""
+    wait_task = asyncio.create_task(auth_server.wait_for_auth())
+    assert not wait_task.done()
+
+    auth_server._auth_complete.set()
+    await asyncio.sleep(0.1)
+    assert wait_task.done()

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "3.5.0b1"
+version = "3.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
This PR adds missing exception handling and tests for the `AuthServer.start` method in `src/better_telegram_mcp/auth_server.py`.

### Changes
- **`src/better_telegram_mcp/auth_server.py`**:
    - Introduced a local `port` variable in the `start()` method.
    - Wrapped the server initialization and startup in a `try...except OSError` block.
    - Raised a `RuntimeError` with a descriptive message (e.g., "Could not start server on port {port}: {e}") if an `OSError` occurs during startup (e.g., port already in use).
- **`tests/test_auth_server.py`**:
    - Created a new test suite to verify the `AuthServer` class.
    - Added `test_auth_server_start_success` to verify successful server startup.
    - Added `test_auth_server_start_oserror` to verify that `OSError` is correctly caught and re-raised as `RuntimeError`.
    - Added tests for `stop()` and `wait_for_auth()` methods.

### Verification
- Ran the new tests using `uv run pytest tests/test_auth_server.py`.
- Verified linting and formatting with `ruff`.
- Ran the full test suite (`uv run pytest -m "not integration"`) to ensure no regressions.
- Verified type safety with `uv run ty check`.

---
*PR created automatically by Jules for task [6355951468314538703](https://jules.google.com/task/6355951468314538703) started by @n24q02m*