### PR TITLE
⚡ Bolt: [Cache Decrypted PerUser Sessions]

### DIFF
--- a/src/better_telegram_mcp/auth/per_user_session_store.py
+++ b/src/better_telegram_mcp/auth/per_user_session_store.py
@@ -7,6 +7,7 @@ Reuses the key derivation pattern from transports/credential_store.py.
 
 from __future__ import annotations
 
+import copy
 import json
 import os
 import stat
@@ -59,6 +60,7 @@ class PerUserSessionStore:
         self._salt_path = data_dir / ".session-salt"
         self._salt = self._resolve_salt()
         self._cached_key: bytes | None = None
+        self._cached_sessions: dict[str, dict] | None = None
 
     def _resolve_salt(self) -> bytes:
         """Load persisted salt, fallback to legacy, or generate new one."""
@@ -118,11 +120,16 @@ class PerUserSessionStore:
 
     def _read_all(self) -> dict[str, dict]:
         """Read and decrypt all sessions from disk."""
+        if self._cached_sessions is not None:
+            return copy.deepcopy(self._cached_sessions)
+
         if not self._path.exists():
+            self._cached_sessions = {}
             return {}
         raw = self._path.read_bytes()
         plaintext = self._decrypt(raw)
-        return json.loads(plaintext)
+        self._cached_sessions = json.loads(plaintext)
+        return copy.deepcopy(self._cached_sessions)
 
     def _write_all(self, sessions: dict[str, dict]) -> None:
         """Encrypt and write all sessions to disk."""
@@ -136,6 +143,7 @@ class PerUserSessionStore:
         plaintext = json.dumps(sessions).encode()
         encrypted = self._encrypt(plaintext)
         self._path.write_bytes(encrypted)
+        self._cached_sessions = copy.deepcopy(sessions)
         try:
             self._path.chmod(stat.S_IRUSR | stat.S_IWUSR)
         except OSError:

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.3.0"
+version = "4.3.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.3.0b1"
+version = "4.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
💡 **What:** Added an in-memory `_cached_sessions` dictionary to `PerUserSessionStore`. File reads and decryptions are only done once when missing from cache. Cache results are cloned via `copy.deepcopy()` to prevent shallow mutation bugs by the caller. Writes update both the encrypted file and the cache.

🎯 **Why:** In multi-user modes where `PerUserSessionStore` handles all active sessions, repeated reads invoke blocking disk I/O, heavy `AESGCM.decrypt`, and `json.loads` operations. This caused a huge bottleneck on busy relays and unnecessary CPU burn.

📊 **Impact:** Reduces disk I/O and CPU-intensive AES-GCM decryptions from $O(N)$ (where N is the number of active HTTP requests looking up a session) to $O(1)$ per class instance.

🔬 **Measurement:** Can be verified by running relay performance benchmarks (e.g. Locust or artillery) with concurrent multi-user HTTP requests and observing the drop in CPU utilization and latency for session load times.

---
*PR created automatically by Jules for task [12524665684322230396](https://jules.google.com/task/12524665684322230396) started by @n24q02m*