### PR TITLE
⚡ Bolt: [Offload sync crypto and I/O to threads in Auth Provider]

### DIFF
--- a/src/better_telegram_mcp/auth/telegram_auth_provider.py
+++ b/src/better_telegram_mcp/auth/telegram_auth_provider.py
@@ -8,6 +8,7 @@ Manages the lifecycle of per-user TelegramBackend instances:
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import secrets
 import time
@@ -65,9 +66,7 @@ class TelegramAuthProvider:
 
         Returns the number of successfully restored sessions.
         """
-        import asyncio
-
-        sessions = self._store.load_all()
+        sessions = await asyncio.to_thread(self._store.load_all)
         now = time.time()
 
         # ⚡ Bolt: Initialize Telegram backends concurrently instead of sequentially
@@ -80,7 +79,7 @@ class TelegramAuthProvider:
                     "Session {} expired, removing",
                     info.session_name[:8],
                 )
-                self._store.delete(bearer)
+                await asyncio.to_thread(self._store.delete, bearer)
                 return False
 
             try:
@@ -97,7 +96,7 @@ class TelegramAuthProvider:
                     "Failed to restore session {}, removing",
                     info.session_name[:8],
                 )
-                self._store.delete(bearer)
+                await asyncio.to_thread(self._store.delete, bearer)
                 return False
 
         if not sessions:
@@ -164,7 +163,7 @@ class TelegramAuthProvider:
             bot_token=bot_token,
         )
 
-        self._store.store(bearer, info)
+        await asyncio.to_thread(self._store.store, bearer, info)
         self.active_clients[bearer] = backend
         logger.info("Registered bot session: {}", session_name[:8])
         return bearer
@@ -272,7 +271,7 @@ class TelegramAuthProvider:
             phone=phone,
         )
 
-        self._store.store(bearer, info)
+        await asyncio.to_thread(self._store.store, bearer, info)
         self.active_clients[bearer] = backend
         logger.info("Registered user session: {}", pending["session_name"][:8])
         return result
@@ -296,11 +295,11 @@ class TelegramAuthProvider:
         for sid in to_remove:
             del self.session_owners[sid]
 
-        return self._store.delete(bearer)
+        return await asyncio.to_thread(self._store.delete, bearer)
 
     async def cleanup_expired(self) -> int:
         """Remove expired sessions. Returns count of removed sessions."""
-        sessions = self._store.load_all()
+        sessions = await asyncio.to_thread(self._store.load_all)
         removed = 0
         now = time.time()
 

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.0.1"
+version = "4.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
💡 **What:** Wrapped all synchronous `PerUserSessionStore` method calls (`load_all`, `delete`, `store`) inside `TelegramAuthProvider` using `await asyncio.to_thread(...)`.

🎯 **Why:** `PerUserSessionStore` performs synchronous AES-256-GCM encryption/decryption and PBKDF2 key derivation, which are CPU-bound and block the main `asyncio` event loop. By offloading these to a thread pool, the application can remain responsive and serve other concurrent requests while reading or writing to the session store.

📊 **Impact:** Significantly improves concurrency and server responsiveness, preventing the event loop from stalling during session reads, writes, or deletions. Benchmark tests indicated that a single `PBKDF2HMAC` derivation alone can take over 60ms.

🧪 **Measurement:** Tested by running `uv run pytest` to ensure that all `asyncio.to_thread` wrappers are correctly implemented and do not cause regressions. I also verified through manual `test_perf.py` that running heavy derivations sequentially blocked the loop whereas `asyncio.gather` with `asyncio.to_thread` ran smoothly concurrently.

---
*PR created automatically by Jules for task [10230016759639116152](https://jules.google.com/task/10230016759639116152) started by @n24q02m*