### PR TITLE
[FIX] Uncached secret file read

### DIFF
--- a/src/better_telegram_mcp/auth/per_user_session_store.py
+++ b/src/better_telegram_mcp/auth/per_user_session_store.py
@@ -20,6 +20,8 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 
+from ..utils.secrets import resolve_or_generate_secret
+
 _LEGACY_SALT = b"mcp-telegram-sessions"
 _KDF_ITERATIONS = 600_000
 _NONCE_SIZE = 12
@@ -81,17 +83,7 @@ class PerUserSessionStore:
     @staticmethod
     def _resolve_or_generate_secret(data_dir: Path) -> str:
         """Load persisted secret or generate a new one."""
-        secret_path = data_dir / ".secret"
-        if secret_path.exists():
-            return secret_path.read_text().strip()
-        data_dir.mkdir(parents=True, exist_ok=True)
-        secret = os.urandom(32).hex()
-        secret_path.write_text(secret)
-        try:
-            secret_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
-        except OSError:
-            pass  # Windows may not support chmod
-        return secret
+        return resolve_or_generate_secret(data_dir)
 
     def _derive_key(self) -> bytes:
         if self._cached_key is not None:

--- a/src/better_telegram_mcp/auth/telegram_auth_provider.py
+++ b/src/better_telegram_mcp/auth/telegram_auth_provider.py
@@ -35,11 +35,13 @@ class TelegramAuthProvider:
     Supports both bot mode (instant) and user mode (OTP flow).
     """
 
-    def __init__(self, data_dir: Path, api_id: int, api_hash: str) -> None:
+    def __init__(
+        self, data_dir: Path, api_id: int, api_hash: str, secret: str | None = None
+    ) -> None:
         self._data_dir = data_dir
         self._api_id = api_id
         self._api_hash = api_hash
-        self._store = PerUserSessionStore(data_dir)
+        self._store = PerUserSessionStore(data_dir, secret=secret)
 
         # bearer -> active TelegramBackend
         self.active_clients: dict[str, TelegramBackend] = {}

--- a/src/better_telegram_mcp/config.py
+++ b/src/better_telegram_mcp/config.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import functools
+import os
 from pathlib import Path
 from typing import Literal
 
 from pydantic import model_validator
 from pydantic_settings import BaseSettings
+
+from .utils.secrets import resolve_or_generate_secret
 
 
 def _empty_to_none(v: str | None) -> str | None:
@@ -37,6 +41,14 @@ class Settings(BaseSettings):
 
     # Runtime (derived)
     mode: Literal["bot", "user"] = "bot"
+
+    @functools.cached_property
+    def secret(self) -> str:
+        """Cached secret for encryption, loaded from env or data_dir."""
+        env_secret = os.environ.get("CREDENTIAL_SECRET")
+        if env_secret:
+            return env_secret
+        return resolve_or_generate_secret(self.data_dir)
 
     @property
     def trusted_proxy_list(self) -> list[str]:

--- a/src/better_telegram_mcp/credential_state.py
+++ b/src/better_telegram_mcp/credential_state.py
@@ -149,7 +149,7 @@ async def trigger_relay_setup(
         from .relay_schema import RELAY_SCHEMA
 
         relay_base = os.environ.get("MCP_RELAY_URL", DEFAULT_RELAY_URL)
-        session = await create_session(relay_base, SERVER_NAME, RELAY_SCHEMA)  # ty: ignore[invalid-argument-type]
+        session = await create_session(relay_base, SERVER_NAME, RELAY_SCHEMA)
 
         # Save session lock for parallel processes
         import time
@@ -201,7 +201,7 @@ async def _poll_relay_background(
         from mcp_relay_core.storage.config_file import write_config
 
         poll_timeout = timeout if timeout is not None else 300.0
-        config = await poll_for_result(relay_base, session, timeout_s=poll_timeout)  # ty: ignore[invalid-argument-type]
+        config = await poll_for_result(relay_base, session, timeout_s=poll_timeout)
 
         # Save config
         write_config(SERVER_NAME, config)
@@ -223,7 +223,7 @@ async def _poll_relay_background(
 
                 await send_message(
                     relay_base,
-                    session.session_id,  # ty: ignore[union-attr]
+                    session.session_id,
                     {
                         "type": "complete",
                         "text": "Telegram config saved. Setup complete!",
@@ -278,7 +278,7 @@ async def _handle_user_mode_auth(
 
             await send_message(
                 relay_base,
-                session.session_id,  # ty: ignore[union-attr]
+                session.session_id,
                 {
                     "type": "info",
                     "text": "Credentials saved. Starting Telegram authentication...",
@@ -287,7 +287,7 @@ async def _handle_user_mode_auth(
 
             auth_ok = await _relay_telethon_auth(
                 relay_base,
-                session.session_id,  # ty: ignore[union-attr]
+                session.session_id,
                 backend,
                 settings,
             )
@@ -298,7 +298,7 @@ async def _handle_user_mode_auth(
 
             await send_message(
                 relay_base,
-                session.session_id,  # ty: ignore[union-attr]
+                session.session_id,
                 {
                     "type": "complete",
                     "text": "Existing Telethon session found — already authorized. No OTP needed. You can close this tab.",

--- a/src/better_telegram_mcp/transports/credential_store.py
+++ b/src/better_telegram_mcp/transports/credential_store.py
@@ -16,6 +16,8 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 
+from ..utils.secrets import resolve_or_generate_secret
+
 _LEGACY_SALT = b"mcp-telegram-creds"
 _KDF_ITERATIONS = 600_000
 _NONCE_SIZE = 12
@@ -61,17 +63,7 @@ class CredentialStore:
     @staticmethod
     def _resolve_or_generate_secret(data_dir: Path) -> str:
         """Load persisted secret or generate a new one."""
-        secret_path = data_dir / ".secret"
-        if secret_path.exists():
-            return secret_path.read_text().strip()
-        data_dir.mkdir(parents=True, exist_ok=True)
-        secret = os.urandom(32).hex()
-        secret_path.write_text(secret)
-        try:
-            secret_path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0o600
-        except OSError:
-            pass  # Windows may not support chmod
-        return secret
+        return resolve_or_generate_secret(data_dir)
 
     def _derive_key(self) -> bytes:
         if self._cached_key is not None:

--- a/src/better_telegram_mcp/transports/http.py
+++ b/src/better_telegram_mcp/transports/http.py
@@ -43,7 +43,7 @@ async def setup_credentials(settings: Settings) -> dict[str, str]:
     Raises:
         RuntimeError: If relay setup fails or times out.
     """
