### PR TITLE
⚡ Bolt: [performance improvement] Offload cryptographic and I/O operations from main loop

### DIFF
--- a/src/better_telegram_mcp/auth/per_user_session_store.py
+++ b/src/better_telegram_mcp/auth/per_user_session_store.py
@@ -52,11 +52,14 @@ class PerUserSessionStore:
     """
 
     def __init__(self, data_dir: Path, secret: str | None = None) -> None:
+        import threading
+
         self._path = data_dir / "sessions.enc"
         self._secret = secret or os.environ.get("CREDENTIAL_SECRET", "")
         if not self._secret:
             self._secret = self._resolve_or_generate_secret(data_dir)
         self._cached_key: bytes | None = None
+        self._lock = threading.Lock()
 
     @staticmethod
     def _resolve_or_generate_secret(data_dir: Path) -> str:
@@ -119,9 +122,10 @@ class PerUserSessionStore:
 
     def _sync_store(self, bearer: str, info: SessionInfo) -> None:
         """Synchronous implementation of store."""
-        sessions = self._read_all()
-        sessions[bearer] = info.to_dict()
-        self._write_all(sessions)
+        with self._lock:
+            sessions = self._read_all()
+            sessions[bearer] = info.to_dict()
+            self._write_all(sessions)
 
     async def store(self, bearer: str, info: SessionInfo) -> None:
         """Store a session for the given bearer token."""
@@ -131,11 +135,12 @@ class PerUserSessionStore:
 
     def _sync_load(self, bearer: str) -> SessionInfo | None:
         """Synchronous implementation of load."""
-        sessions = self._read_all()
-        data = sessions.get(bearer)
-        if data is None:
-            return None
-        return SessionInfo.from_dict(data)
+        with self._lock:
+            sessions = self._read_all()
+            data = sessions.get(bearer)
+            if data is None:
+                return None
+            return SessionInfo.from_dict(data)
 
     async def load(self, bearer: str) -> SessionInfo | None:
         """Load session info for a bearer token. Returns None if not found."""
@@ -145,10 +150,11 @@ class PerUserSessionStore:
 
     def _sync_load_all(self) -> dict[str, SessionInfo]:
         """Synchronous implementation of load_all."""
-        sessions = self._read_all()
-        return {
-            bearer: SessionInfo.from_dict(data) for bearer, data in sessions.items()
-        }
+        with self._lock:
+            sessions = self._read_all()
+            return {
+                bearer: SessionInfo.from_dict(data) for bearer, data in sessions.items()
+            }
 
     async def load_all(self) -> dict[str, SessionInfo]:
         """Load all stored sessions."""
@@ -158,12 +164,13 @@ class PerUserSessionStore:
 
     def _sync_delete(self, bearer: str) -> bool:
         """Synchronous implementation of delete."""
-        sessions = self._read_all()
-        if bearer not in sessions:
-            return False
-        del sessions[bearer]
-        self._write_all(sessions)
-        return True
+        with self._lock:
+            sessions = self._read_all()
+            if bearer not in sessions:
+                return False
+            del sessions[bearer]
+            self._write_all(sessions)
+            return True
 
     async def delete(self, bearer: str) -> bool:
         """Delete a session. Returns True if it existed."""

--- a/src/better_telegram_mcp/auth/per_user_session_store.py
+++ b/src/better_telegram_mcp/auth/per_user_session_store.py
@@ -117,32 +117,56 @@ class PerUserSessionStore:
         except OSError:
             pass
 
-    def store(self, bearer: str, info: SessionInfo) -> None:
-        """Store a session for the given bearer token."""
+    def _sync_store(self, bearer: str, info: SessionInfo) -> None:
+        """Synchronous implementation of store."""
         sessions = self._read_all()
         sessions[bearer] = info.to_dict()
         self._write_all(sessions)
 
-    def load(self, bearer: str) -> SessionInfo | None:
-        """Load session info for a bearer token. Returns None if not found."""
+    async def store(self, bearer: str, info: SessionInfo) -> None:
+        """Store a session for the given bearer token."""
+        import asyncio
+
+        await asyncio.to_thread(self._sync_store, bearer, info)
+
+    def _sync_load(self, bearer: str) -> SessionInfo | None:
+        """Synchronous implementation of load."""
         sessions = self._read_all()
         data = sessions.get(bearer)
         if data is None:
             return None
         return SessionInfo.from_dict(data)
 
-    def load_all(self) -> dict[str, SessionInfo]:
-        """Load all stored sessions."""
+    async def load(self, bearer: str) -> SessionInfo | None:
+        """Load session info for a bearer token. Returns None if not found."""
+        import asyncio
+
+        return await asyncio.to_thread(self._sync_load, bearer)
+
+    def _sync_load_all(self) -> dict[str, SessionInfo]:
+        """Synchronous implementation of load_all."""
         sessions = self._read_all()
         return {
             bearer: SessionInfo.from_dict(data) for bearer, data in sessions.items()
         }
 
-    def delete(self, bearer: str) -> bool:
-        """Delete a session. Returns True if it existed."""
+    async def load_all(self) -> dict[str, SessionInfo]:
+        """Load all stored sessions."""
+        import asyncio
+
+        return await asyncio.to_thread(self._sync_load_all)
+
+    def _sync_delete(self, bearer: str) -> bool:
+        """Synchronous implementation of delete."""
         sessions = self._read_all()
         if bearer not in sessions:
             return False
         del sessions[bearer]
         self._write_all(sessions)
         return True
+
+    async def delete(self, bearer: str) -> bool:
+        """Delete a session. Returns True if it existed."""
+        import asyncio
+
+        return await asyncio.to_thread(self._sync_delete, bearer)

--- a/src/better_telegram_mcp/auth/telegram_auth_provider.py
+++ b/src/better_telegram_mcp/auth/telegram_auth_provider.py
@@ -67,7 +67,7 @@ class TelegramAuthProvider:
         """
         import asyncio
 
