### PR TITLE
[PERF] Synchronous file read in async path

### DIFF
--- a/src/better_telegram_mcp/auth/per_user_session_store.py
+++ b/src/better_telegram_mcp/auth/per_user_session_store.py
@@ -7,6 +7,7 @@ Reuses the key derivation pattern from transports/credential_store.py.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import stat
@@ -98,51 +99,51 @@ class PerUserSessionStore:
         aesgcm = AESGCM(key)
         return aesgcm.decrypt(nonce, ciphertext, None)
 
-    def _read_all(self) -> dict[str, dict]:
+    async def _read_all(self) -> dict[str, dict]:
         """Read and decrypt all sessions from disk."""
-        if not self._path.exists():
+        if not await asyncio.to_thread(self._path.exists):
             return {}
-        raw = self._path.read_bytes()
+        raw = await asyncio.to_thread(self._path.read_bytes)
         plaintext = self._decrypt(raw)
         return json.loads(plaintext)
 
-    def _write_all(self, sessions: dict[str, dict]) -> None:
+    async def _write_all(self, sessions: dict[str, dict]) -> None:
         """Encrypt and write all sessions to disk."""
-        self._path.parent.mkdir(parents=True, exist_ok=True)
+        await asyncio.to_thread(self._path.parent.mkdir, parents=True, exist_ok=True)
         plaintext = json.dumps(sessions).encode()
         encrypted = self._encrypt(plaintext)
-        self._path.write_bytes(encrypted)
+        await asyncio.to_thread(self._path.write_bytes, encrypted)
         try:
-            self._path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+            await asyncio.to_thread(self._path.chmod, stat.S_IRUSR | stat.S_IWUSR)
         except OSError:
             pass
 
-    def store(self, bearer: str, info: SessionInfo) -> None:
+    async def store(self, bearer: str, info: SessionInfo) -> None:
         """Store a session for the given bearer token."""
-        sessions = self._read_all()
+        sessions = await self._read_all()
         sessions[bearer] = info.to_dict()
-        self._write_all(sessions)
+        await self._write_all(sessions)
 
-    def load(self, bearer: str) -> SessionInfo | None:
+    async def load(self, bearer: str) -> SessionInfo | None:
         """Load session info for a bearer token. Returns None if not found."""
-        sessions = self._read_all()
+        sessions = await self._read_all()
         data = sessions.get(bearer)
         if data is None:
             return None
         return SessionInfo.from_dict(data)
 
-    def load_all(self) -> dict[str, SessionInfo]:
+    async def load_all(self) -> dict[str, SessionInfo]:
         """Load all stored sessions."""
-        sessions = self._read_all()
+        sessions = await self._read_all()
         return {
             bearer: SessionInfo.from_dict(data) for bearer, data in sessions.items()
         }
 
-    def delete(self, bearer: str) -> bool:
+    async def delete(self, bearer: str) -> bool:
         """Delete a session. Returns True if it existed."""
-        sessions = self._read_all()
+        sessions = await self._read_all()
         if bearer not in sessions:
             return False
         del sessions[bearer]
-        self._write_all(sessions)
+        await self._write_all(sessions)
         return True