-    store = CredentialStore(settings.data_dir)
+    store = CredentialStore(settings.data_dir, secret=settings.secret)
     creds = store.load()
 
     if creds is not None:
@@ -113,7 +113,7 @@ def _start_single_user_http(settings: Settings) -> None:
 
     # If env vars already have credentials, skip CredentialStore/relay
     if not settings.is_configured:
-        store = CredentialStore(settings.data_dir)
+        store = CredentialStore(settings.data_dir, secret=settings.secret)
         creds = store.load()
 
         if creds is None:
@@ -146,6 +146,7 @@ def _start_multi_user_http(settings: Settings) -> None:
         dcr_secret=dcr_secret,
         api_id=api_id,
         api_hash=api_hash,
+        secret=settings.secret,
     )
 
     logger.info("Starting multi-user HTTP server on port {}", port)

--- a/src/better_telegram_mcp/transports/http_multi_user.py
+++ b/src/better_telegram_mcp/transports/http_multi_user.py
@@ -103,11 +103,12 @@ def create_app(
     dcr_secret: str,
     api_id: int,
     api_hash: str,
+    secret: str | None = None,
 ) -> Starlette:
     """Create the multi-user Starlette ASGI application."""
 
     client_store = StatelessClientStore(dcr_secret)
-    auth_provider = TelegramAuthProvider(data_dir, api_id, api_hash)
+    auth_provider = TelegramAuthProvider(data_dir, api_id, api_hash, secret=secret)
 
     # Create MCP server and session manager for streamable-http
     from ..server import create_http_mcp_server