-        sessions = self._store.load_all()
+        sessions = await self._store.load_all()
         now = time.time()
 
         # ⚡ Bolt: Initialize Telegram backends concurrently instead of sequentially
@@ -80,7 +80,7 @@ class TelegramAuthProvider:
                     "Session {} expired, removing",
                     info.session_name[:8],
                 )
-                self._store.delete(bearer)
+                await self._store.delete(bearer)
                 return False
 
             try:
@@ -97,7 +97,7 @@ class TelegramAuthProvider:
                     "Failed to restore session {}, removing",
                     info.session_name[:8],
                 )
-                self._store.delete(bearer)
+                await self._store.delete(bearer)
                 return False
 
         if not sessions:
@@ -164,7 +164,7 @@ class TelegramAuthProvider:
             bot_token=bot_token,
         )
 
-        self._store.store(bearer, info)
+        await self._store.store(bearer, info)
         self.active_clients[bearer] = backend
         logger.info("Registered bot session: {}", session_name[:8])
         return bearer
@@ -272,7 +272,7 @@ class TelegramAuthProvider:
             phone=phone,
         )
 
-        self._store.store(bearer, info)
+        await self._store.store(bearer, info)
         self.active_clients[bearer] = backend
         logger.info("Registered user session: {}", pending["session_name"][:8])
         return result
@@ -296,11 +296,11 @@ class TelegramAuthProvider:
         for sid in to_remove:
             del self.session_owners[sid]
 
-        return self._store.delete(bearer)
+        return await self._store.delete(bearer)
 
     async def cleanup_expired(self) -> int:
         """Remove expired sessions. Returns count of removed sessions."""
-        sessions = self._store.load_all()
+        sessions = await self._store.load_all()
         removed = 0
         now = time.time()
 

--- a/src/better_telegram_mcp/transports/credential_store.py
+++ b/src/better_telegram_mcp/transports/credential_store.py
@@ -28,6 +28,8 @@ class CredentialStore:
     """
 
     def __init__(self, data_dir: Path, secret: str | None = None) -> None:
+        import threading
+
         self._path = data_dir / "credentials.enc"
         self._salt_path = data_dir / ".salt"
         self._secret = secret or os.environ.get("CREDENTIAL_SECRET", "")
@@ -36,6 +38,7 @@ class CredentialStore:
         self._salt = self._resolve_salt()
         # Cache derived key to avoid repeated 100k iteration PBKDF2 (~60ms) overhead
         self._cached_key: bytes | None = None
+        self._lock = threading.Lock()
 
     def _resolve_salt(self) -> bytes:
         """Load persisted salt, fallback to legacy, or generate new one."""
@@ -85,29 +88,30 @@ class CredentialStore:
 
     def _sync_store(self, credentials: dict[str, str]) -> None:
         """Synchronous implementation of store."""
-        self._path.parent.mkdir(parents=True, exist_ok=True)
+        with self._lock:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
 
-        # Migrate from legacy hardcoded salt to random salt on re-encryption
-        if self._salt == _LEGACY_SALT:
-            new_salt = os.urandom(16)
-            self._salt_path.write_bytes(new_salt)
+            # Migrate from legacy hardcoded salt to random salt on re-encryption
+            if self._salt == _LEGACY_SALT:
+                new_salt = os.urandom(16)
+                self._salt_path.write_bytes(new_salt)
+                try:
+                    self._salt_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+                except OSError:
+                    pass
+                self._salt = new_salt
+                self._cached_key = None  # Force re-derivation
+
+            key = self._derive_key()
+            aesgcm = AESGCM(key)
+            nonce = os.urandom(_NONCE_SIZE)
+            plaintext = json.dumps(credentials).encode()
+            ciphertext = aesgcm.encrypt(nonce, plaintext, None)
+            self._path.write_bytes(nonce + ciphertext)
             try:
-                self._salt_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+                self._path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0o600
             except OSError:
-                pass
-            self._salt = new_salt
-            self._cached_key = None  # Force re-derivation
-
-        key = self._derive_key()
-        aesgcm = AESGCM(key)
-        nonce = os.urandom(_NONCE_SIZE)
-        plaintext = json.dumps(credentials).encode()
-        ciphertext = aesgcm.encrypt(nonce, plaintext, None)
-        self._path.write_bytes(nonce + ciphertext)
-        try:
-            self._path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0o600
-        except OSError:
-            pass  # Windows may not support chmod
+                pass  # Windows may not support chmod
 
     async def store(self, credentials: dict[str, str]) -> None:
         """Encrypt and save credentials."""
@@ -117,14 +121,15 @@ class CredentialStore:
 
     def _sync_load(self) -> dict[str, str] | None:
         """Synchronous implementation of load."""
-        if not self._path.exists():
-            return None
-        key = self._derive_key()
-        data = self._path.read_bytes()
-        nonce, ciphertext = data[:_NONCE_SIZE], data[_NONCE_SIZE:]
-        aesgcm = AESGCM(key)
-        plaintext = aesgcm.decrypt(nonce, ciphertext, None)
-        return json.loads(plaintext)
+        with self._lock:
+            if not self._path.exists():
+                return None
+            key = self._derive_key()
+            data = self._path.read_bytes()
+            nonce, ciphertext = data[:_NONCE_SIZE], data[_NONCE_SIZE:]
+            aesgcm = AESGCM(key)
+            plaintext = aesgcm.decrypt(nonce, ciphertext, None)
+            return json.loads(plaintext)
 
     async def load(self) -> dict[str, str] | None:
         """Load and decrypt credentials. Returns None if not found."""
@@ -134,8 +139,9 @@ class CredentialStore:
 
     def _sync_delete(self) -> None:
         """Synchronous implementation of delete."""
-        if self._path.exists():
-            self._path.unlink()
+        with self._lock:
+            if self._path.exists():
+                self._path.unlink()
 
     async def delete(self) -> None:
         """Delete stored credentials."""

--- a/src/better_telegram_mcp/transports/credential_store.py
+++ b/src/better_telegram_mcp/transports/credential_store.py
@@ -83,8 +83,8 @@ class CredentialStore:
         self._cached_key = kdf.derive(self._secret.encode())
         return self._cached_key
 
-    def store(self, credentials: dict[str, str]) -> None:
-        """Encrypt and save credentials."""
+    def _sync_store(self, credentials: dict[str, str]) -> None:
+        """Synchronous implementation of store."""
         self._path.parent.mkdir(parents=True, exist_ok=True)
 
         # Migrate from legacy hardcoded salt to random salt on re-encryption
@@ -109,8 +109,14 @@ class CredentialStore:
         except OSError:
             pass  # Windows may not support chmod
 
-    def load(self) -> dict[str, str] | None:
-        """Load and decrypt credentials. Returns None if not found."""
+    async def store(self, credentials: dict[str, str]) -> None:
+        """Encrypt and save credentials."""
+        import asyncio
+
+        await asyncio.to_thread(self._sync_store, credentials)
+
+    def _sync_load(self) -> dict[str, str] | None:
+        """Synchronous implementation of load."""
         if not self._path.exists():
             return None
         key = self._derive_key()
@@ -120,7 +126,19 @@ class CredentialStore:
         plaintext = aesgcm.decrypt(nonce, ciphertext, None)
         return json.loads(plaintext)
 
-    def delete(self) -> None:
-        """Delete stored credentials."""
+    async def load(self) -> dict[str, str] | None:
+        """Load and decrypt credentials. Returns None if not found."""
+        import asyncio
+
+        return await asyncio.to_thread(self._sync_load)
+
+    def _sync_delete(self) -> None:
+        """Synchronous implementation of delete."""
         if self._path.exists():
             self._path.unlink()
+
+    async def delete(self) -> None:
+        """Delete stored credentials."""
+        import asyncio
+
+        await asyncio.to_thread(self._sync_delete)

--- a/src/better_telegram_mcp/transports/http.py
+++ b/src/better_telegram_mcp/transports/http.py
@@ -44,7 +44,7 @@ async def setup_credentials(settings: Settings) -> dict[str, str]:
         RuntimeError: If relay setup fails or times out.
     """
     store = CredentialStore(settings.data_dir)
