### PR TITLE
⚡ Bolt: Offload blocking I/O in TelegramAuthProvider

### DIFF
--- a/src/better_telegram_mcp/auth/telegram_auth_provider.py
+++ b/src/better_telegram_mcp/auth/telegram_auth_provider.py
@@ -8,6 +8,7 @@ Manages the lifecycle of per-user TelegramBackend instances:
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import secrets
 import time
@@ -65,9 +66,9 @@ class TelegramAuthProvider:
 
         Returns the number of successfully restored sessions.
         """
-        import asyncio
-
-        sessions = self._store.load_all()
+        # ⚡ Bolt: Offload synchronous I/O and crypto operations to a worker thread
+        # to prevent blocking the main asyncio event loop.
+        sessions = await asyncio.to_thread(self._store.load_all)
         now = time.time()
 
         # ⚡ Bolt: Initialize Telegram backends concurrently instead of sequentially
@@ -80,7 +81,9 @@ class TelegramAuthProvider:
                     "Session {} expired, removing",
                     info.session_name[:8],
                 )
-                self._store.delete(bearer)
+                # ⚡ Bolt: Offload deletion to prevent blocking
+                # ⚡ Bolt: Offload deletion to prevent blocking
+                await asyncio.to_thread(self._store.delete, bearer)
                 return False
 
             try:
@@ -97,7 +100,7 @@ class TelegramAuthProvider:
                     "Failed to restore session {}, removing",
                     info.session_name[:8],
                 )
-                self._store.delete(bearer)
+                await asyncio.to_thread(self._store.delete, bearer)
                 return False
 
         if not sessions:
@@ -164,7 +167,8 @@ class TelegramAuthProvider:
             bot_token=bot_token,
         )
 
-        self._store.store(bearer, info)
+        # ⚡ Bolt: Offload synchronous store I/O and crypto
+        await asyncio.to_thread(self._store.store, bearer, info)
         self.active_clients[bearer] = backend
         logger.info("Registered bot session: {}", session_name[:8])
         return bearer
@@ -272,7 +276,8 @@ class TelegramAuthProvider:
             phone=phone,
         )
 
-        self._store.store(bearer, info)
+        # ⚡ Bolt: Offload synchronous store I/O and crypto
+        await asyncio.to_thread(self._store.store, bearer, info)
         self.active_clients[bearer] = backend
         logger.info("Registered user session: {}", pending["session_name"][:8])
         return result
@@ -296,11 +301,13 @@ class TelegramAuthProvider:
         for sid in to_remove:
             del self.session_owners[sid]
 
-        return self._store.delete(bearer)
+        # ⚡ Bolt: Offload deletion to prevent blocking
+        return await asyncio.to_thread(self._store.delete, bearer)
 
     async def cleanup_expired(self) -> int:
         """Remove expired sessions. Returns count of removed sessions."""
-        sessions = self._store.load_all()
+        # ⚡ Bolt: Offload load_all I/O to prevent blocking
+        sessions = await asyncio.to_thread(self._store.load_all)
         removed = 0
         now = time.time()
 

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.0.1"
+version = "4.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
💡 What: Offloaded synchronous `PerUserSessionStore` operations (`load_all`, `store`, `delete`) inside `TelegramAuthProvider` to worker threads using `asyncio.to_thread`.
🎯 Why: These operations involve disk I/O and expensive cryptographic key derivation (`PBKDF2HMAC` with 100k iterations) and AES-GCM encryption/decryption. Executing them directly on the main thread blocked the `asyncio` event loop, causing poor responsiveness when multiple clients authenticated or when restoring many sessions during startup.
📊 Impact: Significantly improves concurrency and responsiveness of the HTTP multi-user auth server by preventing the event loop from stalling during I/O and crypto operations.
🔬 Measurement: Verify by running multiple concurrent authentications or startup loads, or by inspecting the code to ensure `asyncio.to_thread` is correctly applied to `self._store` calls in `telegram_auth_provider.py`.

---
*PR created automatically by Jules for task [12595561874016511368](https://jules.google.com/task/12595561874016511368) started by @n24q02m*