### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix timing attacks in AuthServer token comparison

### DIFF
--- a/src/better_telegram_mcp/auth_server.py
+++ b/src/better_telegram_mcp/auth_server.py
@@ -266,7 +266,8 @@ class AuthServer:
             )
 
         async def status_endpoint(request: Request) -> JSONResponse:
-            if request.headers.get("X-Auth-Token") != self._token:
+            auth_token = request.headers.get("X-Auth-Token")
+            if not auth_token or not secrets.compare_digest(auth_token, self._token):
                 return JSONResponse({"error": "Forbidden"}, status_code=403)
             try:
                 authorized = await self._backend.is_authorized()
@@ -278,7 +279,8 @@ class AuthServer:
             return JSONResponse(data)
 
         async def send_code(request: Request) -> JSONResponse:
-            if request.headers.get("X-Auth-Token") != self._token:
+            auth_token = request.headers.get("X-Auth-Token")
+            if not auth_token or not secrets.compare_digest(auth_token, self._token):
                 return JSONResponse({"error": "Forbidden"}, status_code=403)
             ip = self._get_client_ip(request)
             if not self._check_rate_limit(f"send_code:{ip}"):
@@ -301,7 +303,8 @@ class AuthServer:
                 return JSONResponse({"ok": False, "error": _sanitize_error(str(e))})
 
         async def verify(request: Request) -> JSONResponse:
-            if request.headers.get("X-Auth-Token") != self._token:
+            auth_token = request.headers.get("X-Auth-Token")
+            if not auth_token or not secrets.compare_digest(auth_token, self._token):
                 return JSONResponse({"error": "Forbidden"}, status_code=403)
             ip = self._get_client_ip(request)
             if not self._check_rate_limit(f"verify:{ip}"):

--- a/src/better_telegram_mcp/credential_state.py
+++ b/src/better_telegram_mcp/credential_state.py
@@ -149,7 +149,7 @@ async def trigger_relay_setup(
         from .relay_schema import RELAY_SCHEMA
 
         relay_base = os.environ.get("MCP_RELAY_URL", DEFAULT_RELAY_URL)
-        session = await create_session(relay_base, SERVER_NAME, RELAY_SCHEMA)  # ty: ignore[invalid-argument-type]
+        session = await create_session(relay_base, SERVER_NAME, RELAY_SCHEMA)
 
         # Save session lock for parallel processes
         import time
@@ -201,7 +201,7 @@ async def _poll_relay_background(
         from mcp_core.storage.config_file import write_config
 
         poll_timeout = timeout if timeout is not None else 300.0
-        config = await poll_for_result(relay_base, session, timeout_s=poll_timeout)  # ty: ignore[invalid-argument-type]
+        config = await poll_for_result(relay_base, session, timeout_s=poll_timeout)
 
         # Save config
         write_config(SERVER_NAME, config)
@@ -223,7 +223,7 @@ async def _poll_relay_background(
 
                 await send_message(
                     relay_base,
-                    session.session_id,  # ty: ignore[union-attr]
+                    session.session_id,
                     {
                         "type": "complete",
                         "text": "Telegram config saved. Setup complete!",
@@ -278,7 +278,7 @@ async def _handle_user_mode_auth(
 
             await send_message(
                 relay_base,
-                session.session_id,  # ty: ignore[union-attr]
+                session.session_id,
                 {
                     "type": "info",
                     "text": "Credentials saved. Starting Telegram authentication...",
@@ -287,7 +287,7 @@ async def _handle_user_mode_auth(
 
             auth_ok = await _relay_telethon_auth(
                 relay_base,
-                session.session_id,  # ty: ignore[union-attr]
+                session.session_id,
                 backend,
                 settings,
             )
@@ -298,7 +298,7 @@ async def _handle_user_mode_auth(
 
             await send_message(
                 relay_base,
-                session.session_id,  # ty: ignore[union-attr]
+                session.session_id,
                 {
                     "type": "complete",
                     "text": "Existing Telethon session found — already authorized. No OTP needed. You can close this tab.",

--- a/src/better_telegram_mcp/server.py
+++ b/src/better_telegram_mcp/server.py
@@ -553,7 +553,7 @@ async def run_http(port: int = 0) -> None:
     from .relay_schema import RELAY_SCHEMA
 
     await run_local_server(
-        mcp,  # ty: ignore[invalid-argument-type]
+        mcp,
         server_name="better-telegram-mcp",
         relay_schema=RELAY_SCHEMA,
         port=port,

--- a/tests/test_credential_state.py
+++ b/tests/test_credential_state.py
@@ -138,9 +138,7 @@ def test_resolve_from_config_file_bot():
         os.environ.pop("TELEGRAM_BOT_TOKEN", None)
         os.environ.pop("TELEGRAM_PHONE", None)
 
-        with patch(
-            "mcp_core.storage.config_file.read_config", return_value=saved
-        ):
+        with patch("mcp_core.storage.config_file.read_config", return_value=saved):
             state = resolve_credential_state()
 
         assert state == CredentialState.CONFIGURED
@@ -158,9 +156,7 @@ def test_resolve_from_config_file_user():
         os.environ.pop("TELEGRAM_BOT_TOKEN", None)
         os.environ.pop("TELEGRAM_PHONE", None)
 
-        with patch(
-            "mcp_core.storage.config_file.read_config", return_value=saved
-        ):
+        with patch("mcp_core.storage.config_file.read_config", return_value=saved):
             state = resolve_credential_state()
 
         assert state == CredentialState.CONFIGURED


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `AuthServer` in `src/better_telegram_mcp/auth_server.py` uses standard string equality operators (`!=`) to compare incoming `X-Auth-Token` headers against the expected token. This allows attackers to perform timing attacks, sequentially guessing the token byte-by-byte by observing the response time.
🎯 Impact: Attackers could theoretically brute-force the authentication token, bypassing authentication checks and accessing protected functionality.
🔧 Fix: Used `secrets.compare_digest()` from Python's standard library to perform constant-time comparison, effectively mitigating timing attacks.
✅ Verification: Ran `pytest` suite, specifically `test_auth_server.py`, to ensure no regressions were introduced. Also passed `ty` and `ruff` linting checks. Added a journal entry to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [9279166593998176521](https://jules.google.com/task/9279166593998176521) started by @n24q02m*