-    creds = store.load()
+    creds = await store.load()
 
     if creds is not None:
         logger.info("Loaded stored credentials from {}", settings.data_dir)
@@ -75,7 +75,7 @@ async def setup_credentials(settings: Settings) -> dict[str, str]:
         msg = "Relay setup timed out or session expired"
         raise RuntimeError(msg) from exc
 
-    store.store(creds)
+    await store.store(creds)
     logger.info("Credentials stored successfully")
     return creds
 
@@ -108,16 +108,53 @@ def _start_single_user_http(settings: Settings) -> None:
     Backward compatible with the original HTTP transport.
     """
     import asyncio
+    import threading
 
     from ..server import mcp
 
     # If env vars already have credentials, skip CredentialStore/relay
     if not settings.is_configured:
         store = CredentialStore(settings.data_dir)
-        creds = store.load()
 
-        if creds is None:
-            creds = asyncio.run(setup_credentials(settings))
+        # Bridging async to sync safely
+        def _load_creds():
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                loop = None
+
+            if loop and loop.is_running():
+                # Loop already running, use dedicated thread
+                result = []
+
+                def _thread_worker():
+                    new_loop = asyncio.new_event_loop()
+                    asyncio.set_event_loop(new_loop)
+                    try:
+                        creds = new_loop.run_until_complete(store.load())
+                        if creds is None:
+                            creds = new_loop.run_until_complete(
+                                setup_credentials(settings)
+                            )
+                        result.append(creds)
+                    finally:
+                        new_loop.close()
+
+                t = threading.Thread(target=_thread_worker)
+                t.start()
+                t.join()
+                return result[0]
+            else:
+                # No running loop, safe to run directly
+                async def _get():
+                    creds = await store.load()
+                    if creds is None:
+                        creds = await setup_credentials(settings)
+                    return creds
+
+                return asyncio.run(_get())
+
+        creds = _load_creds()
 
         # Apply credentials to environment so lifespan picks them up
         for key, value in creds.items():

--- a/src/better_telegram_mcp/transports/http.py
+++ b/src/better_telegram_mcp/transports/http.py
@@ -108,7 +108,6 @@ def _start_single_user_http(settings: Settings) -> None:
     Backward compatible with the original HTTP transport.
     """
     import asyncio
-    import threading
 
     from ..server import mcp
 
@@ -116,45 +115,10 @@ def _start_single_user_http(settings: Settings) -> None:
     if not settings.is_configured:
         store = CredentialStore(settings.data_dir)
 
