### PR TITLE
⚡ Bolt: [performance improvement] O(1) stale OTP cleanup using dict insertion order

### DIFF
--- a/src/better_telegram_mcp/auth/telegram_auth_provider.py
+++ b/src/better_telegram_mcp/auth/telegram_auth_provider.py
@@ -211,6 +211,9 @@ class TelegramAuthProvider:
             msg = f"Failed to send code: {exc}"
             raise ValueError(msg) from exc
 
+        # Pop existing key to maintain insertion order if updated
+        self._pending_otps.pop(bearer, None)
+
         # Store pending OTP state
         self._pending_otps[bearer] = {
             "bearer": bearer,
@@ -310,11 +313,14 @@ class TelegramAuthProvider:
                 removed += 1
 
         # Also clean up stale pending OTPs (5 min TTL)
-        stale_otps = [
-            b for b, p in self._pending_otps.items() if now - p["created_at"] > 300
-        ]
-        for bearer in stale_otps:
-            pending = self._pending_otps.pop(bearer)
+        # Using dict insertion order allows O(1) time-based popping
+        while self._pending_otps:
+            bearer = next(iter(self._pending_otps))
+            pending = self._pending_otps[bearer]
+            if now - pending["created_at"] <= 300:
+                break
+            # Pop the stale item directly
+            self._pending_otps.pop(bearer)
             await pending["backend"].disconnect()
             removed += 1
 

--- a/uv.lock
+++ b/uv.lock
@@ -76,7 +76,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.3.0"
+version = "4.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
💡 **What:** 
Replaced a `$O(N)$` list comprehension scanning `self._pending_otps` with an amortized `$O(1)$` `while` loop that takes advantage of Python's dictionary insertion ordering. Explicitly updated `start_user_auth` to `pop` an existing bearer key before recreating the element, guaranteeing strict time-ordered insertion.

🎯 **Why:** 
The background cleanup task runs periodically. In systems with a large volume of pending OTPs, doing a full map traversal and allocating an intermediate list every time creates unnecessary CPU overhead and memory churn.

📊 **Impact:** 
Reduces the time complexity of the periodic background OTP cleanup step from `$O(N)$` to `$O(1)$` (amortized) by only checking the oldest elements and breaking early as soon as a non-stale element is found.

🔬 **Measurement:** 
Unit tests pass completely. Verifiable in a micro-benchmark context where checking the time elapsed of `cleanup_expired` on a dictionary populated with >10,000 active OTPs completes near-instantly compared to iterating over the entire dictionary values list.

---
*PR created automatically by Jules for task [4241282937948653326](https://jules.google.com/task/4241282937948653326) started by @n24q02m*