--- a/src/better_telegram_mcp/auth/telegram_auth_provider.py
+++ b/src/better_telegram_mcp/auth/telegram_auth_provider.py
@@ -67,7 +67,7 @@ class TelegramAuthProvider:
         """
         import asyncio
 
-        sessions = self._store.load_all()
+        sessions = await self._store.load_all()
         now = time.time()
 
         # ⚡ Bolt: Initialize Telegram backends concurrently instead of sequentially
@@ -80,7 +80,7 @@ class TelegramAuthProvider:
                     "Session {} expired, removing",
                     info.session_name[:8],
                 )
-                self._store.delete(bearer)
+                await self._store.delete(bearer)
                 return False
 
             try:
@@ -97,7 +97,7 @@ class TelegramAuthProvider:
                     "Failed to restore session {}, removing",
                     info.session_name[:8],
                 )
-                self._store.delete(bearer)
+                await self._store.delete(bearer)
                 return False
 
         if not sessions:
@@ -164,7 +164,7 @@ class TelegramAuthProvider:
             bot_token=bot_token,
         )
 
-        self._store.store(bearer, info)
+        await self._store.store(bearer, info)
         self.active_clients[bearer] = backend
         logger.info("Registered bot session: {}", session_name[:8])
         return bearer
@@ -272,7 +272,7 @@ class TelegramAuthProvider:
             phone=phone,
         )
 
-        self._store.store(bearer, info)
+        await self._store.store(bearer, info)
         self.active_clients[bearer] = backend
         logger.info("Registered user session: {}", pending["session_name"][:8])
         return result
@@ -296,11 +296,11 @@ class TelegramAuthProvider:
         for sid in to_remove:
             del self.session_owners[sid]
 
-        return self._store.delete(bearer)
+        return await self._store.delete(bearer)
 
     async def cleanup_expired(self) -> int:
         """Remove expired sessions. Returns count of removed sessions."""
-        sessions = self._store.load_all()
+        sessions = await self._store.load_all()
         removed = 0
         now = time.time()
 

--- a/src/better_telegram_mcp/transports/credential_store.py
+++ b/src/better_telegram_mcp/transports/credential_store.py
@@ -6,6 +6,7 @@ Key derived from server secret (CREDENTIAL_SECRET env var or auto-generated).
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import stat
@@ -62,32 +63,34 @@ class CredentialStore:
         self._cached_key = kdf.derive(self._secret.encode())
         return self._cached_key
 
-    def store(self, credentials: dict[str, str]) -> None:
+    async def store(self, credentials: dict[str, str]) -> None:
         """Encrypt and save credentials."""
-        self._path.parent.mkdir(parents=True, exist_ok=True)
+        await asyncio.to_thread(self._path.parent.mkdir, parents=True, exist_ok=True)
         key = self._derive_key()
         aesgcm = AESGCM(key)
         nonce = os.urandom(_NONCE_SIZE)
         plaintext = json.dumps(credentials).encode()
         ciphertext = aesgcm.encrypt(nonce, plaintext, None)
-        self._path.write_bytes(nonce + ciphertext)
+        await asyncio.to_thread(self._path.write_bytes, nonce + ciphertext)
         try:
-            self._path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0o600
+            await asyncio.to_thread(
+                self._path.chmod, stat.S_IRUSR | stat.S_IWUSR
+            )  # 0o600
         except OSError:
             pass  # Windows may not support chmod
 
-    def load(self) -> dict[str, str] | None:
+    async def load(self) -> dict[str, str] | None:
         """Load and decrypt credentials. Returns None if not found."""
-        if not self._path.exists():
+        if not await asyncio.to_thread(self._path.exists):
             return None
         key = self._derive_key()
-        data = self._path.read_bytes()
+        data = await asyncio.to_thread(self._path.read_bytes)
         nonce, ciphertext = data[:_NONCE_SIZE], data[_NONCE_SIZE:]
         aesgcm = AESGCM(key)
         plaintext = aesgcm.decrypt(nonce, ciphertext, None)
         return json.loads(plaintext)
 
-    def delete(self) -> None:
+    async def delete(self) -> None:
         """Delete stored credentials."""
-        if self._path.exists():
-            self._path.unlink()
+        if await asyncio.to_thread(self._path.exists):
+            await asyncio.to_thread(self._path.unlink)

--- a/src/better_telegram_mcp/transports/http.py
+++ b/src/better_telegram_mcp/transports/http.py
@@ -44,7 +44,7 @@ async def setup_credentials(settings: Settings) -> dict[str, str]:
         RuntimeError: If relay setup fails or times out.
     """
     store = CredentialStore(settings.data_dir)
-    creds = store.load()
+    creds = await store.load()
 
     if creds is not None:
         logger.info("Loaded stored credentials from {}", settings.data_dir)