-        # Bridging async to sync safely
-        def _load_creds():
-            try:
-                loop = asyncio.get_running_loop()
-            except RuntimeError:
-                loop = None
+        creds = store._sync_load()
 
-            if loop and loop.is_running():
-                # Loop already running, use dedicated thread
-                result = []
-
-                def _thread_worker():
-                    new_loop = asyncio.new_event_loop()
-                    asyncio.set_event_loop(new_loop)
-                    try:
-                        creds = new_loop.run_until_complete(store.load())
-                        if creds is None:
-                            creds = new_loop.run_until_complete(
-                                setup_credentials(settings)
-                            )
-                        result.append(creds)
-                    finally:
-                        new_loop.close()
-
-                t = threading.Thread(target=_thread_worker)
-                t.start()
-                t.join()
-                return result[0]
-            else:
-                # No running loop, safe to run directly
-                async def _get():
-                    creds = await store.load()
-                    if creds is None:
-                        creds = await setup_credentials(settings)
-                    return creds
-
-                return asyncio.run(_get())
-
-        creds = _load_creds()
+        if creds is None:
+            creds = asyncio.run(setup_credentials(settings))
 
         # Apply credentials to environment so lifespan picks them up
         for key, value in creds.items():

--- a/tests/test_credential_store.py
+++ b/tests/test_credential_store.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+import pytest_asyncio
 from cryptography.exceptions import InvalidTag
 
 from better_telegram_mcp.transports.credential_store import CredentialStore
@@ -17,30 +18,31 @@ def data_dir(tmp_path: Path) -> Path:
     return d
 
 
+@pytest.mark.asyncio
 class TestCredentialStore:
-    def test_store_load_roundtrip(self, data_dir: Path) -> None:
+    async def test_store_load_roundtrip(self, data_dir: Path) -> None:
         """Credentials can be stored and loaded back correctly."""
         store = CredentialStore(data_dir, secret="test-secret")
         creds = {
             "TELEGRAM_BOT_TOKEN": "123456:ABC-DEF",
             "TELEGRAM_API_ID": "12345",
         }
-        store.store(creds)
-        loaded = store.load()
+        await store.store(creds)
+        loaded = await store.load()
         assert loaded == creds
 
-    def test_load_returns_none_when_no_file(self, data_dir: Path) -> None:
+    async def test_load_returns_none_when_no_file(self, data_dir: Path) -> None:
         """Loading from empty store returns None."""
         store = CredentialStore(data_dir, secret="test-secret")
-        assert store.load() is None
+        assert await store.load() is None
 
