### PR TITLE
[FIX] Too Many Parameters

### DIFF
--- a/src/better_telegram_mcp/server.py
+++ b/src/better_telegram_mcp/server.py
@@ -170,20 +170,7 @@ mcp = FastMCP(
         openWorldHint=True,
     )
 )
-async def message(
-    action: str,
-    chat_id: str | int | None = None,
-    text: str | None = None,
-    message_id: int | None = None,
-    reply_to: int | None = None,
-    parse_mode: str | None = None,
-    from_chat: str | int | None = None,
-    to_chat: str | int | None = None,
-    emoji: str | None = None,
-    query: str | None = None,
-    limit: int = 20,
-    offset_id: int | None = None,
-) -> str:
+async def message(args: MessagesArgs) -> str:
     """Send, edit, delete, forward, pin, react, search, and get message history.
 
     Actions (chat_id: "@username" | int):
@@ -199,20 +186,6 @@ async def message(
     if _unconfigured or _pending_auth:
         return _not_ready_response()
 
-    args = MessagesArgs(
-        action=action,
-        chat_id=chat_id,
-        text=text,
-        message_id=message_id,
-        reply_to=reply_to,
-        parse_mode=parse_mode,
-        from_chat=from_chat,
-        to_chat=to_chat,
-        emoji=emoji,
-        query=query,
-        limit=limit,
-        offset_id=offset_id,
-    )
     return await handle_messages(get_backend(), args)
 
 
@@ -225,20 +198,7 @@ async def message(
         openWorldHint=True,
     )
 )
-async def chat(
-    action: str,
-    chat_id: str | int | None = None,
-    title: str | None = None,
-    description: str | None = None,
-    is_channel: bool = False,
-    link_or_hash: str | None = None,
-    user_id: int | None = None,
-    demote: bool = False,
-    limit: int = 50,
-    topic_action: str | None = None,
-    topic_id: int | None = None,
-    topic_name: str | None = None,
-) -> str:
+async def chat(options: ChatOptions) -> str:
     """List, create, join, leave, manage members, settings, and topics.
 
     Actions:
