### PR TITLE
⚡ Bolt: [performance improvement] cache static help docs in memory

### DIFF
--- a/src/better_telegram_mcp/tools/help_tool.py
+++ b/src/better_telegram_mcp/tools/help_tool.py
@@ -8,6 +8,7 @@ from ..utils.formatting import err
 _DOCS_DIR = Path(__file__).resolve().parent.parent / "docs"
 
 _VALID_TOPICS = {"messages", "chats", "media", "contacts"}
+_DOC_CACHE: dict[str, str] = {}
 
 
 async def handle_help(topic: str | None = None) -> str:
@@ -39,9 +40,14 @@ async def handle_help(topic: str | None = None) -> str:
 
 
 async def _load_doc(topic: str) -> str | None:
+    # Bolt: Return cached content immediately if available to avoid thread dispatch overhead
+    if topic in _DOC_CACHE:
+        return _DOC_CACHE[topic]
+
     path = _DOCS_DIR / f"{topic}.md"
     if path.exists():
-        # Bolt: Read file asynchronously to prevent blocking the event loop
         content = await asyncio.to_thread(path.read_text, encoding="utf-8")
-        return content.strip()
+        content = content.strip()
+        _DOC_CACHE[topic] = content
+        return content
     return None

--- a/tests/test_tools/test_help_tool.py
+++ b/tests/test_tools/test_help_tool.py
@@ -7,6 +7,14 @@ import pytest
 from better_telegram_mcp.tools.help_tool import handle_help
 
 
+@pytest.fixture(autouse=True)
+def clear_doc_cache():
+    import better_telegram_mcp.tools.help_tool
+
+    better_telegram_mcp.tools.help_tool._DOC_CACHE.clear()
+    yield
+
+
 @pytest.mark.asyncio
 async def test_help_messages():
     result = await handle_help("messages")


### PR DESCRIPTION
💡 What: Implemented a module-level dictionary cache (`_DOC_CACHE`) for markdown documentation in `help_tool.py`.
🎯 Why: Prevents redundant filesystem I/O and `asyncio.to_thread` dispatch overhead for frequently requested help topics.
📊 Impact: Reduces disk reads and thread dispatches from O(N) to O(1) per topic.
🔬 Measurement: Verified caching logic and test cache clearing via `pytest tests/test_tools/test_help_tool.py`.

---
*PR created automatically by Jules for task [16663868716596621212](https://jules.google.com/task/16663868716596621212) started by @n24q02m*