--- a/src/better_telegram_mcp/utils/secrets.py
+++ b/src/better_telegram_mcp/utils/secrets.py
@@ -1,0 +1,30 @@
+"""Secret management utilities."""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+
+def resolve_or_generate_secret(data_dir: Path) -> str:
+    """Load persisted secret or generate a new one.
+
+    Args:
+        data_dir: Directory where the .secret file is stored.
+
+    Returns:
+        The 32-byte hex-encoded secret string.
+    """
+    secret_path = data_dir / ".secret"
+    if secret_path.exists():
+        return secret_path.read_text().strip()
+
+    data_dir.mkdir(parents=True, exist_ok=True)
+    secret = os.urandom(32).hex()
+    secret_path.write_text(secret)
+    try:
+        secret_path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0o600
+    except OSError:
+        pass  # Windows may not support chmod
+    return secret

--- a/tests/test_secret_caching.py
+++ b/tests/test_secret_caching.py
@@ -1,0 +1,56 @@
+"""Tests for secret caching in Settings and storage classes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from better_telegram_mcp.config import Settings
+from better_telegram_mcp.transports.credential_store import CredentialStore
+
+
+def test_settings_secret_caching(tmp_path: Path) -> None:
+    """Settings.secret should only read the secret file once."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    secret_path = data_dir / ".secret"
+    secret_path.write_text("test-secret-value")
+
+    settings = Settings(data_dir=data_dir)
+
+    # Patch the utility function in the config module
+    with patch("better_telegram_mcp.config.resolve_or_generate_secret") as mock_resolve:
+        mock_resolve.return_value = "mock-secret"
+
+        # First access
+        s1 = settings.secret
+        assert s1 == "mock-secret"
+        assert mock_resolve.call_count == 1
+
+        # Second access
+        s2 = settings.secret
+        assert s2 == "mock-secret"
+        # cached_property should prevent second call to mock_resolve
+        assert mock_resolve.call_count == 1
+
+
+def test_credential_store_uses_cached_secret(tmp_path: Path) -> None:
+    """CredentialStore should use the secret from Settings if provided."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+
+    settings = Settings(data_dir=data_dir)
+    # Trigger secret generation/load
+    secret = settings.secret
+
+    with patch(
+        "better_telegram_mcp.transports.credential_store.resolve_or_generate_secret"
+    ) as mock_resolve:
+        # If we pass the secret, it should NOT call resolve_or_generate_secret
+        store = CredentialStore(data_dir, secret=secret)
+        assert store._secret == secret
+        assert mock_resolve.call_count == 0
+
+        # If we DON'T pass the secret, it SHOULD call it
+        _ = CredentialStore(data_dir)
+        assert mock_resolve.call_count == 1


### PR DESCRIPTION
This PR addresses the issue of repetitive secret file reads during encryption key derivation. By caching the secret at the application level within the \`Settings\` singleton, we avoid redundant disk I/O and ensure consistent secret usage across different components.

Key changes:
- Centralized secret resolution logic in a new utility module.
- Added \`@functools.cached_property\` to \`Settings.secret\` to provide instance-level caching.
- Updated \`CredentialStore\` and \`PerUserSessionStore\` to accept an externally provided secret.
- Refactored transport layers to pass the \`Settings.secret\` down to storage classes.
- Added comprehensive tests to verify that the secret is only read once per \`Settings\` instance.
- Performed minor cleanup of type-check suppressions in \`credential_state.py\` to satisfy CI requirements.

---
*PR created automatically by Jules for task [14171476850362773670](https://jules.google.com/task/14171476850362773670) started by @n24q02m*