@@ -255,20 +215,7 @@ async def chat(
     if _unconfigured or _pending_auth:
         return _not_ready_response()
 
-    opts = ChatOptions(
-        chat_id=chat_id,
-        title=title,
-        description=description,
-        is_channel=is_channel,
-        link_or_hash=link_or_hash,
-        user_id=user_id,
-        demote=demote,
-        limit=limit,
-        topic_action=topic_action,
-        topic_id=topic_id,
-        topic_name=topic_name,
-    )
-    return await handle_chats(get_backend(), action, opts)
+    return await handle_chats(get_backend(), options)
 
 
 @mcp.tool(
@@ -280,14 +227,7 @@ async def chat(
         openWorldHint=True,
     )
 )
-async def media(
-    action: str,
-    chat_id: str | int | None = None,
-    file_path_or_url: str | None = None,
-    message_id: int | None = None,
-    caption: str | None = None,
-    output_dir: str | None = None,
-) -> str:
+async def media(options: MediaOptions) -> str:
     """Send photos, files, voice, video, and download media from messages.
 
     Actions (file_path_or_url: local path or URL):
@@ -300,14 +240,7 @@ async def media(
     if _unconfigured or _pending_auth:
         return _not_ready_response()
 
-    opts = MediaOptions(
-        chat_id=chat_id,
-        file_path_or_url=file_path_or_url,
-        message_id=message_id,
-        caption=caption,
-        output_dir=output_dir,
-    )
-    return await handle_media(get_backend(), action, opts)
+    return await handle_media(get_backend(), options)
 
 
 @mcp.tool(
@@ -319,15 +252,7 @@ async def media(
         openWorldHint=True,
     )
 )
-async def contact(
-    action: str,
-    query: str | None = None,
-    phone: str | None = None,
-    first_name: str | None = None,
-    last_name: str | None = None,
-    user_id: int | None = None,
-    unblock: bool = False,
-) -> str:
+async def contact(options: ContactsOptions) -> str:
     """Manage contacts: list, search, add, and block/unblock users (user mode only).
 
     Actions:
@@ -339,15 +264,7 @@ async def contact(
     if _unconfigured or _pending_auth:
         return _not_ready_response()
 
-    opts = ContactsOptions(
-        query=query,
-        phone=phone,
-        first_name=first_name,
-        last_name=last_name,
-        user_id=user_id,
-        unblock=unblock,
-    )
-    return await handle_contacts(get_backend(), action, options=opts)
+    return await handle_contacts(get_backend(), options)
 
 
 @mcp.tool(

--- a/src/better_telegram_mcp/tools/chats.py
+++ b/src/better_telegram_mcp/tools/chats.py
@@ -10,6 +10,7 @@ from ..utils.formatting import err, ok, safe_error
 
 
 class ChatOptions(BaseModel):
+    action: str = Field(description="Action to perform")
     chat_id: str | int | None = Field(default=None, description="ID of the chat")
     title: str | None = Field(default=None, description="Title for new/updated chat")
     description: str | None = Field(default=None, description="Description for chat")
@@ -125,20 +126,21 @@ _ACTION_HANDLERS: dict[
 
 async def handle_chats(
     backend: TelegramBackend,
-    action: str,
     options: ChatOptions,
 ) -> str:
     try:
-        handler = _ACTION_HANDLERS.get(action)
+        handler = _ACTION_HANDLERS.get(options.action)
         if handler:
             return await handler(backend, options)
 
         import difflib
 
         valid = sorted(_ACTION_HANDLERS)
-        closest = difflib.get_close_matches(action, valid, n=1)
+        closest = difflib.get_close_matches(options.action, valid, n=1)
         suggestion = f" Did you mean '{closest[0]}'?" if closest else ""
-        return err(f"Unknown action '{action}'.{suggestion} Valid: {'|'.join(valid)}")
+        return err(
+            f"Unknown action '{options.action}'.{suggestion} Valid: {'|'.join(valid)}"
+        )
     except ModeError as e:
         return err(str(e))
     except Exception as e:

--- a/src/better_telegram_mcp/tools/contacts.py
+++ b/src/better_telegram_mcp/tools/contacts.py
@@ -7,6 +7,7 @@ from ..utils.formatting import err, ok, safe_error
 
 
 class ContactsOptions(BaseModel):
+    action: str = Field(description="Action to perform")
     query: str | None = Field(default=None, description="Query to search for")
     phone: str | None = Field(default=None, description="Phone number to add")
     first_name: str | None = Field(
@@ -19,13 +20,10 @@ class ContactsOptions(BaseModel):
 
 async def handle_contacts(
     backend: TelegramBackend,
-    action: str,
-    options: ContactsOptions | None = None,
+    options: ContactsOptions,
 ) -> str:
-    if options is None:
-        options = ContactsOptions()
     try:
-        match action:
+        match options.action:
             case "list":
                 results = await backend.list_contacts()
                 return ok({"contacts": results, "count": len(results)})
@@ -57,10 +55,10 @@ async def handle_contacts(
                 import difflib
 
                 valid = ["add", "block", "list", "search"]
-                closest = difflib.get_close_matches(action, valid, n=1)
+                closest = difflib.get_close_matches(options.action, valid, n=1)
                 suggestion = f" Did you mean '{closest[0]}'?" if closest else ""
                 return err(
-                    f"Unknown action '{action}'.{suggestion} Valid: {'|'.join(valid)}"
+                    f"Unknown action '{options.action}'.{suggestion} Valid: {'|'.join(valid)}"
                 )
     except ModeError as e:
         return err(str(e))

--- a/src/better_telegram_mcp/tools/media.py
+++ b/src/better_telegram_mcp/tools/media.py
@@ -7,6 +7,7 @@ from ..utils.formatting import err, ok, safe_error
 
 
 class MediaOptions(BaseModel):
+    action: str = Field(description="Action to perform")
     chat_id: str | int | None = Field(default=None, description="ID of the chat")
     file_path_or_url: str | None = Field(
         default=None, description="Path or URL of the file to send"
@@ -30,18 +31,17 @@ _ACTION_TO_MEDIA_TYPE = {
 
 async def handle_media(
     backend: TelegramBackend,
-    action: str,
     options: MediaOptions,
 ) -> str:
     try:
-        if action in _ACTION_TO_MEDIA_TYPE:
+        if options.action in _ACTION_TO_MEDIA_TYPE:
             if not options.chat_id or not options.file_path_or_url:
                 return err(
-                    f"'{action}' requires chat_id and file_path_or_url. "
+                    f"'{options.action}' requires chat_id and file_path_or_url. "
                     "file_path_or_url: local path or HTTP(S) URL. "
                     "Limits: photo 10MB, file/voice/video 50MB (2GB local in user mode)."
                 )
-            media_type = _ACTION_TO_MEDIA_TYPE[action]
+            media_type = _ACTION_TO_MEDIA_TYPE[options.action]
             result = await backend.send_media(
                 options.chat_id,
                 media_type,
@@ -50,7 +50,7 @@ async def handle_media(
             )
             return ok(result)
 
-        if action == "download":
+        if options.action == "download":
             if not options.chat_id or options.message_id is None:
                 return err("'download' requires chat_id and message_id")
             path = await backend.download_media(
@@ -61,9 +61,11 @@ async def handle_media(
         import difflib
 
         valid = sorted([*_ACTION_TO_MEDIA_TYPE, "download"])
-        closest = difflib.get_close_matches(action, valid, n=1)
+        closest = difflib.get_close_matches(options.action, valid, n=1)
         suggestion = f" Did you mean '{closest[0]}'?" if closest else ""
-        return err(f"Unknown action '{action}'.{suggestion} Valid: {'|'.join(valid)}")
+        return err(
+            f"Unknown action '{options.action}'.{suggestion} Valid: {'|'.join(valid)}"
+        )
     except ModeError as e:
         return err(str(e))
     except Exception as e:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -11,6 +11,10 @@ from better_telegram_mcp.server import (
     main,
     mcp,
 )
+from better_telegram_mcp.tools.chats import ChatOptions
+from better_telegram_mcp.tools.contacts import ContactsOptions
+from better_telegram_mcp.tools.media import MediaOptions
+from better_telegram_mcp.tools.messages import MessagesArgs
 
 
 def test_mcp_has_6_tools():
@@ -58,7 +62,7 @@ async def test_message_send(mock_backend):
     try:
         srv._backend = mock_backend
         srv._pending_auth = False
-        result = await message(action="send", chat_id=123, text="hi")
+        result = await message(args=MessagesArgs(action="send", chat_id=123, text="hi"))
         assert "message_id" in result
     finally:
         srv._backend = old_backend
@@ -75,7 +79,7 @@ async def test_chat_list(mock_backend):
     try:
         srv._backend = mock_backend
         srv._pending_auth = False
-        result = await chat(action="list")
+        result = await chat(options=ChatOptions(action="list"))
         assert "chats" in result
     finally:
         srv._backend = old_backend
@@ -93,9 +97,11 @@ async def test_media_send_photo(mock_backend):
         srv._backend = mock_backend
         srv._pending_auth = False
         result = await media(
-            action="send_photo",
-            chat_id=123,
-            file_path_or_url="https://example.com/photo.jpg",
+            options=MediaOptions(
+                action="send_photo",
+                chat_id=123,
+                file_path_or_url="https://example.com/photo.jpg",
+            )
         )
         assert "message_id" in result
     finally:
@@ -113,7 +119,7 @@ async def test_contact_list(mock_backend):
     try:
         srv._backend = mock_backend
         srv._pending_auth = False
-        result = await contact(action="list")
+        result = await contact(options=ContactsOptions(action="list"))
         assert "contacts" in result
     finally:
         srv._backend = old_backend
@@ -130,7 +136,7 @@ async def test_message_unknown_action(mock_backend):
     try:
         srv._backend = mock_backend
         srv._pending_auth = False
-        result = json.loads(await message(action="nonexistent"))
+        result = json.loads(await message(args=MessagesArgs(action="nonexistent")))
         assert "error" in result
         assert "Unknown action" in result["error"]
     finally:
@@ -251,7 +257,9 @@ async def test_message_blocked_during_pending_auth(mock_backend):
     try:
         srv._backend = mock_backend
         srv._pending_auth = True
-        result = json.loads(await message(action="send", chat_id=123, text="hi"))
+        result = json.loads(
+            await message(args=MessagesArgs(action="send", chat_id=123, text="hi"))
+        )
         assert "error" in result
         assert "not authenticated" in result["error"].lower()
     finally:
@@ -269,7 +277,7 @@ async def test_chat_blocked_during_pending_auth(mock_backend):
     try:
         srv._backend = mock_backend
         srv._pending_auth = True
-        result = json.loads(await chat(action="list"))
+        result = json.loads(await chat(options=ChatOptions(action="list")))
         assert "error" in result
         assert "not authenticated" in result["error"].lower()
     finally:
@@ -289,9 +297,11 @@ async def test_media_blocked_during_pending_auth(mock_backend):
         srv._pending_auth = True
         result = json.loads(
             await media(
-                action="send_photo",
-                chat_id=123,
-                file_path_or_url="https://example.com/photo.jpg",
+                options=MediaOptions(
+                    action="send_photo",
+                    chat_id=123,
+                    file_path_or_url="https://example.com/photo.jpg",
+                )
             )
         )
         assert "error" in result
@@ -311,7 +321,7 @@ async def test_contact_blocked_during_pending_auth(mock_backend):
     try:
         srv._backend = mock_backend
         srv._pending_auth = True
-        result = json.loads(await contact(action="list"))
+        result = json.loads(await contact(options=ContactsOptions(action="list")))
         assert "error" in result
         assert "not authenticated" in result["error"].lower()
     finally:
@@ -388,7 +398,9 @@ async def test_message_returns_setup_hint_when_unconfigured():
     try:
         srv._unconfigured = True
         srv._pending_auth = False
-        result = json.loads(await message(action="send", chat_id=123, text="hi"))
+        result = json.loads(
+            await message(args=MessagesArgs(action="send", chat_id=123, text="hi"))
+        )
         assert "error" in result
         assert result["error"] == "Not configured"
         assert "setup" in result
@@ -409,7 +421,7 @@ async def test_chat_returns_setup_hint_when_unconfigured():
     old = srv._unconfigured
     try:
         srv._unconfigured = True
-        result = json.loads(await chat(action="list"))
+        result = json.loads(await chat(options=ChatOptions(action="list")))
         assert result["error"] == "Not configured"
         assert "setup" in result
     finally:
@@ -461,9 +473,11 @@ async def test_media_returns_setup_hint_when_unconfigured():
         srv._unconfigured = True
         result = json.loads(
             await media(
-                action="send_photo",
-                chat_id=123,
-                file_path_or_url="https://example.com/photo.jpg",
+                options=MediaOptions(
+                    action="send_photo",
+                    chat_id=123,
+                    file_path_or_url="https://example.com/photo.jpg",
+                )
             )
         )
         assert result["error"] == "Not configured"
@@ -481,7 +495,7 @@ async def test_contact_returns_setup_hint_when_unconfigured():
     old = srv._unconfigured
     try:
         srv._unconfigured = True
-        result = json.loads(await contact(action="list"))
+        result = json.loads(await contact(options=ContactsOptions(action="list")))
         assert result["error"] == "Not configured"
         assert "setup" in result
     finally:

--- a/tests/test_tools/test_chats.py
+++ b/tests/test_tools/test_chats.py
@@ -10,7 +10,9 @@ from better_telegram_mcp.tools.chats import ChatOptions, handle_chats
 
 @pytest.mark.asyncio
 async def test_list(mock_backend):
-    result = json.loads(await handle_chats(mock_backend, "list", ChatOptions(limit=10)))
+    result = json.loads(
+        await handle_chats(mock_backend, ChatOptions(action="list", limit=10))
+    )
     assert result["chats"] == []
     assert result["count"] == 0
 
@@ -19,14 +21,21 @@ async def test_list(mock_backend):
 async def test_info(mock_backend):
     mock_backend.get_chat_info.return_value = {"id": 123, "title": "Test"}
     result = json.loads(
-        await handle_chats(mock_backend, "info", ChatOptions(chat_id=123))
+        await handle_chats(mock_backend, ChatOptions(action="info", chat_id=123))
     )
     assert result["id"] == 123
 
 
 @pytest.mark.asyncio
 async def test_info_missing_params(mock_backend):
-    result = json.loads(await handle_chats(mock_backend, "info", ChatOptions()))
+    result = json.loads(
+        await handle_chats(
+            mock_backend,
+            ChatOptions(
+                action="info",
+            ),
+        )
+    )
     assert "error" in result
 
 
@@ -35,7 +44,7 @@ async def test_create(mock_backend):
     mock_backend.create_chat.return_value = {"id": 456, "title": "New"}
     result = json.loads(
         await handle_chats(
-            mock_backend, "create", ChatOptions(title="New", is_channel=True)
+            mock_backend, ChatOptions(action="create", title="New", is_channel=True)
         )
     )
     assert result["id"] == 456
@@ -43,42 +52,67 @@ async def test_create(mock_backend):
 
 @pytest.mark.asyncio
 async def test_create_missing_params(mock_backend):
-    result = json.loads(await handle_chats(mock_backend, "create", ChatOptions()))
+    result = json.loads(
+        await handle_chats(
+            mock_backend,
+            ChatOptions(
+                action="create",
+            ),
+        )
+    )
     assert "error" in result
 
 
 @pytest.mark.asyncio
 async def test_join(mock_backend):
     result = json.loads(
-        await handle_chats(mock_backend, "join", ChatOptions(link_or_hash="abc123"))
+        await handle_chats(
+            mock_backend, ChatOptions(action="join", link_or_hash="abc123")
+        )
     )
     assert result["joined"] is True
 
 
 @pytest.mark.asyncio
 async def test_join_missing_params(mock_backend):
-    result = json.loads(await handle_chats(mock_backend, "join", ChatOptions()))
+    result = json.loads(
+        await handle_chats(
+            mock_backend,
+            ChatOptions(
+                action="join",
+            ),
+        )
+    )
     assert "error" in result
 
 
 @pytest.mark.asyncio
 async def test_leave(mock_backend):
     result = json.loads(
-        await handle_chats(mock_backend, "leave", ChatOptions(chat_id=123))
+        await handle_chats(mock_backend, ChatOptions(action="leave", chat_id=123))
     )
     assert result["left"] is True
 
 
 @pytest.mark.asyncio
 async def test_leave_missing_params(mock_backend):
-    result = json.loads(await handle_chats(mock_backend, "leave", ChatOptions()))
+    result = json.loads(
+        await handle_chats(
+            mock_backend,
+            ChatOptions(
+                action="leave",
+            ),
+        )
+    )
     assert "error" in result
 
 
 @pytest.mark.asyncio
 async def test_members(mock_backend):
     result = json.loads(
-        await handle_chats(mock_backend, "members", ChatOptions(chat_id=123, limit=10))
+        await handle_chats(
+            mock_backend, ChatOptions(action="members", chat_id=123, limit=10)
+        )
     )
     assert result["members"] == []
     assert result["count"] == 0
@@ -86,14 +120,23 @@ async def test_members(mock_backend):
 
 @pytest.mark.asyncio
 async def test_members_missing_params(mock_backend):
-    result = json.loads(await handle_chats(mock_backend, "members", ChatOptions()))
+    result = json.loads(
+        await handle_chats(
+            mock_backend,
+            ChatOptions(
+                action="members",
+            ),
+        )
+    )
     assert "error" in result
 
 
 @pytest.mark.asyncio
 async def test_admin_promote(mock_backend):
     result = json.loads(
-        await handle_chats(mock_backend, "admin", ChatOptions(chat_id=123, user_id=456))
+        await handle_chats(
+            mock_backend, ChatOptions(action="admin", chat_id=123, user_id=456)
+        )
     )
     assert result["promoted"] is True
 
@@ -102,7 +145,8 @@ async def test_admin_promote(mock_backend):
 async def test_admin_demote(mock_backend):
     result = json.loads(
         await handle_chats(
-            mock_backend, "admin", ChatOptions(chat_id=123, user_id=456, demote=True)
+            mock_backend,
+            ChatOptions(action="admin", chat_id=123, user_id=456, demote=True),
         )
     )
     assert result["demoted"] is True
@@ -111,7 +155,7 @@ async def test_admin_demote(mock_backend):
 @pytest.mark.asyncio
 async def test_admin_missing_params(mock_backend):
     result = json.loads(
-        await handle_chats(mock_backend, "admin", ChatOptions(chat_id=123))
+        await handle_chats(mock_backend, ChatOptions(action="admin", chat_id=123))
     )
     assert "error" in result
 
@@ -121,8 +165,8 @@ async def test_settings(mock_backend):
     result = json.loads(
         await handle_chats(
             mock_backend,
-            "settings",
             ChatOptions(
+                action="settings",
                 chat_id=123,
                 title="New Title",
                 description="New Desc",
@@ -135,7 +179,7 @@ async def test_settings(mock_backend):
 @pytest.mark.asyncio
 async def test_settings_missing_chat_id(mock_backend):
     result = json.loads(
-        await handle_chats(mock_backend, "settings", ChatOptions(title="X"))
+        await handle_chats(mock_backend, ChatOptions(action="settings", title="X"))
     )
     assert "error" in result
 
@@ -143,7 +187,7 @@ async def test_settings_missing_chat_id(mock_backend):
 @pytest.mark.asyncio
 async def test_settings_no_fields(mock_backend):
     result = json.loads(
-        await handle_chats(mock_backend, "settings", ChatOptions(chat_id=123))
+        await handle_chats(mock_backend, ChatOptions(action="settings", chat_id=123))
     )
     assert "error" in result
 
@@ -153,7 +197,7 @@ async def test_topics(mock_backend):
     mock_backend.manage_topics.return_value = {"topics": []}
     result = json.loads(
         await handle_chats(
-            mock_backend, "topics", ChatOptions(chat_id=123, topic_action="list")
+            mock_backend, ChatOptions(action="topics", chat_id=123, topic_action="list")
         )
     )
     assert "topics" in result
@@ -165,8 +209,8 @@ async def test_topics_create(mock_backend):
     result = json.loads(
         await handle_chats(
             mock_backend,
-            "topics",
             ChatOptions(
+                action="topics",
                 chat_id=123,
                 topic_action="create",
                 topic_name="General",
@@ -182,8 +226,8 @@ async def test_topics_close_with_id(mock_backend):
     result = json.loads(
         await handle_chats(
             mock_backend,
-            "topics",
             ChatOptions(
+                action="topics",
                 chat_id=123,
                 topic_action="close",
                 topic_id=42,
@@ -197,7 +241,9 @@ async def test_topics_close_with_id(mock_backend):
 @pytest.mark.asyncio
 async def test_topics_missing_chat_id(mock_backend):
     result = json.loads(
-        await handle_chats(mock_backend, "topics", ChatOptions(topic_action="list"))
+        await handle_chats(
+            mock_backend, ChatOptions(action="topics", topic_action="list")
+        )
     )
     assert "error" in result
 
@@ -205,14 +251,21 @@ async def test_topics_missing_chat_id(mock_backend):
 @pytest.mark.asyncio
 async def test_topics_missing_action(mock_backend):
     result = json.loads(
-        await handle_chats(mock_backend, "topics", ChatOptions(chat_id=123))
+        await handle_chats(mock_backend, ChatOptions(action="topics", chat_id=123))
     )
     assert "error" in result
 
 
 @pytest.mark.asyncio
 async def test_unknown_action(mock_backend):
-    result = json.loads(await handle_chats(mock_backend, "unknown", ChatOptions()))
+    result = json.loads(
+        await handle_chats(
+            mock_backend,
+            ChatOptions(
+                action="unknown",
+            ),
+        )
+    )
     assert "error" in result
     assert "Unknown action" in result["error"]
 
@@ -220,7 +273,14 @@ async def test_unknown_action(mock_backend):
 @pytest.mark.asyncio
 async def test_mode_error(mock_backend):
     mock_backend.list_chats.side_effect = ModeError("user")
-    result = json.loads(await handle_chats(mock_backend, "list", ChatOptions()))
+    result = json.loads(
+        await handle_chats(
+            mock_backend,
+            ChatOptions(
+                action="list",
+            ),
+        )
+    )
     assert "error" in result
     assert "user mode" in result["error"]
 
@@ -229,7 +289,7 @@ async def test_mode_error(mock_backend):
 async def test_general_exception(mock_backend):
     mock_backend.get_chat_info.side_effect = RuntimeError("fail")
     result = json.loads(
-        await handle_chats(mock_backend, "info", ChatOptions(chat_id=123))
+        await handle_chats(mock_backend, ChatOptions(action="info", chat_id=123))
     )
     assert "error" in result
     assert "RuntimeError" in result["error"]

--- a/tests/test_tools/test_contacts.py
+++ b/tests/test_tools/test_contacts.py
@@ -10,7 +10,9 @@ from better_telegram_mcp.tools.contacts import ContactsOptions, handle_contacts
 
 @pytest.mark.asyncio
 async def test_list(mock_backend):
-    result = json.loads(await handle_contacts(mock_backend, "list"))
+    result = json.loads(
+        await handle_contacts(mock_backend, ContactsOptions(action="list"))
+    )
     assert result["contacts"] == []
     assert result["count"] == 0
 
@@ -18,7 +20,9 @@ async def test_list(mock_backend):
 @pytest.mark.asyncio
 async def test_search(mock_backend):
     result = json.loads(
-        await handle_contacts(mock_backend, "search", ContactsOptions(query="John"))
+        await handle_contacts(
+            mock_backend, ContactsOptions(action="search", query="John")
+        )
     )
     assert result["contacts"] == []
     assert result["count"] == 0
@@ -26,7 +30,9 @@ async def test_search(mock_backend):
 
 @pytest.mark.asyncio
 async def test_search_missing_params(mock_backend):
-    result = json.loads(await handle_contacts(mock_backend, "search"))
+    result = json.loads(
+        await handle_contacts(mock_backend, ContactsOptions(action="search"))
+    )
     assert "error" in result
 
 
@@ -35,8 +41,8 @@ async def test_add(mock_backend):
     result = json.loads(
         await handle_contacts(
             mock_backend,
-            "add",
             ContactsOptions(
+                action="add",
                 phone="+1234567890",
                 first_name="John",
                 last_name="Doe",
@@ -52,12 +58,14 @@ async def test_add(mock_backend):
 @pytest.mark.asyncio
 async def test_add_missing_params(mock_backend):
     result = json.loads(
-        await handle_contacts(mock_backend, "add", ContactsOptions(phone="+123"))
+        await handle_contacts(mock_backend, ContactsOptions(action="add", phone="+123"))
     )
     assert "error" in result
 
     result = json.loads(
-        await handle_contacts(mock_backend, "add", ContactsOptions(first_name="John"))
+        await handle_contacts(
+            mock_backend, ContactsOptions(action="add", first_name="John")
+        )
     )
     assert "error" in result
 
@@ -65,7 +73,9 @@ async def test_add_missing_params(mock_backend):
 @pytest.mark.asyncio
 async def test_block(mock_backend):
     result = json.loads(
-        await handle_contacts(mock_backend, "block", ContactsOptions(user_id=123))
+        await handle_contacts(
+            mock_backend, ContactsOptions(action="block", user_id=123)
+        )
     )
     assert result["blocked"] is True
 
@@ -74,7 +84,7 @@ async def test_block(mock_backend):
 async def test_unblock(mock_backend):
     result = json.loads(
         await handle_contacts(
-            mock_backend, "block", ContactsOptions(user_id=123, unblock=True)
+            mock_backend, ContactsOptions(action="block", user_id=123, unblock=True)
         )
     )
     assert result["unblocked"] is True
@@ -82,13 +92,17 @@ async def test_unblock(mock_backend):
 
 @pytest.mark.asyncio
 async def test_block_missing_params(mock_backend):
-    result = json.loads(await handle_contacts(mock_backend, "block"))
+    result = json.loads(
+        await handle_contacts(mock_backend, ContactsOptions(action="block"))
+    )
     assert "error" in result
 
 
 @pytest.mark.asyncio
 async def test_unknown_action(mock_backend):
-    result = json.loads(await handle_contacts(mock_backend, "unknown"))
+    result = json.loads(
+        await handle_contacts(mock_backend, ContactsOptions(action="unknown"))
+    )
     assert "error" in result
     assert "Unknown action" in result["error"]
 
@@ -96,7 +110,9 @@ async def test_unknown_action(mock_backend):
 @pytest.mark.asyncio
 async def test_mode_error(mock_backend):
     mock_backend.list_contacts.side_effect = ModeError("user")
-    result = json.loads(await handle_contacts(mock_backend, "list"))
+    result = json.loads(
+        await handle_contacts(mock_backend, ContactsOptions(action="list"))
+    )
     assert "error" in result
     assert "user mode" in result["error"]
 
@@ -106,7 +122,7 @@ async def test_general_exception(mock_backend):
     mock_backend.add_contact.side_effect = RuntimeError("network error")
     result = json.loads(
         await handle_contacts(
-            mock_backend, "add", ContactsOptions(phone="+1", first_name="X")
+            mock_backend, ContactsOptions(action="add", phone="+1", first_name="X")
         )
     )
     assert "error" in result

--- a/tests/test_tools/test_media.py
+++ b/tests/test_tools/test_media.py
@@ -13,8 +13,8 @@ async def test_send_photo(mock_backend):
     result = json.loads(
         await handle_media(
             mock_backend,
-            "send_photo",
             MediaOptions(
+                action="send_photo",
                 chat_id=123,
                 file_path_or_url="https://example.com/photo.jpg",
                 caption="Nice photo",
@@ -32,8 +32,8 @@ async def test_send_file(mock_backend):
     result = json.loads(
         await handle_media(
             mock_backend,
-            "send_file",
             MediaOptions(
+                action="send_file",
                 chat_id=123,
                 file_path_or_url="/tmp/doc.pdf",
             ),
@@ -50,8 +50,8 @@ async def test_send_voice(mock_backend):
     result = json.loads(
         await handle_media(
             mock_backend,
-            "send_voice",
             MediaOptions(
+                action="send_voice",
                 chat_id=123,
                 file_path_or_url="/tmp/voice.ogg",
             ),
@@ -68,8 +68,8 @@ async def test_send_video(mock_backend):
     result = json.loads(
         await handle_media(
             mock_backend,
-            "send_video",
             MediaOptions(
+                action="send_video",
                 chat_id=123,
                 file_path_or_url="/tmp/video.mp4",
             ),
@@ -84,15 +84,15 @@ async def test_send_video(mock_backend):
 @pytest.mark.asyncio
 async def test_send_photo_missing_params(mock_backend):
     result = json.loads(
-        await handle_media(mock_backend, "send_photo", MediaOptions(chat_id=123))
+        await handle_media(mock_backend, MediaOptions(action="send_photo", chat_id=123))
     )
     assert "error" in result
 
     result = json.loads(
         await handle_media(
             mock_backend,
-            "send_photo",
             MediaOptions(
+                action="send_photo",
                 file_path_or_url="https://example.com/photo.jpg",
             ),
         )
@@ -105,8 +105,8 @@ async def test_download(mock_backend):
     result = json.loads(
         await handle_media(
             mock_backend,
-            "download",
             MediaOptions(
+                action="download",
                 chat_id=123,
                 message_id=10,
                 output_dir="/tmp",
@@ -119,19 +119,26 @@ async def test_download(mock_backend):
 @pytest.mark.asyncio
 async def test_download_missing_params(mock_backend):
     result = json.loads(
-        await handle_media(mock_backend, "download", MediaOptions(chat_id=123))
+        await handle_media(mock_backend, MediaOptions(action="download", chat_id=123))
     )
     assert "error" in result
 
     result = json.loads(
-        await handle_media(mock_backend, "download", MediaOptions(message_id=10))
+        await handle_media(mock_backend, MediaOptions(action="download", message_id=10))
     )
     assert "error" in result
 
 
 @pytest.mark.asyncio
 async def test_unknown_action(mock_backend):
-    result = json.loads(await handle_media(mock_backend, "unknown", MediaOptions()))
+    result = json.loads(
+        await handle_media(
+            mock_backend,
+            MediaOptions(
+                action="unknown",
+            ),
+        )
+    )
     assert "error" in result
     assert "Unknown action" in result["error"]
 
@@ -142,8 +149,8 @@ async def test_mode_error(mock_backend):
     result = json.loads(
         await handle_media(
             mock_backend,
-            "send_photo",
             MediaOptions(
+                action="send_photo",
                 chat_id=123,
                 file_path_or_url="https://example.com/photo.jpg",
             ),
@@ -158,7 +165,7 @@ async def test_general_exception(mock_backend):
     mock_backend.download_media.side_effect = RuntimeError("disk full")
     result = json.loads(
         await handle_media(
-            mock_backend, "download", MediaOptions(chat_id=123, message_id=10)
+            mock_backend, MediaOptions(action="download", chat_id=123, message_id=10)
         )
     )
     assert "error" in result


### PR DESCRIPTION
Refactored the core MCP tools (`message`, `chat`, `media`, `contact`) in `src/better_telegram_mcp/server.py` to use Pydantic `BaseModel` classes for parameter grouping. This simplifies the function signatures and makes them easier to maintain and use. All corresponding tool handlers and tests have been updated accordingly. Verified with 122 passing tests.

---
*PR created automatically by Jules for task [10242842903317672276](https://jules.google.com/task/10242842903317672276) started by @n24q02m*