### PR TITLE
[TEST] Missing test for relay_setup _sanitize_error edge case

### DIFF
--- a/src/better_telegram_mcp/relay_setup.py
+++ b/src/better_telegram_mcp/relay_setup.py
@@ -36,6 +36,14 @@ ALL_POSSIBLE_FIELDS = [
 _CAUSED_BY_RE = re.compile(r"\s*\(caused by \w+\)\s*$", re.IGNORECASE)
 _ERROR_SIMPLIFICATIONS: list[tuple[re.Pattern[str], str]] = [
     (
+        re.compile(r".*PHONE_NUMBER_INVALID.*", re.IGNORECASE),
+        "Invalid phone number format",
+    ),
+    (
+        re.compile(r".*PHONE_CODE_INVALID.*", re.IGNORECASE),
+        "Invalid verification code",
+    ),
+    (
         re.compile(r".*password.*required.*", re.IGNORECASE),
         "Two-factor authentication password is required.",
     ),

--- a/tests/test_relay_setup.py
+++ b/tests/test_relay_setup.py
@@ -582,6 +582,12 @@ class TestSanitizeError:
     def test_passthrough_unknown_error(self):
         assert _sanitize_error("Some unknown error") == "Some unknown error"
 
+    def test_phone_number_invalid(self):
+        assert _sanitize_error("PHONE_NUMBER_INVALID") == "Invalid phone number format"
+
+    def test_phone_code_invalid_api(self):
+        assert _sanitize_error("PHONE_CODE_INVALID") == "Invalid verification code"
+
 
 # --- _needs_2fa_password ---
 

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.0.1"
+version = "4.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
This PR adds missing error sanitization patterns for `PHONE_NUMBER_INVALID` and `PHONE_CODE_INVALID` to `relay_setup.py` and corresponding unit tests in `test_relay_setup.py`.

💡 What: Added missing error sanitization patterns and their tests.
🎯 Why: To ensure robust and user-friendly error messages when Telegram API returns specific authentication errors during relay-based setup.
✅ Verification: Ran `uv run pytest tests/test_relay_setup.py` (54 passed). Verified coverage and consistency with `auth_server.py`.

---
*PR created automatically by Jules for task [8581068080088326895](https://jules.google.com/task/8581068080088326895) started by @n24q02m*