@@ -75,7 +75,7 @@ async def setup_credentials(settings: Settings) -> dict[str, str]:
         msg = "Relay setup timed out or session expired"
         raise RuntimeError(msg) from exc
 
-    store.store(creds)
+    await store.store(creds)
     logger.info("Credentials stored successfully")
     return creds
 
@@ -114,7 +114,7 @@ def _start_single_user_http(settings: Settings) -> None:
     # If env vars already have credentials, skip CredentialStore/relay
     if not settings.is_configured:
         store = CredentialStore(settings.data_dir)
-        creds = store.load()
+        creds = asyncio.run(store.load())
 
         if creds is None:
             creds = asyncio.run(setup_credentials(settings))

--- a/tests/test_credential_store.py
+++ b/tests/test_credential_store.py
@@ -18,29 +18,29 @@ def data_dir(tmp_path: Path) -> Path:
 
 
 class TestCredentialStore:
-    def test_store_load_roundtrip(self, data_dir: Path) -> None:
+    async def test_store_load_roundtrip(self, data_dir: Path) -> None:
         """Credentials can be stored and loaded back correctly."""
         store = CredentialStore(data_dir, secret="test-secret")
         creds = {
             "TELEGRAM_BOT_TOKEN": "123456:ABC-DEF",
             "TELEGRAM_API_ID": "12345",
         }
-        store.store(creds)
-        loaded = store.load()
+        await store.store(creds)
+        loaded = await store.load()
         assert loaded == creds
 
-    def test_load_returns_none_when_no_file(self, data_dir: Path) -> None:
+    async def test_load_returns_none_when_no_file(self, data_dir: Path) -> None:
         """Loading from empty store returns None."""
         store = CredentialStore(data_dir, secret="test-secret")
-        assert store.load() is None
+        assert await store.load() is None
 
