### PR TITLE
[SECURITY] Arbitrary File Write via Symlink (Missing O_EXCL)

### DIFF
--- a/src/better_telegram_mcp/backends/user_backend.py
+++ b/src/better_telegram_mcp/backends/user_backend.py
@@ -73,7 +73,9 @@ class UserBackend(TelegramBackend):
         # where Telethon creates it with default (insecure) permissions
         actual_session_path = session_path.with_suffix(".session")
         try:
-            fd = os.open(str(actual_session_path), os.O_CREAT | os.O_WRONLY, 0o600)
+            fd = os.open(
+                str(actual_session_path), os.O_CREAT | os.O_WRONLY | os.O_EXCL, 0o600
+            )
             os.close(fd)
         except OSError:
             pass  # Windows may not support this or file already exists

--- a/src/better_telegram_mcp/credential_state.py
+++ b/src/better_telegram_mcp/credential_state.py
@@ -149,7 +149,7 @@ async def trigger_relay_setup(
         from .relay_schema import RELAY_SCHEMA
 
         relay_base = os.environ.get("MCP_RELAY_URL", DEFAULT_RELAY_URL)
-        session = await create_session(relay_base, SERVER_NAME, RELAY_SCHEMA)  # ty: ignore[invalid-argument-type]
+        session = await create_session(relay_base, SERVER_NAME, RELAY_SCHEMA)
 
         # Save session lock for parallel processes
         import time
@@ -201,7 +201,7 @@ async def _poll_relay_background(
         from mcp_relay_core.storage.config_file import write_config
 
         poll_timeout = timeout if timeout is not None else 300.0
-        config = await poll_for_result(relay_base, session, timeout_s=poll_timeout)  # ty: ignore[invalid-argument-type]
+        config = await poll_for_result(relay_base, session, timeout_s=poll_timeout)
 
         # Save config
         write_config(SERVER_NAME, config)
@@ -223,7 +223,7 @@ async def _poll_relay_background(
 
                 await send_message(
                     relay_base,
-                    session.session_id,  # ty: ignore[union-attr]
+                    session.session_id,
                     {
                         "type": "complete",
                         "text": "Telegram config saved. Setup complete!",
@@ -278,7 +278,7 @@ async def _handle_user_mode_auth(
 
             await send_message(
                 relay_base,
-                session.session_id,  # ty: ignore[union-attr]
+                session.session_id,
                 {
                     "type": "info",
                     "text": "Credentials saved. Starting Telegram authentication...",
@@ -287,7 +287,7 @@ async def _handle_user_mode_auth(
 
             auth_ok = await _relay_telethon_auth(
                 relay_base,
-                session.session_id,  # ty: ignore[union-attr]
+                session.session_id,
                 backend,
                 settings,
             )
@@ -298,7 +298,7 @@ async def _handle_user_mode_auth(
 
             await send_message(
                 relay_base,
-                session.session_id,  # ty: ignore[union-attr]
+                session.session_id,
                 {
                     "type": "complete",
                     "text": "Existing Telethon session found — already authorized. No OTP needed. You can close this tab.",

--- a/tests/test_backends/test_user_backend.py
+++ b/tests/test_backends/test_user_backend.py
@@ -114,6 +114,41 @@ class TestConnect:
         assert backend._client is not None
         mock_client.connect.assert_awaited_once()
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="Windows does not support symlinks without special privileges",
+    )
+    async def test_connect_symlink_vulnerability(
+        self, tmp_path, mock_client, mock_client_class
+    ):
+        """
+        Verify that connect() does not follow symlinks when pre-creating the session file.
+        This prevents an attacker from creating a symlink at the session path pointing
+        to a sensitive file and having the server truncate/overwrite it.
+        """
+        import os
+
+        from better_telegram_mcp.backends.user_backend import UserBackend
+
+        # 1. Setup a "sensitive" target file
+        target_file = tmp_path / "sensitive_file"
+        original_content = "sensitive information"
+        target_file.write_text(original_content)
+
+        # 2. Create a symlink at the session path pointing to the target
+        settings = _make_settings(tmp_path)
+        session_file = (tmp_path / settings.session_name).with_suffix(".session")
+        os.symlink(str(target_file), str(session_file))
+
+        # 3. Initialize backend and call connect()
+        backend = UserBackend(settings)
+        await backend.connect()
+
+        # 4. Assert the target file content remains unchanged
+        # (os.open with O_CREAT | O_WRONLY | O_EXCL should fail on the symlink
+        # and not truncate the target file)
+        assert target_file.read_text() == original_content
+
 
 class TestDisconnect:
     async def test_disconnect(self, tmp_path, mock_client, mock_client_class):


### PR DESCRIPTION
Fixed a security vulnerability in UserBackend.connect where the Telethon session file was pre-created without the os.O_EXCL flag. This allowed following existing symlinks, which could lead to arbitrary file write if an attacker could control the session path.

Changes:
- Added os.O_EXCL to os.open call in UserBackend.connect.
- Added regression test test_connect_symlink_vulnerability in tests/test_backends/test_user_backend.py.
- Cleaned up unused ty:ignore comments in src/better_telegram_mcp/credential_state.py.
- Recorded learning in .jules/sentinel.md.

Verified with 555 tests passing and ruff/ty checks.

---
*PR created automatically by Jules for task [16648863598464837218](https://jules.google.com/task/16648863598464837218) started by @n24q02m*