### PR TITLE
[FIX] Implement CLI using ty typer

### DIFF
--- a/src/better_telegram_mcp/__main__.py
+++ b/src/better_telegram_mcp/__main__.py
@@ -1,10 +1,13 @@
+"""Main entry point for better-telegram-mcp."""
+
 from __future__ import annotations
 
 
 def _cli() -> None:
-    from .server import main
+    """Run the Typer CLI."""
+    from .cli import app
 
-    main()
+    app()
 
 
 if __name__ == "__main__":

--- a/src/better_telegram_mcp/cli.py
+++ b/src/better_telegram_mcp/cli.py
@@ -1,0 +1,125 @@
+"""Typer-based CLI for better-telegram-mcp."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import typer
+
+from .config import Settings
+
+app = typer.Typer(help="Better Telegram MCP Server CLI")
+
+
+def _run_async(coro):
+    """Run an async coroutine synchronously."""
+    return asyncio.run(coro)
+
+
+@app.callback(invoke_without_command=True)
+def main(
+    ctx: typer.Context,
+    transport: str = typer.Option("stdio", help="Transport mode (stdio or http)"),
+):
+    """Start the MCP server (default)."""
+    if ctx.invoked_subcommand is not None:
+        return
+
+    os.environ["TRANSPORT_MODE"] = transport
+    from .server import main as server_main
+
+    server_main()
+
+
+@app.command()
+def auth(
+    phone: str | None = typer.Option(None, help="Telegram phone number"),
+    session: str = typer.Option("default", help="Session name"),
+):
+    """Interactive terminal-based Telegram authentication."""
+    settings = Settings(phone=phone, session_name=session)
+    if not settings.phone:
+        typer.echo("Error: TELEGRAM_PHONE is required for authentication.")
+        raise typer.Exit(code=1)
+
+    from .backends.user_backend import UserBackend
+
+    backend = UserBackend(settings)
+
+    async def _auth_flow():
+        await backend.connect()
+        try:
+            if await backend.is_authorized():
+                typer.echo(f"Already authorized as {settings.phone}")
+                return
+
+            typer.echo(f"Sending OTP to {settings.phone}...")
+            await backend.send_code(settings.phone)
+
+            code = typer.prompt("Enter the OTP code sent to your Telegram app")
+            try:
+                result = await backend.sign_in(settings.phone, code)
+                name = result.get("authenticated_as", "User")
+                typer.echo(f"Successfully authenticated as {name}")
+            except Exception as e:
+                error_msg = str(e)
+                if any(
+                    kw in error_msg.lower()
+                    for kw in ("password", "2fa", "two-factor", "srp")
+                ):
+                    password = typer.prompt("2FA password required", hide_input=True)
+                    result = await backend.sign_in(
+                        settings.phone, code, password=password
+                    )
+                    name = result.get("authenticated_as", "User")
+                    typer.echo(f"Successfully authenticated as {name}")
+                else:
+                    typer.echo(f"Authentication failed: {e}")
+                    raise typer.Exit(code=1) from e
+        finally:
+            await backend.disconnect()
+
+    _run_async(_auth_flow())
+
+
+@app.command()
+def auth_relay(
+    phone: str | None = typer.Option(None, help="Telegram phone number"),
+    url: str | None = typer.Option(None, help="Remote relay server URL"),
+):
+    """Poll a remote relay server for OTP commands."""
+    settings = Settings(phone=phone)
+    if url:
+        settings.auth_url = url
+
+    if not settings.phone:
+        typer.echo("Error: TELEGRAM_PHONE is required.")
+        raise typer.Exit(code=1)
+
+    from .auth_client import AuthClient
+    from .backends.user_backend import UserBackend
+
+    backend = UserBackend(settings)
+    client = AuthClient(backend, settings)
+
+    async def _relay_flow():
+        await backend.connect()
+        try:
+            auth_url = await client.create_session()
+            typer.echo(f"Auth session created. Please visit: {auth_url}")
+            typer.echo("Polling for commands...")
+
+            # Start polling in background and wait for it
+            await client.poll_and_execute()
+            await client.wait_for_auth()
+            typer.echo("Authentication complete!")
+        finally:
+            await client.close()
+            await backend.disconnect()
+
+    _run_async(_relay_flow())
+
+
+if __name__ == "__main__":
+    app()

--- a/src/better_telegram_mcp/credential_state.py
+++ b/src/better_telegram_mcp/credential_state.py
@@ -149,7 +149,7 @@ async def trigger_relay_setup(
         from .relay_schema import RELAY_SCHEMA
 
         relay_base = os.environ.get("MCP_RELAY_URL", DEFAULT_RELAY_URL)
-        session = await create_session(relay_base, SERVER_NAME, RELAY_SCHEMA)  # ty: ignore[invalid-argument-type]
+        session = await create_session(relay_base, SERVER_NAME, RELAY_SCHEMA)
 
         # Save session lock for parallel processes
         import time
@@ -201,7 +201,7 @@ async def _poll_relay_background(
         from mcp_relay_core.storage.config_file import write_config
 
         poll_timeout = timeout if timeout is not None else 300.0
-        config = await poll_for_result(relay_base, session, timeout_s=poll_timeout)  # ty: ignore[invalid-argument-type]
+        config = await poll_for_result(relay_base, session, timeout_s=poll_timeout)
 
         # Save config
         write_config(SERVER_NAME, config)
@@ -223,7 +223,7 @@ async def _poll_relay_background(
 
                 await send_message(
                     relay_base,
-                    session.session_id,  # ty: ignore[union-attr]
+                    session.session_id,
                     {
                         "type": "complete",
                         "text": "Telegram config saved. Setup complete!",
@@ -278,7 +278,7 @@ async def _handle_user_mode_auth(
 
             await send_message(
                 relay_base,
-                session.session_id,  # ty: ignore[union-attr]
+                session.session_id,
                 {
                     "type": "info",
                     "text": "Credentials saved. Starting Telegram authentication...",
@@ -287,7 +287,7 @@ async def _handle_user_mode_auth(
 
             auth_ok = await _relay_telethon_auth(
                 relay_base,
-                session.session_id,  # ty: ignore[union-attr]
+                session.session_id,
                 backend,
                 settings,
             )
@@ -298,7 +298,7 @@ async def _handle_user_mode_auth(
 
             await send_message(
                 relay_base,
-                session.session_id,  # ty: ignore[union-attr]
+                session.session_id,
                 {
                     "type": "complete",
                     "text": "Existing Telethon session found — already authorized. No OTP needed. You can close this tab.",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,15 +1,76 @@
-"""Tests for __main__.py CLI entry point."""
+"""Tests for Typer CLI."""
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
+
+from typer.testing import CliRunner
+
+from better_telegram_mcp.cli import app
+
+runner = CliRunner()
 
 
-class TestCliDispatch:
-    def test_server_dispatch(self):
-        """CLI dispatches to server main."""
-        from better_telegram_mcp.__main__ import _cli
+def test_server_dispatch():
+    """CLI dispatches to server main by default."""
+    with patch("better_telegram_mcp.server.main") as mock_main:
+        result = runner.invoke(app)
+        assert result.exit_code == 0
+        mock_main.assert_called_once()
 
-        with patch("better_telegram_mcp.server.main") as mock_main:
-            _cli()
-            mock_main.assert_called_once()
+
+def test_auth_requires_phone():
+    """Auth command requires phone if not in env."""
+    with patch.dict("os.environ", {}, clear=True):
+        result = runner.invoke(app, ["auth"])
+        assert result.exit_code == 1
+        assert "TELEGRAM_PHONE is required" in result.stdout
+
+
+def test_auth_success():
+    """Terminal auth flow success."""
+    with patch(
+        "better_telegram_mcp.backends.user_backend.UserBackend"
+    ) as mock_backend_cls:
+        mock_backend = mock_backend_cls.return_value
+        mock_backend.connect = AsyncMock()
+        mock_backend.is_authorized = AsyncMock(return_value=False)
+        mock_backend.send_code = AsyncMock()
+        mock_backend.sign_in = AsyncMock(return_value={"authenticated_as": "TestUser"})
+        mock_backend.disconnect = AsyncMock()
+
+        result = runner.invoke(app, ["auth", "--phone", "+1234567890"], input="12345\n")
+
+        assert result.exit_code == 0
+        assert "Successfully authenticated as TestUser" in result.stdout
+        mock_backend.connect.assert_called_once()
+        mock_backend.send_code.assert_called_once_with("+1234567890")
+        mock_backend.sign_in.assert_called_once_with("+1234567890", "12345")
+        mock_backend.disconnect.assert_called_once()
+
+
+def test_auth_relay():
+    """Relay auth flow initialization."""
+    with patch(
+        "better_telegram_mcp.backends.user_backend.UserBackend"
+    ) as mock_backend_cls:
+        with patch("better_telegram_mcp.auth_client.AuthClient") as mock_client_cls:
+            mock_backend = mock_backend_cls.return_value
+            mock_backend.connect = AsyncMock()
+            mock_backend.disconnect = AsyncMock()
+
+            mock_client = mock_client_cls.return_value
+            mock_client.create_session = AsyncMock(return_value="http://relay/auth")
+            mock_client.poll_and_execute = AsyncMock()
+            mock_client.wait_for_auth = AsyncMock()
+            mock_client.close = AsyncMock()
+
+            result = runner.invoke(app, ["auth-relay", "--phone", "+1234567890"])
+
+            assert result.exit_code == 0
+            assert (
+                "Auth session created. Please visit: http://relay/auth" in result.stdout
+            )
+            mock_client.create_session.assert_called_once()
+            mock_client.poll_and_execute.assert_called_once()
+            mock_client.close.assert_called_once()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import sys
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 
 def test_cli_runs_server():
     with patch.object(sys, "argv", ["better-telegram-mcp"]):
@@ -15,5 +17,9 @@ def test_cli_runs_server():
         ):
             from better_telegram_mcp.__main__ import _cli
 
-            _cli()
+            # Typer CLI calls sys.exit(0) on success
+            with pytest.raises(SystemExit) as excinfo:
+                _cli()
+
+            assert excinfo.value.code == 0
             mock_server.main.assert_called_once()


### PR DESCRIPTION
This PR implements a robust CLI for the Better Telegram MCP server using `typer`.

### Key Changes:
- **`src/better_telegram_mcp/cli.py`**: Centralized CLI implementation.
  - Default action: Starts the MCP server (stdio or http).
  - `auth` command: Handles interactive Telegram OTP/2FA authentication directly in the terminal.
  - `auth-relay` command: Connects to a remote relay server and executes authentication commands locally.
- **`src/better_telegram_mcp/__main__.py`**: Updated to delegate to the new Typer app.
- **`tests/test_cli.py` & `tests/test_main.py`**: Refactored to use `CliRunner` and verify Typer-specific exit codes.
- **`src/better_telegram_mcp/credential_state.py`**: Removed unsupported `ty: ignore` rules to fix diagnostics.

### Verification:
- All unit tests pass (`uv run pytest`).
- Type checking passes (`uv run ty check`).
- Linting and formatting pass (`uv run ruff check .`).
- Verified that `uv run better-telegram-mcp --help` displays correctly.

---
*PR created automatically by Jules for task [7420192420107117274](https://jules.google.com/task/7420192420107117274) started by @n24q02m*