-    def test_different_secrets_produce_different_encryption(
+    async def test_different_secrets_produce_different_encryption(
         self, data_dir: Path
     ) -> None:
         """Different secrets should not decrypt each other's data."""
         store1 = CredentialStore(data_dir, secret="secret-one")
         creds = {"TELEGRAM_BOT_TOKEN": "token123"}
-        store1.store(creds)
+        await store1.store(creds)
 
         # Read raw encrypted bytes
         enc_path = data_dir / "credentials.enc"
@@ -49,43 +49,43 @@ class TestCredentialStore:
         # Try to decrypt with different secret -- should fail
         store2 = CredentialStore(data_dir, secret="secret-two")
         with pytest.raises(InvalidTag):
-            store2.load()
+            await store2.load()
 
         # Original secret still works
         store1_again = CredentialStore(data_dir, secret="secret-one")
-        assert store1_again.load() == creds
+        assert await store1_again.load() == creds
 
         # Verify the encrypted file is still the same (not corrupted by failed load)
         assert enc_path.read_bytes() == encrypted_data
 
-    def test_delete_removes_file(self, data_dir: Path) -> None:
+    async def test_delete_removes_file(self, data_dir: Path) -> None:
         """Delete should remove the credentials file."""
         store = CredentialStore(data_dir, secret="test-secret")
         creds = {"TELEGRAM_BOT_TOKEN": "token123"}
-        store.store(creds)
+        await store.store(creds)
 
         enc_path = data_dir / "credentials.enc"
         assert enc_path.exists()
 
-        store.delete()
+        await store.delete()
         assert not enc_path.exists()
 
-    def test_delete_noop_when_no_file(self, data_dir: Path) -> None:
+    async def test_delete_noop_when_no_file(self, data_dir: Path) -> None:
         """Delete should not raise when no file exists."""
         store = CredentialStore(data_dir, secret="test-secret")
-        store.delete()  # Should not raise
+        await store.delete()  # Should not raise
 
-    def test_auto_generated_secret_persists(self, data_dir: Path) -> None:
+    async def test_auto_generated_secret_persists(self, data_dir: Path) -> None:
         """Auto-generated secret should be saved and reused across instances."""
         store1 = CredentialStore(data_dir)
         creds = {"TELEGRAM_BOT_TOKEN": "token123"}
-        store1.store(creds)
+        await store1.store(creds)
 
         # New instance should auto-load the persisted secret
         store2 = CredentialStore(data_dir)
-        assert store2.load() == creds
+        assert await store2.load() == creds
 
-    def test_auto_generated_secret_file_created(self, data_dir: Path) -> None:
+    async def test_auto_generated_secret_file_created(self, data_dir: Path) -> None:
         """Secret file should be created when no secret is provided."""
         CredentialStore(data_dir)
         secret_path = data_dir / ".secret"
@@ -93,47 +93,47 @@ class TestCredentialStore:
         secret = secret_path.read_text().strip()
         assert len(secret) == 64  # 32 bytes hex-encoded
 
-    def test_env_var_secret_takes_precedence(
+    async def test_env_var_secret_takes_precedence(
         self, data_dir: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """CREDENTIAL_SECRET env var should be used when set."""
         monkeypatch.setenv("CREDENTIAL_SECRET", "env-secret")
         store = CredentialStore(data_dir)
         creds = {"TELEGRAM_BOT_TOKEN": "token123"}
-        store.store(creds)
+        await store.store(creds)
 
         # Should load with same env var
         store2 = CredentialStore(data_dir)
-        assert store2.load() == creds
+        assert await store2.load() == creds
 
         # Should not load without env var (different auto-generated secret)
         monkeypatch.delenv("CREDENTIAL_SECRET")
         store3 = CredentialStore(data_dir)
         # Auto-generated secret is different from "env-secret"
         with pytest.raises(InvalidTag):
-            store3.load()
+            await store3.load()
 
-    def test_store_overwrites_existing(self, data_dir: Path) -> None:
+    async def test_store_overwrites_existing(self, data_dir: Path) -> None:
         """Storing new credentials should overwrite old ones."""
         store = CredentialStore(data_dir, secret="test-secret")
-        store.store({"TELEGRAM_BOT_TOKEN": "old-token"})
-        store.store({"TELEGRAM_BOT_TOKEN": "new-token"})
-        assert store.load() == {"TELEGRAM_BOT_TOKEN": "new-token"}
+        await store.store({"TELEGRAM_BOT_TOKEN": "old-token"})
+        await store.store({"TELEGRAM_BOT_TOKEN": "new-token"})
+        assert await store.load() == {"TELEGRAM_BOT_TOKEN": "new-token"}
 
-    def test_empty_credentials(self, data_dir: Path) -> None:
+    async def test_empty_credentials(self, data_dir: Path) -> None:
         """Empty dict should be storable and loadable."""
         store = CredentialStore(data_dir, secret="test-secret")
-        store.store({})
-        assert store.load() == {}
+        await store.store({})
+        assert await store.load() == {}
 
-    def test_data_dir_created_if_missing(self, tmp_path: Path) -> None:
+    async def test_data_dir_created_if_missing(self, tmp_path: Path) -> None:
         """Store should create data_dir if it does not exist."""
         nested = tmp_path / "a" / "b" / "c"
         store = CredentialStore(nested, secret="test-secret")
-        store.store({"key": "value"})
-        assert store.load() == {"key": "value"}
+        await store.store({"key": "value"})
+        assert await store.load() == {"key": "value"}
 
-    def test_chmod_failure_swallowed(
+    async def test_chmod_failure_swallowed(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         """Test that OSError during chmod is silently ignored."""
@@ -145,4 +145,4 @@ class TestCredentialStore:
 
         store = CredentialStore(tmp_path)
         # Store writing triggers credential chmod
-        store.store({"api_id": "123"})
+        await store.store({"api_id": "123"})

--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -31,7 +31,7 @@ class TestSetupCredentials:
         """Should return stored credentials without hitting relay."""
         store = CredentialStore(data_dir, secret="test")
         expected = {"TELEGRAM_BOT_TOKEN": "stored-token"}
-        store.store(expected)
+        await store.store(expected)
 
         # Patch env so CredentialStore inside setup_credentials uses same secret
         with patch.dict("os.environ", {"CREDENTIAL_SECRET": "test"}):
@@ -118,7 +118,7 @@ class TestSetupCredentials:
 
         # Verify credentials were persisted
         store = CredentialStore(data_dir)
-        assert store.load() == expected_creds
+        assert await store.load() == expected_creds
 
 
 class TestStartHttp:
@@ -126,8 +126,10 @@ class TestStartHttp:
         self, settings: Settings, data_dir: Path
     ) -> None:
         """start_http should load stored creds and run mcp with streamable-http."""
+        import asyncio
+
         store = CredentialStore(data_dir, secret="test")
-        store.store({"TELEGRAM_BOT_TOKEN": "stored-token"})
+        asyncio.run(store.store({"TELEGRAM_BOT_TOKEN": "stored-token"}))
 
         with (
             patch.dict("os.environ", {"CREDENTIAL_SECRET": "test"}),
@@ -141,6 +143,7 @@ class TestStartHttp:
 
     def test_start_http_sets_env_vars(self, settings: Settings, data_dir: Path) -> None:
         """start_http should set TELEGRAM_ env vars from stored credentials."""
+        import asyncio
         import os
 
         store = CredentialStore(data_dir, secret="test")
@@ -148,7 +151,7 @@ class TestStartHttp:
             "TELEGRAM_BOT_TOKEN": "env-token-123",
             "TELEGRAM_API_ID": "99999",
         }
-        store.store(creds)
+        asyncio.run(store.store(creds))
 
         with (
             patch.dict(

--- a/tests/test_per_user_session_store.py
+++ b/tests/test_per_user_session_store.py
@@ -26,7 +26,7 @@ def store(data_dir: Path) -> PerUserSessionStore:
 
 
 class TestSessionInfo:
-    def test_to_dict_roundtrip(self) -> None:
+    async def test_to_dict_roundtrip(self) -> None:
         """SessionInfo should serialize and deserialize correctly."""
         info = SessionInfo(
             session_name="test",
@@ -44,7 +44,7 @@ class TestSessionInfo:
         assert restored.api_id is None
         assert restored.phone is None
 
-    def test_user_mode_fields(self) -> None:
+    async def test_user_mode_fields(self) -> None:
         """User mode SessionInfo should preserve all fields."""
         info = SessionInfo(
             session_name="user123",
@@ -62,49 +62,53 @@ class TestSessionInfo:
         assert restored.phone == "+84912345678"
         assert restored.bot_token is None
 
-    def test_created_at_default(self) -> None:
+    async def test_created_at_default(self) -> None:
         """created_at should default to current time."""
         info = SessionInfo(session_name="test", mode="bot")
         assert info.created_at > 0
 
 
 class TestPerUserSessionStore:
-    def test_store_load_roundtrip(self, store: PerUserSessionStore) -> None:
+    async def test_store_load_roundtrip(self, store: PerUserSessionStore) -> None:
         """Session can be stored and loaded back correctly."""
         info = SessionInfo(
             session_name="test",
             mode="bot",
             bot_token="123:ABC",
         )
-        store.store("bearer-token-1", info)
-        loaded = store.load("bearer-token-1")
+        await store.store("bearer-token-1", info)
+        loaded = await store.load("bearer-token-1")
 
         assert loaded is not None
         assert loaded.session_name == "test"
         assert loaded.mode == "bot"
         assert loaded.bot_token == "123:ABC"
 
-    def test_load_returns_none_for_unknown(self, store: PerUserSessionStore) -> None:
+    async def test_load_returns_none_for_unknown(
+        self, store: PerUserSessionStore
+    ) -> None:
         """Loading unknown bearer should return None."""
-        assert store.load("nonexistent") is None
+        assert await store.load("nonexistent") is None
 
-    def test_load_returns_none_when_empty(self, store: PerUserSessionStore) -> None:
+    async def test_load_returns_none_when_empty(
+        self, store: PerUserSessionStore
+    ) -> None:
         """Loading from empty store should return None."""
-        assert store.load("any-bearer") is None
+        assert await store.load("any-bearer") is None
 
-    def test_store_multiple_sessions(self, store: PerUserSessionStore) -> None:
+    async def test_store_multiple_sessions(self, store: PerUserSessionStore) -> None:
         """Multiple sessions can coexist."""
-        store.store(
+        await store.store(
             "bearer-1",
             SessionInfo(session_name="s1", mode="bot", bot_token="t1"),
         )
-        store.store(
+        await store.store(
             "bearer-2",
             SessionInfo(session_name="s2", mode="user", api_id=1, api_hash="h"),
         )
 
-        s1 = store.load("bearer-1")
-        s2 = store.load("bearer-2")
+        s1 = await store.load("bearer-1")
+        s2 = await store.load("bearer-2")
 
         assert s1 is not None
         assert s1.session_name == "s1"
@@ -114,105 +118,127 @@ class TestPerUserSessionStore:
         assert s2.session_name == "s2"
         assert s2.mode == "user"
 
-    def test_load_all(self, store: PerUserSessionStore) -> None:
+    async def test_load_all(self, store: PerUserSessionStore) -> None:
         """load_all should return all stored sessions."""
-        store.store("b1", SessionInfo(session_name="s1", mode="bot", bot_token="t1"))
-        store.store("b2", SessionInfo(session_name="s2", mode="bot", bot_token="t2"))
+        await store.store(
+            "b1", SessionInfo(session_name="s1", mode="bot", bot_token="t1")
+        )
+        await store.store(
+            "b2", SessionInfo(session_name="s2", mode="bot", bot_token="t2")
+        )
 
-        all_sessions = store.load_all()
+        all_sessions = await store.load_all()
         assert len(all_sessions) == 2
         assert "b1" in all_sessions
         assert "b2" in all_sessions
         assert all_sessions["b1"].session_name == "s1"
         assert all_sessions["b2"].session_name == "s2"
 
-    def test_load_all_empty(self, store: PerUserSessionStore) -> None:
+    async def test_load_all_empty(self, store: PerUserSessionStore) -> None:
         """load_all on empty store should return empty dict."""
-        assert store.load_all() == {}
+        assert await store.load_all() == {}
 
-    def test_delete_existing(self, store: PerUserSessionStore) -> None:
+    async def test_delete_existing(self, store: PerUserSessionStore) -> None:
         """Delete should remove session and return True."""
-        store.store(
+        await store.store(
             "bearer-1",
             SessionInfo(session_name="s1", mode="bot", bot_token="t1"),
         )
-        assert store.delete("bearer-1") is True
-        assert store.load("bearer-1") is None
+        assert await store.delete("bearer-1") is True
+        assert await store.load("bearer-1") is None
 
-    def test_delete_nonexistent(self, store: PerUserSessionStore) -> None:
+    async def test_delete_nonexistent(self, store: PerUserSessionStore) -> None:
         """Delete of nonexistent bearer should return False."""
-        assert store.delete("nonexistent") is False
+        assert await store.delete("nonexistent") is False
 
-    def test_delete_preserves_others(self, store: PerUserSessionStore) -> None:
+    async def test_delete_preserves_others(self, store: PerUserSessionStore) -> None:
         """Deleting one session should not affect others."""
-        store.store("b1", SessionInfo(session_name="s1", mode="bot", bot_token="t1"))
-        store.store("b2", SessionInfo(session_name="s2", mode="bot", bot_token="t2"))
+        await store.store(
+            "b1", SessionInfo(session_name="s1", mode="bot", bot_token="t1")
+        )
+        await store.store(
+            "b2", SessionInfo(session_name="s2", mode="bot", bot_token="t2")
+        )
 
-        store.delete("b1")
+        await store.delete("b1")
 
-        assert store.load("b1") is None
-        loaded = store.load("b2")
+        assert await store.load("b1") is None
+        loaded = await store.load("b2")
         assert loaded is not None
         assert loaded.session_name == "s2"
 
-    def test_overwrite_existing_session(self, store: PerUserSessionStore) -> None:
+    async def test_overwrite_existing_session(self, store: PerUserSessionStore) -> None:
         """Storing with same bearer should overwrite."""
-        store.store("b1", SessionInfo(session_name="s1", mode="bot", bot_token="old"))
-        store.store("b1", SessionInfo(session_name="s1", mode="bot", bot_token="new"))
+        await store.store(
+            "b1", SessionInfo(session_name="s1", mode="bot", bot_token="old")
+        )
+        await store.store(
+            "b1", SessionInfo(session_name="s1", mode="bot", bot_token="new")
+        )
 
-        loaded = store.load("b1")
+        loaded = await store.load("b1")
         assert loaded is not None
         assert loaded.bot_token == "new"
 
-    def test_encryption_different_secrets(self, data_dir: Path) -> None:
+    async def test_encryption_different_secrets(self, data_dir: Path) -> None:
         """Different secrets should not decrypt each other's data."""
         store1 = PerUserSessionStore(data_dir, secret="secret-one")
-        store1.store("b1", SessionInfo(session_name="s1", mode="bot", bot_token="t1"))
+        await store1.store(
+            "b1", SessionInfo(session_name="s1", mode="bot", bot_token="t1")
+        )
 
         store2 = PerUserSessionStore(data_dir, secret="secret-two")
         with pytest.raises(InvalidTag):
-            store2.load_all()
+            await store2.load_all()
 
-    def test_persistence_across_instances(self, data_dir: Path) -> None:
+    async def test_persistence_across_instances(self, data_dir: Path) -> None:
         """Sessions should persist across store instances with same secret."""
         store1 = PerUserSessionStore(data_dir, secret="shared-secret")
-        store1.store("b1", SessionInfo(session_name="s1", mode="bot", bot_token="t1"))
+        await store1.store(
+            "b1", SessionInfo(session_name="s1", mode="bot", bot_token="t1")
+        )
 
         store2 = PerUserSessionStore(data_dir, secret="shared-secret")
-        loaded = store2.load("b1")
+        loaded = await store2.load("b1")
         assert loaded is not None
         assert loaded.bot_token == "t1"
 
-    def test_auto_generated_secret_persists(self, data_dir: Path) -> None:
+    async def test_auto_generated_secret_persists(self, data_dir: Path) -> None:
         """Auto-generated secret should be reusable across instances."""
         store1 = PerUserSessionStore(data_dir)
-        store1.store("b1", SessionInfo(session_name="s1", mode="bot", bot_token="t1"))
+        await store1.store(
+            "b1", SessionInfo(session_name="s1", mode="bot", bot_token="t1")
+        )
 
         store2 = PerUserSessionStore(data_dir)
-        loaded = store2.load("b1")
+        loaded = await store2.load("b1")
         assert loaded is not None
         assert loaded.bot_token == "t1"
 
-    def test_data_dir_created_if_missing(self, tmp_path: Path) -> None:
+    async def test_data_dir_created_if_missing(self, tmp_path: Path) -> None:
         """Store should create data_dir if it does not exist."""
         nested = tmp_path / "a" / "b" / "c"
         store = PerUserSessionStore(nested, secret="test")
-        store.store("b1", SessionInfo(session_name="s1", mode="bot", bot_token="t1"))
-        assert store.load("b1") is not None
+        await store.store(
+            "b1", SessionInfo(session_name="s1", mode="bot", bot_token="t1")
+        )
+        assert await store.load("b1") is not None
 
-    def test_env_var_secret(
+    async def test_env_var_secret(
         self, data_dir: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """CREDENTIAL_SECRET env var should be used when set."""
         monkeypatch.setenv("CREDENTIAL_SECRET", "env-secret")
         store = PerUserSessionStore(data_dir)
-        store.store("b1", SessionInfo(session_name="s1", mode="bot", bot_token="t1"))
+        await store.store(
+            "b1", SessionInfo(session_name="s1", mode="bot", bot_token="t1")
+        )
 
         store2 = PerUserSessionStore(data_dir)
-        assert store2.load("b1") is not None
+        assert await store2.load("b1") is not None
 
         # Different env var should fail
         monkeypatch.setenv("CREDENTIAL_SECRET", "different-env-secret")
         store3 = PerUserSessionStore(data_dir)
         with pytest.raises(InvalidTag):
-            store3.load_all()
+            await store3.load_all()

--- a/tests/test_telegram_auth_provider.py
+++ b/tests/test_telegram_auth_provider.py
@@ -81,7 +81,7 @@ class TestRegisterBot:
 
             bearer = await provider.register_bot("", "123:ABC")
 
-        info = provider._store.load(bearer)
+        info = await provider._store.load(bearer)
         assert info is not None
         assert info.mode == "bot"
         assert info.bot_token == "123:ABC"
@@ -309,7 +309,7 @@ class TestRestoreSessions:
     async def test_restore_bot_sessions(self, provider: TelegramAuthProvider) -> None:
         """Should restore bot sessions from store on startup."""
         # Store a session directly
-        provider._store.store(
+        await provider._store.store(
             "stored-bearer",
             SessionInfo(
                 session_name="test",
@@ -334,7 +334,7 @@ class TestRestoreSessions:
         self, provider: TelegramAuthProvider
     ) -> None:
         """Should remove expired sessions during restore."""
-        provider._store.store(
+        await provider._store.store(
             "expired-bearer",
             SessionInfo(
                 session_name="old",
@@ -352,7 +352,7 @@ class TestRestoreSessions:
         self, provider: TelegramAuthProvider
     ) -> None:
         """Should remove sessions that fail to reconnect."""
-        provider._store.store(
+        await provider._store.store(
             "broken-bearer",
             SessionInfo(
                 session_name="broken",
@@ -373,7 +373,7 @@ class TestRestoreSessions:
             restored = await provider.restore_sessions()
 
         assert restored == 0
-        assert provider._store.load("broken-bearer") is None
+        assert await provider._store.load("broken-bearer") is None
 
 
 class TestCleanupExpired:
@@ -382,7 +382,7 @@ class TestCleanupExpired:
     ) -> None:
         """Should remove expired sessions."""
         # Store an expired session
-        provider._store.store(
+        await provider._store.store(
             "expired",
             SessionInfo(
                 session_name="old",
@@ -392,7 +392,7 @@ class TestCleanupExpired:
             ),
         )
         # Store a valid session
-        provider._store.store(
+        await provider._store.store(
             "valid",
             SessionInfo(
                 session_name="new",
@@ -404,8 +404,8 @@ class TestCleanupExpired:
 
         removed = await provider.cleanup_expired()
         assert removed == 1
-        assert provider._store.load("expired") is None
-        assert provider._store.load("valid") is not None
+        assert await provider._store.load("expired") is None
+        assert await provider._store.load("valid") is not None
 
     async def test_cleanup_stale_otps(self, provider: TelegramAuthProvider) -> None:
         """Should clean up pending OTPs older than 5 minutes."""

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "3.5.0b1"
+version = "3.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Synchronous file read in async path was fixed by making CredentialStore and PerUserSessionStore methods asynchronous and using asyncio.to_thread for all filesystem operations. This ensures that the event loop is not blocked during credential/session loading and storage. All callers and tests were updated to accommodate these changes.

---
*PR created automatically by Jules for task [10406071392360046892](https://jules.google.com/task/10406071392360046892) started by @n24q02m*