### PR TITLE
⚡ Bolt: Add in-memory caching to credential and session stores

### DIFF
--- a/src/better_telegram_mcp/auth/per_user_session_store.py
+++ b/src/better_telegram_mcp/auth/per_user_session_store.py
@@ -7,11 +7,11 @@ Reuses the key derivation pattern from transports/credential_store.py.
 
 from __future__ import annotations
 
+import copy
 import json
 import os
 import stat
 import time
-import copy
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Literal

--- a/src/better_telegram_mcp/auth/per_user_session_store.py
+++ b/src/better_telegram_mcp/auth/per_user_session_store.py
@@ -11,6 +11,7 @@ import json
 import os
 import stat
 import time
+import copy
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Literal
@@ -59,6 +60,7 @@ class PerUserSessionStore:
         self._salt_path = data_dir / ".session-salt"
         self._salt = self._resolve_salt()
         self._cached_key: bytes | None = None
+        self._cached_sessions: dict[str, dict] | None = None
 
     def _resolve_salt(self) -> bytes:
         """Load persisted salt, fallback to legacy, or generate new one."""
@@ -118,11 +120,14 @@ class PerUserSessionStore:
 
     def _read_all(self) -> dict[str, dict]:
         """Read and decrypt all sessions from disk."""
+        if self._cached_sessions is not None:
+            return copy.deepcopy(self._cached_sessions)
         if not self._path.exists():
             return {}
         raw = self._path.read_bytes()
         plaintext = self._decrypt(raw)
-        return json.loads(plaintext)
+        self._cached_sessions = json.loads(plaintext)
+        return copy.deepcopy(self._cached_sessions)
 
     def _write_all(self, sessions: dict[str, dict]) -> None:
         """Encrypt and write all sessions to disk."""
@@ -133,6 +138,7 @@ class PerUserSessionStore:
             self._salt = new_salt
             self._cached_key = None  # Invalidate cached key
         self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._cached_sessions = copy.deepcopy(sessions)
         plaintext = json.dumps(sessions).encode()
         encrypted = self._encrypt(plaintext)
         self._path.write_bytes(encrypted)

--- a/src/better_telegram_mcp/transports/credential_store.py
+++ b/src/better_telegram_mcp/transports/credential_store.py
@@ -6,6 +6,7 @@ Key derived from server secret (CREDENTIAL_SECRET env var or auto-generated).
 
 from __future__ import annotations
 
+import copy
 import json
 import os
 import stat
@@ -36,6 +37,7 @@ class CredentialStore:
         self._salt = self._resolve_salt()
         # Cache derived key to avoid repeated 100k iteration PBKDF2 (~60ms) overhead
         self._cached_key: bytes | None = None
+        self._cached_credentials: dict[str, str] | None = None
 
     def _resolve_salt(self) -> bytes:
         """Load persisted salt, fallback to legacy, or generate new one."""
@@ -103,6 +105,7 @@ class CredentialStore:
         nonce = os.urandom(_NONCE_SIZE)
         plaintext = json.dumps(credentials).encode()
         ciphertext = aesgcm.encrypt(nonce, plaintext, None)
+        self._cached_credentials = copy.deepcopy(credentials)
         self._path.write_bytes(nonce + ciphertext)
         try:
             self._path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0o600
@@ -111,6 +114,8 @@ class CredentialStore:
 
     def load(self) -> dict[str, str] | None:
         """Load and decrypt credentials. Returns None if not found."""
+        if self._cached_credentials is not None:
+            return copy.deepcopy(self._cached_credentials)
         if not self._path.exists():
             return None
         key = self._derive_key()
@@ -118,9 +123,11 @@ class CredentialStore:
         nonce, ciphertext = data[:_NONCE_SIZE], data[_NONCE_SIZE:]
         aesgcm = AESGCM(key)
         plaintext = aesgcm.decrypt(nonce, ciphertext, None)
-        return json.loads(plaintext)
+        self._cached_credentials = json.loads(plaintext)
+        return copy.deepcopy(self._cached_credentials)
 
     def delete(self) -> None:
         """Delete stored credentials."""
+        self._cached_credentials = None
         if self._path.exists():
             self._path.unlink()

