### PR TITLE
🛡️ Sentinel: [HIGH] Fix Rate Limit Bypass via IP Spoofing

### DIFF
--- a/src/better_telegram_mcp/auth_server.py
+++ b/src/better_telegram_mcp/auth_server.py
@@ -228,11 +228,8 @@ class AuthServer:
         self.url: str = ""
 
     def _get_client_ip(self, request: Request) -> str:
-        """Extract client IP, respecting reverse proxy headers."""
-        if "cf-connecting-ip" in request.headers:
-            return request.headers["cf-connecting-ip"]
-        if "x-forwarded-for" in request.headers:
-            return request.headers["x-forwarded-for"].split(",")[0].strip()
+        """Extract client IP from the connection."""
+        # 🛡️ Sentinel: Prevent rate limit bypass by not blindly trusting proxy headers
         return request.client.host if request.client else "unknown"
 
     def _check_rate_limit(self, key: str) -> bool:

--- a/src/better_telegram_mcp/transports/http_multi_user.py
+++ b/src/better_telegram_mcp/transports/http_multi_user.py
@@ -53,12 +53,12 @@ def _check_rate_limit(ip: str, limit: int) -> bool:
 
 
 def _get_client_ip(request: Request) -> str:
-    """Safely extract client IP, respecting reverse proxies if headers are present."""
-    if "cf-connecting-ip" in request.headers:
-        return request.headers["cf-connecting-ip"]
-    if "x-forwarded-for" in request.headers:
-        # X-Forwarded-For can be a comma-separated list of IPs; the first is the client
-        return request.headers["x-forwarded-for"].split(",")[0].strip()
+    """Safely extract client IP from the connection.
+
+    🛡️ Sentinel: Do not blindly trust X-Forwarded-For or CF-Connecting-IP headers,
+    as they can be trivially spoofed by attackers to bypass rate limits.
+    If behind a proxy, configure ASGI server (e.g., uvicorn --proxy-headers) securely.
+    """
     return request.client.host if request.client else "unknown"
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.0.1"
+version = "4.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Rate limit bypass via IP spoofing. The `_get_client_ip` functions blindly trusted `cf-connecting-ip` and `x-forwarded-for` headers to determine the client's IP.
🎯 Impact: Attackers could trivially bypass rate limiting on sensitive endpoints (like authentication and OTP verification) by sending spoofed proxy headers containing random IP addresses, rendering rate limits ineffective and opening the door to brute-force attacks.
🔧 Fix: Removed manual parsing of proxy headers in `auth_server.py` and `http_multi_user.py`. The code now strictly relies on `request.client.host`. Reverse proxy trust must be configured at the ASGI layer (e.g., Uvicorn's `--proxy-headers`), which is the standard, secure practice.
✅ Verification: Ran `pytest` suite, formatters, linters, and type checkers. Verified that IP extraction logic uses only `request.client.host`.

---
*PR created automatically by Jules for task [10798220695682259528](https://jules.google.com/task/10798220695682259528) started by @n24q02m*