### PR TITLE
🎨 Palette: [UX improvement] Add CSS loading spinner to aria-busy buttons

### DIFF
--- a/src/better_telegram_mcp/auth_server.py
+++ b/src/better_telegram_mcp/auth_server.py
@@ -49,9 +49,15 @@ input[type="password"]{letter-spacing:normal;text-align:left}
 input:focus{border-color:#3b82f6}
 input:focus-visible,button:focus-visible{outline:2px solid #3b82f6;outline-offset:2px}
 button{width:100%;padding:.75rem;background:#3b82f6;color:#fff;border:none;
-  border-radius:8px;font-size:1rem;cursor:pointer;font-weight:500}
+  border-radius:8px;font-size:1rem;cursor:pointer;font-weight:500;position:relative}
 button:hover{background:#2563eb}
 button:disabled{background:#333;color:#666;cursor:not-allowed}
+button[aria-busy="true"]{color:transparent!important;cursor:wait}
+button[aria-busy="true"]::after{content:"";position:absolute;top:50%;left:50%;
+  transform:translate(-50%,-50%);display:inline-block;width:1.2em;height:1.2em;
+  border:2px solid rgba(255,255,255,0.3);border-radius:50%;border-top-color:#fff;
+  animation:spin 1s linear infinite}
+@keyframes spin{to{transform:translate(-50%,-50%) rotate(360deg)}}
 .st{margin-top:1rem;padding:.75rem;border-radius:8px;font-size:.875rem;display:none}
 .st.error{display:block;background:#2d1111;border:1px solid #dc2626;color:#f87171}
 .st.success{display:block;background:#0d2818;border:1px solid #16a34a;color:#4ade80}

--- a/uv.lock
+++ b/uv.lock
@@ -76,7 +76,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.3.0"
+version = "4.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
💡 **What**: Added CSS styles to display a loading spinner natively on buttons when they receive the `aria-busy="true"` state.
🎯 **Why**: Previously, asynchronous operations in the auth flow (like sending/verifying OTPs) updated button text and set `aria-busy`, but provided no visual animated indicator. This CSS-only update makes the interface feel more responsive.
♿ **Accessibility**: Directly leverages the semantic `aria-busy` attribute, ensuring that the visual loading state remains perfectly in sync with the accessibility state.

---
*PR created automatically by Jules for task [5820484258485953914](https://jules.google.com/task/5820484258485953914) started by @n24q02m*