--- a/tests/test_credential_store.py
+++ b/tests/test_credential_store.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 from cryptography.exceptions import InvalidTag
+from unittest.mock import patch
 
 from better_telegram_mcp.transports.credential_store import CredentialStore
 
@@ -74,6 +75,29 @@ class TestCredentialStore:
         """Delete should not raise when no file exists."""
         store = CredentialStore(data_dir, secret="test-secret")
         store.delete()  # Should not raise
+
+    def test_caching_behavior(self, data_dir: Path) -> None:
+        """Repeated reads should use cache and avoid disk I/O."""
+        store = CredentialStore(data_dir, secret="test-secret")
+        store.store({"TELEGRAM_BOT_TOKEN": "123:ABC"})
+
+        # Invalidate the in-memory cache to force the next read from disk
+        store._cached_credentials = None
+
+        original_read_bytes = Path.read_bytes
+        with patch.object(Path, "read_bytes", autospec=True) as mock_read:
+            # First load reads from disk
+            mock_read.side_effect = lambda self: original_read_bytes(self)
+            creds1 = store.load()
+            assert creds1 is not None
+            assert creds1["TELEGRAM_BOT_TOKEN"] == "123:ABC"
+            assert mock_read.call_count == 1
+
+            # Second load uses cache
+            creds2 = store.load()
+            assert creds2 is not None
+            assert creds2["TELEGRAM_BOT_TOKEN"] == "123:ABC"
+            assert mock_read.call_count == 1
 
     def test_auto_generated_secret_persists(self, data_dir: Path) -> None:
         """Auto-generated secret should be saved and reused across instances."""

--- a/tests/test_credential_store.py
+++ b/tests/test_credential_store.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from cryptography.exceptions import InvalidTag
-from unittest.mock import patch
 
 from better_telegram_mcp.transports.credential_store import CredentialStore
 

--- a/tests/test_per_user_session_store.py
+++ b/tests/test_per_user_session_store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from cryptography.exceptions import InvalidTag
@@ -11,7 +12,6 @@ from better_telegram_mcp.auth.per_user_session_store import (
     PerUserSessionStore,
     SessionInfo,
 )
-from unittest.mock import patch
 
 
 @pytest.fixture

--- a/tests/test_per_user_session_store.py
+++ b/tests/test_per_user_session_store.py
@@ -11,6 +11,7 @@ from better_telegram_mcp.auth.per_user_session_store import (
     PerUserSessionStore,
     SessionInfo,
 )
+from unittest.mock import patch
 
 
 @pytest.fixture
@@ -216,3 +217,28 @@ class TestPerUserSessionStore:
         store3 = PerUserSessionStore(data_dir)
         with pytest.raises(InvalidTag):
             store3.load_all()
+
+    def test_caching_behavior(self, store: PerUserSessionStore) -> None:
+        """Repeated reads should use cache and avoid disk I/O."""
+        store.store("b1", SessionInfo(session_name="s1", mode="bot", bot_token="t1"))
+
+        # Invalidate the in-memory cache to force the next read from disk
+        store._cached_sessions = None
+
+        original_read_bytes = Path.read_bytes
+        with patch.object(Path, "read_bytes", autospec=True) as mock_read:
+            # First load reads from disk
+            mock_read.side_effect = lambda self: original_read_bytes(self)
+            s1 = store.load("b1")
+            assert s1 is not None
+            assert mock_read.call_count == 1
+
+            # Second load uses cache
+            s2 = store.load("b1")
+            assert s2 is not None
+            assert mock_read.call_count == 1
+
+            # Third load (all) uses cache
+            all_s = store.load_all()
+            assert "b1" in all_s
+            assert mock_read.call_count == 1

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.3.0b1"
+version = "4.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
💡 What: Implemented in-memory caching for `PerUserSessionStore` and `CredentialStore`.
🎯 Why: Repeated reads currently incur unnecessary disk I/O, AES-GCM decryption, and JSON parsing overhead because there is no caching.
📊 Impact: Eliminates expensive, repeated disk and cryptographic operations on all subsequent cache reads.
🔬 Measurement: Verified caching behavior in unit tests via mocking to assert that the file is only read once.

---
*PR created automatically by Jules for task [14604196543747077801](https://jules.google.com/task/14604196543747077801) started by @n24q02m*