-    def test_different_secrets_produce_different_encryption(
+    async def test_different_secrets_produce_different_encryption(
         self, data_dir: Path
     ) -> None:
         """Different secrets should not decrypt each other's data."""
         store1 = CredentialStore(data_dir, secret="secret-one")
         creds = {"TELEGRAM_BOT_TOKEN": "token123"}
-        store1.store(creds)
+        await store1.store(creds)
 
         # Read raw encrypted bytes
         enc_path = data_dir / "credentials.enc"
@@ -49,43 +51,43 @@ class TestCredentialStore:
         # Try to decrypt with different secret -- should fail
         store2 = CredentialStore(data_dir, secret="secret-two")
         with pytest.raises(InvalidTag):
-            store2.load()
+            await store2.load()
 
         # Original secret still works
         store1_again = CredentialStore(data_dir, secret="secret-one")
-        assert store1_again.load() == creds
+        assert await store1_again.load() == creds
 
         # Verify the encrypted file is still the same (not corrupted by failed load)
         assert enc_path.read_bytes() == encrypted_data
 
-    def test_delete_removes_file(self, data_dir: Path) -> None:
+    async def test_delete_removes_file(self, data_dir: Path) -> None:
         """Delete should remove the credentials file."""
         store = CredentialStore(data_dir, secret="test-secret")
         creds = {"TELEGRAM_BOT_TOKEN": "token123"}
-        store.store(creds)
+        await store.store(creds)
 
         enc_path = data_dir / "credentials.enc"
         assert enc_path.exists()
 
-        store.delete()
+        await store.delete()
         assert not enc_path.exists()
 
-    def test_delete_noop_when_no_file(self, data_dir: Path) -> None:
+    async def test_delete_noop_when_no_file(self, data_dir: Path) -> None:
         """Delete should not raise when no file exists."""
         store = CredentialStore(data_dir, secret="test-secret")
-        store.delete()  # Should not raise
+        await store.delete()  # Should not raise
 
-    def test_auto_generated_secret_persists(self, data_dir: Path) -> None:
+    async def test_auto_generated_secret_persists(self, data_dir: Path) -> None:
         """Auto-generated secret should be saved and reused across instances."""
         store1 = CredentialStore(data_dir)
         creds = {"TELEGRAM_BOT_TOKEN": "token123"}
-        store1.store(creds)
+        await store1.store(creds)
 
         # New instance should auto-load the persisted secret
         store2 = CredentialStore(data_dir)
-        assert store2.load() == creds
+        assert await store2.load() == creds
 
-    def test_auto_generated_secret_file_created(self, data_dir: Path) -> None:
+    async def test_auto_generated_secret_file_created(self, data_dir: Path) -> None:
         """Secret file should be created when no secret is provided."""
         CredentialStore(data_dir)
         secret_path = data_dir / ".secret"
@@ -93,47 +95,47 @@ class TestCredentialStore:
         secret = secret_path.read_text().strip()
         assert len(secret) == 64  # 32 bytes hex-encoded
 
-    def test_env_var_secret_takes_precedence(
+    async def test_env_var_secret_takes_precedence(
         self, data_dir: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """CREDENTIAL_SECRET env var should be used when set."""
         monkeypatch.setenv("CREDENTIAL_SECRET", "env-secret")
         store = CredentialStore(data_dir)
         creds = {"TELEGRAM_BOT_TOKEN": "token123"}
-        store.store(creds)
+        await store.store(creds)
 
         # Should load with same env var
         store2 = CredentialStore(data_dir)
-        assert store2.load() == creds
+        assert await store2.load() == creds
 
         # Should not load without env var (different auto-generated secret)
         monkeypatch.delenv("CREDENTIAL_SECRET")
         store3 = CredentialStore(data_dir)
         # Auto-generated secret is different from "env-secret"
         with pytest.raises(InvalidTag):
-            store3.load()
+            await store3.load()
 
-    def test_store_overwrites_existing(self, data_dir: Path) -> None:
+    async def test_store_overwrites_existing(self, data_dir: Path) -> None:
         """Storing new credentials should overwrite old ones."""
         store = CredentialStore(data_dir, secret="test-secret")
-        store.store({"TELEGRAM_BOT_TOKEN": "old-token"})
-        store.store({"TELEGRAM_BOT_TOKEN": "new-token"})
-        assert store.load() == {"TELEGRAM_BOT_TOKEN": "new-token"}
+        await store.store({"TELEGRAM_BOT_TOKEN": "old-token"})
+        await store.store({"TELEGRAM_BOT_TOKEN": "new-token"})
+        assert await store.load() == {"TELEGRAM_BOT_TOKEN": "new-token"}
 
-    def test_empty_credentials(self, data_dir: Path) -> None:
+    async def test_empty_credentials(self, data_dir: Path) -> None:
         """Empty dict should be storable and loadable."""
         store = CredentialStore(data_dir, secret="test-secret")
-        store.store({})
-        assert store.load() == {}
+        await store.store({})
+        assert await store.load() == {}
 
-    def test_data_dir_created_if_missing(self, tmp_path: Path) -> None:
+    async def test_data_dir_created_if_missing(self, tmp_path: Path) -> None:
         """Store should create data_dir if it does not exist."""
         nested = tmp_path / "a" / "b" / "c"
         store = CredentialStore(nested, secret="test-secret")
-        store.store({"key": "value"})
-        assert store.load() == {"key": "value"}
+        await store.store({"key": "value"})
+        assert await store.load() == {"key": "value"}
 
-    def test_legacy_salt_migration(self, data_dir: Path) -> None:
+    async def test_legacy_salt_migration(self, data_dir: Path) -> None:
         """Credentials stored with legacy hardcoded salt should be loadable,
         and re-storing should migrate to a random salt."""
         from better_telegram_mcp.transports.credential_store import _LEGACY_SALT
@@ -166,20 +168,20 @@ class TestCredentialStore:
         # Create new store -- should detect legacy salt (creds exist, no .salt)
         store2 = CredentialStore(data_dir, secret="test-secret")
         assert store2._salt == _LEGACY_SALT
-        loaded = store2.load()
+        loaded = await store2.load()
         assert loaded == creds
 
         # Re-store should trigger salt migration
-        store2.store(creds)
+        await store2.store(creds)
         assert store2._salt != _LEGACY_SALT
         assert salt_path.exists()
 
         # New store should use the migrated salt
         store3 = CredentialStore(data_dir, secret="test-secret")
         assert store3._salt != _LEGACY_SALT
-        assert store3.load() == creds
+        assert await store3.load() == creds
 
-    def test_random_salt_for_new_install(self, data_dir: Path) -> None:
+    async def test_random_salt_for_new_install(self, data_dir: Path) -> None:
         """New installation should generate random salt, not use legacy."""
         from better_telegram_mcp.transports.credential_store import _LEGACY_SALT
 
@@ -189,7 +191,7 @@ class TestCredentialStore:
         assert salt_path.exists()
         assert len(store._salt) == 16
 
-    def test_chmod_failure_swallowed(
+    async def test_chmod_failure_swallowed(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         """Test that OSError during chmod is silently ignored."""
@@ -201,4 +203,4 @@ class TestCredentialStore:
 
         store = CredentialStore(tmp_path)
         # Store writing triggers credential chmod
-        store.store({"api_id": "123"})
+        await store.store({"api_id": "123"})

--- a/tests/test_credential_store.py
+++ b/tests/test_credential_store.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-import pytest_asyncio
 from cryptography.exceptions import InvalidTag
 
 from better_telegram_mcp.transports.credential_store import CredentialStore

--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -31,7 +31,7 @@ class TestSetupCredentials:
         """Should return stored credentials without hitting relay."""
         store = CredentialStore(data_dir, secret="test")
         expected = {"TELEGRAM_BOT_TOKEN": "stored-token"}
-        store.store(expected)
+        await store.store(expected)
 
         # Patch env so CredentialStore inside setup_credentials uses same secret
         with patch.dict("os.environ", {"CREDENTIAL_SECRET": "test"}):
@@ -118,16 +118,16 @@ class TestSetupCredentials:
 
         # Verify credentials were persisted
         store = CredentialStore(data_dir)
-        assert store.load() == expected_creds
+        assert await store.load() == expected_creds
 
 
 class TestStartHttp:
-    def test_start_http_with_stored_credentials(
+    async def test_start_http_with_stored_credentials(
         self, settings: Settings, data_dir: Path
     ) -> None:
         """start_http should load stored creds and run mcp with streamable-http."""
         store = CredentialStore(data_dir, secret="test")
-        store.store({"TELEGRAM_BOT_TOKEN": "stored-token"})
+        await store.store({"TELEGRAM_BOT_TOKEN": "stored-token"})
 
         with (
             patch.dict("os.environ", {"CREDENTIAL_SECRET": "test"}),
@@ -139,7 +139,9 @@ class TestStartHttp:
 
         mock_mcp.run.assert_called_once_with(transport="streamable-http")
 
-    def test_start_http_sets_env_vars(self, settings: Settings, data_dir: Path) -> None:
+    async def test_start_http_sets_env_vars(
+        self, settings: Settings, data_dir: Path
+    ) -> None:
         """start_http should set TELEGRAM_ env vars from stored credentials."""
         import os
 
@@ -148,7 +150,7 @@ class TestStartHttp:
             "TELEGRAM_BOT_TOKEN": "env-token-123",
             "TELEGRAM_API_ID": "99999",
         }
-        store.store(creds)
+        await store.store(creds)
 
         with (
             patch.dict(

--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -24,6 +24,7 @@ def settings(data_dir: Path) -> Settings:
     return Settings(data_dir=data_dir)
 
 
+@pytest.mark.asyncio
 class TestSetupCredentials:
     async def test_loads_stored_credentials(
         self, settings: Settings, data_dir: Path
@@ -121,6 +122,7 @@ class TestSetupCredentials:
         assert await store.load() == expected_creds
 
 
+@pytest.mark.asyncio
 class TestStartHttp:
     async def test_start_http_with_stored_credentials(
         self, settings: Settings, data_dir: Path

--- a/tests/test_per_user_session_store.py
+++ b/tests/test_per_user_session_store.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+import pytest_asyncio
 from cryptography.exceptions import InvalidTag
 
 from better_telegram_mcp.auth.per_user_session_store import (
@@ -25,8 +26,9 @@ def store(data_dir: Path) -> PerUserSessionStore:
     return PerUserSessionStore(data_dir, secret="test-secret")
 
 
+@pytest.mark.asyncio
 class TestSessionInfo:
-    def test_to_dict_roundtrip(self) -> None:
+    async def test_to_dict_roundtrip(self) -> None:
         """SessionInfo should serialize and deserialize correctly."""
         info = SessionInfo(
             session_name="test",
@@ -44,7 +46,7 @@ class TestSessionInfo:
         assert restored.api_id is None
         assert restored.phone is None
 
-    def test_user_mode_fields(self) -> None:
+    async def test_user_mode_fields(self) -> None:
         """User mode SessionInfo should preserve all fields."""
         info = SessionInfo(
             session_name="user123",
@@ -62,49 +64,54 @@ class TestSessionInfo:
         assert restored.phone == "+84912345678"
         assert restored.bot_token is None
 
-    def test_created_at_default(self) -> None:
+    async def test_created_at_default(self) -> None:
         """created_at should default to current time."""
         info = SessionInfo(session_name="test", mode="bot")
         assert info.created_at > 0
 
 
+@pytest.mark.asyncio
 class TestPerUserSessionStore:
-    def test_store_load_roundtrip(self, store: PerUserSessionStore) -> None:
+    async def test_store_load_roundtrip(self, store: PerUserSessionStore) -> None:
         """Session can be stored and loaded back correctly."""
         info = SessionInfo(
             session_name="test",
             mode="bot",
             bot_token="123:ABC",
         )
-        store.store("bearer-token-1", info)
-        loaded = store.load("bearer-token-1")
+        await store.store("bearer-token-1", info)
+        loaded = await store.load("bearer-token-1")
 
         assert loaded is not None
         assert loaded.session_name == "test"
         assert loaded.mode == "bot"
         assert loaded.bot_token == "123:ABC"
 
-    def test_load_returns_none_for_unknown(self, store: PerUserSessionStore) -> None:
+    async def test_load_returns_none_for_unknown(
+        self, store: PerUserSessionStore
+    ) -> None:
         """Loading unknown bearer should return None."""
-        assert store.load("nonexistent") is None
+        assert await store.load("nonexistent") is None
 
-    def test_load_returns_none_when_empty(self, store: PerUserSessionStore) -> None:
+    async def test_load_returns_none_when_empty(
+        self, store: PerUserSessionStore
+    ) -> None:
         """Loading from empty store should return None."""
-        assert store.load("any-bearer") is None
+        assert await store.load("any-bearer") is None
 
-    def test_store_multiple_sessions(self, store: PerUserSessionStore) -> None:
+    async def test_store_multiple_sessions(self, store: PerUserSessionStore) -> None:
         """Multiple sessions can coexist."""
-        store.store(
+        await store.store(
             "bearer-1",
             SessionInfo(session_name="s1", mode="bot", bot_token="t1"),
         )
-        store.store(
+        await store.store(
             "bearer-2",
             SessionInfo(session_name="s2", mode="user", api_id=1, api_hash="h"),
         )
 
-        s1 = store.load("bearer-1")
-        s2 = store.load("bearer-2")
+        s1 = await store.load("bearer-1")
+        s2 = await store.load("bearer-2")
 
         assert s1 is not None
         assert s1.session_name == "s1"
@@ -114,105 +121,127 @@ class TestPerUserSessionStore:
         assert s2.session_name == "s2"
         assert s2.mode == "user"
 
-    def test_load_all(self, store: PerUserSessionStore) -> None:
+    async def test_load_all(self, store: PerUserSessionStore) -> None:
         """load_all should return all stored sessions."""
-        store.store("b1", SessionInfo(session_name="s1", mode="bot", bot_token="t1"))
-        store.store("b2", SessionInfo(session_name="s2", mode="bot", bot_token="t2"))
+        await store.store(
+            "b1", SessionInfo(session_name="s1", mode="bot", bot_token="t1")
+        )
+        await store.store(
+            "b2", SessionInfo(session_name="s2", mode="bot", bot_token="t2")
+        )
 
-        all_sessions = store.load_all()
+        all_sessions = await store.load_all()
         assert len(all_sessions) == 2
         assert "b1" in all_sessions
         assert "b2" in all_sessions
         assert all_sessions["b1"].session_name == "s1"
         assert all_sessions["b2"].session_name == "s2"
 
-    def test_load_all_empty(self, store: PerUserSessionStore) -> None:
+    async def test_load_all_empty(self, store: PerUserSessionStore) -> None:
         """load_all on empty store should return empty dict."""
-        assert store.load_all() == {}
+        assert await store.load_all() == {}
 
-    def test_delete_existing(self, store: PerUserSessionStore) -> None:
+    async def test_delete_existing(self, store: PerUserSessionStore) -> None:
         """Delete should remove session and return True."""
-        store.store(
+        await store.store(
             "bearer-1",
             SessionInfo(session_name="s1", mode="bot", bot_token="t1"),
         )
-        assert store.delete("bearer-1") is True
-        assert store.load("bearer-1") is None
+        assert await store.delete("bearer-1") is True
+        assert await store.load("bearer-1") is None
 
-    def test_delete_nonexistent(self, store: PerUserSessionStore) -> None:
+    async def test_delete_nonexistent(self, store: PerUserSessionStore) -> None:
         """Delete of nonexistent bearer should return False."""
-        assert store.delete("nonexistent") is False
+        assert await store.delete("nonexistent") is False
 
-    def test_delete_preserves_others(self, store: PerUserSessionStore) -> None:
+    async def test_delete_preserves_others(self, store: PerUserSessionStore) -> None:
         """Deleting one session should not affect others."""
-        store.store("b1", SessionInfo(session_name="s1", mode="bot", bot_token="t1"))
-        store.store("b2", SessionInfo(session_name="s2", mode="bot", bot_token="t2"))
+        await store.store(
+            "b1", SessionInfo(session_name="s1", mode="bot", bot_token="t1")
+        )
+        await store.store(
+            "b2", SessionInfo(session_name="s2", mode="bot", bot_token="t2")
+        )
 
-        store.delete("b1")
+        await store.delete("b1")
 
-        assert store.load("b1") is None
-        loaded = store.load("b2")
+        assert await store.load("b1") is None
+        loaded = await store.load("b2")
         assert loaded is not None
         assert loaded.session_name == "s2"
 
-    def test_overwrite_existing_session(self, store: PerUserSessionStore) -> None:
+    async def test_overwrite_existing_session(self, store: PerUserSessionStore) -> None:
         """Storing with same bearer should overwrite."""
-        store.store("b1", SessionInfo(session_name="s1", mode="bot", bot_token="old"))
-        store.store("b1", SessionInfo(session_name="s1", mode="bot", bot_token="new"))
+        await store.store(
+            "b1", SessionInfo(session_name="s1", mode="bot", bot_token="old")
+        )
+        await store.store(
+            "b1", SessionInfo(session_name="s1", mode="bot", bot_token="new")
+        )
 
-        loaded = store.load("b1")
+        loaded = await store.load("b1")
         assert loaded is not None
         assert loaded.bot_token == "new"
 
-    def test_encryption_different_secrets(self, data_dir: Path) -> None:
+    async def test_encryption_different_secrets(self, data_dir: Path) -> None:
         """Different secrets should not decrypt each other's data."""
         store1 = PerUserSessionStore(data_dir, secret="secret-one")
-        store1.store("b1", SessionInfo(session_name="s1", mode="bot", bot_token="t1"))
+        await store1.store(
+            "b1", SessionInfo(session_name="s1", mode="bot", bot_token="t1")
+        )
 
         store2 = PerUserSessionStore(data_dir, secret="secret-two")
         with pytest.raises(InvalidTag):
-            store2.load_all()
+            await store2.load_all()
 
-    def test_persistence_across_instances(self, data_dir: Path) -> None:
+    async def test_persistence_across_instances(self, data_dir: Path) -> None:
         """Sessions should persist across store instances with same secret."""
         store1 = PerUserSessionStore(data_dir, secret="shared-secret")
-        store1.store("b1", SessionInfo(session_name="s1", mode="bot", bot_token="t1"))
+        await store1.store(
+            "b1", SessionInfo(session_name="s1", mode="bot", bot_token="t1")
+        )
 
         store2 = PerUserSessionStore(data_dir, secret="shared-secret")
-        loaded = store2.load("b1")
+        loaded = await store2.load("b1")
         assert loaded is not None
         assert loaded.bot_token == "t1"
 
-    def test_auto_generated_secret_persists(self, data_dir: Path) -> None:
+    async def test_auto_generated_secret_persists(self, data_dir: Path) -> None:
         """Auto-generated secret should be reusable across instances."""
         store1 = PerUserSessionStore(data_dir)
-        store1.store("b1", SessionInfo(session_name="s1", mode="bot", bot_token="t1"))
+        await store1.store(
+            "b1", SessionInfo(session_name="s1", mode="bot", bot_token="t1")
+        )
 
         store2 = PerUserSessionStore(data_dir)
-        loaded = store2.load("b1")
+        loaded = await store2.load("b1")
         assert loaded is not None
         assert loaded.bot_token == "t1"
 
-    def test_data_dir_created_if_missing(self, tmp_path: Path) -> None:
+    async def test_data_dir_created_if_missing(self, tmp_path: Path) -> None:
         """Store should create data_dir if it does not exist."""
         nested = tmp_path / "a" / "b" / "c"
         store = PerUserSessionStore(nested, secret="test")
-        store.store("b1", SessionInfo(session_name="s1", mode="bot", bot_token="t1"))
-        assert store.load("b1") is not None
+        await store.store(
+            "b1", SessionInfo(session_name="s1", mode="bot", bot_token="t1")
+        )
+        assert await store.load("b1") is not None
 
-    def test_env_var_secret(
+    async def test_env_var_secret(
         self, data_dir: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """CREDENTIAL_SECRET env var should be used when set."""
         monkeypatch.setenv("CREDENTIAL_SECRET", "env-secret")
         store = PerUserSessionStore(data_dir)
-        store.store("b1", SessionInfo(session_name="s1", mode="bot", bot_token="t1"))
+        await store.store(
+            "b1", SessionInfo(session_name="s1", mode="bot", bot_token="t1")
+        )
 
         store2 = PerUserSessionStore(data_dir)
-        assert store2.load("b1") is not None
+        assert await store2.load("b1") is not None
 
         # Different env var should fail
         monkeypatch.setenv("CREDENTIAL_SECRET", "different-env-secret")
         store3 = PerUserSessionStore(data_dir)
         with pytest.raises(InvalidTag):
-            store3.load_all()
+            await store3.load_all()

--- a/tests/test_per_user_session_store.py
+++ b/tests/test_per_user_session_store.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-import pytest_asyncio
 from cryptography.exceptions import InvalidTag
 
 from better_telegram_mcp.auth.per_user_session_store import (

--- a/tests/test_telegram_auth_provider.py
+++ b/tests/test_telegram_auth_provider.py
@@ -81,7 +81,7 @@ class TestRegisterBot:
 
             bearer = await provider.register_bot("", "123:ABC")
 
-        info = provider._store.load(bearer)
+        info = await provider._store.load(bearer)
         assert info is not None
         assert info.mode == "bot"
         assert info.bot_token == "123:ABC"
@@ -309,7 +309,7 @@ class TestRestoreSessions:
     async def test_restore_bot_sessions(self, provider: TelegramAuthProvider) -> None:
         """Should restore bot sessions from store on startup."""
         # Store a session directly
-        provider._store.store(
+        await provider._store.store(
             "stored-bearer",
             SessionInfo(
                 session_name="test",
@@ -334,7 +334,7 @@ class TestRestoreSessions:
         self, provider: TelegramAuthProvider
     ) -> None:
         """Should remove expired sessions during restore."""
-        provider._store.store(
+        await provider._store.store(
             "expired-bearer",
             SessionInfo(
                 session_name="old",
@@ -352,7 +352,7 @@ class TestRestoreSessions:
         self, provider: TelegramAuthProvider
     ) -> None:
         """Should remove sessions that fail to reconnect."""
-        provider._store.store(
+        await provider._store.store(
             "broken-bearer",
             SessionInfo(
                 session_name="broken",
@@ -373,7 +373,7 @@ class TestRestoreSessions:
             restored = await provider.restore_sessions()
 
         assert restored == 0
-        assert provider._store.load("broken-bearer") is None
+        assert await provider._store.load("broken-bearer") is None
 
 
 class TestCleanupExpired:
@@ -382,7 +382,7 @@ class TestCleanupExpired:
     ) -> None:
         """Should remove expired sessions."""
         # Store an expired session
-        provider._store.store(
+        await provider._store.store(
             "expired",
             SessionInfo(
                 session_name="old",
@@ -392,7 +392,7 @@ class TestCleanupExpired:
             ),
         )
         # Store a valid session
-        provider._store.store(
+        await provider._store.store(
             "valid",
             SessionInfo(
                 session_name="new",
@@ -404,8 +404,8 @@ class TestCleanupExpired:
 
         removed = await provider.cleanup_expired()
         assert removed == 1
-        assert provider._store.load("expired") is None
-        assert provider._store.load("valid") is not None
+        assert await provider._store.load("expired") is None
+        assert await provider._store.load("valid") is not None
 
     async def test_cleanup_stale_otps(self, provider: TelegramAuthProvider) -> None:
         """Should clean up pending OTPs older than 5 minutes."""

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.1.0"
+version = "4.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
💡 **What**:
Converted the synchronous `store`, `load`, and `delete` methods in `CredentialStore` and `PerUserSessionStore` to `async` methods that utilize `await asyncio.to_thread` to execute the underlying synchronous logic in a separate thread. Refactored consumers (`telegram_auth_provider.py`, `transports/http.py`) and updated tests.

🎯 **Why**:
Cryptographic operations like PBKDF2 with 100k iterations and AES-GCM, along with synchronous file I/O, block the main asyncio event loop. In an asynchronous MCP server, this degrades responsiveness and throughput, especially in multi-user environments handling multiple session operations concurrently.

📊 **Impact**:
Eliminates event loop blockage during authentication persistence and retrieval. Increases concurrency and overall throughput for the MCP HTTP server, avoiding stalls in background polling loops and request handling.

🔬 **Measurement**:
The server can now handle multiple concurrent backend setups without one user's file writing or PBKDF2 calculation delaying another's HTTP response. Test coverage proves no regressions in core logic or persistence capabilities.

---
*PR created automatically by Jules for task [16434254171153554686](https://jules.google.com/task/16434254171153554686) started by @n24q02m*