### PR TITLE
[TEST] Missing edge case test for get_current_backend

### DIFF
--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -165,3 +165,25 @@ class TestStartHttp:
             # Assert inside the context manager before patch.dict restores env
             assert os.environ.get("TELEGRAM_BOT_TOKEN") == "env-token-123"
             assert os.environ.get("TELEGRAM_API_ID") == "99999"
+
+
+class TestGetCurrentBackend:
+    def test_get_current_backend_none(self) -> None:
+        """Should return None when no backend is set in context."""
+        from better_telegram_mcp.transports.http import get_current_backend
+
+        assert get_current_backend() is None
+
+    def test_get_current_backend_set(self) -> None:
+        """Should return the backend when set in context."""
+        from better_telegram_mcp.transports.http import (
+            _current_backend,
+            get_current_backend,
+        )
+
+        mock_backend = MagicMock()
+        token = _current_backend.set(mock_backend)
+        try:
+            assert get_current_backend() is mock_backend
+        finally:
+            _current_backend.reset(token)


### PR DESCRIPTION
Added unit tests for `get_current_backend` in `src/better_telegram_mcp/transports/http.py`.

The new tests cover:
- Default case: returns `None` when no backend is set in the `ContextVar`.
- Set case: returns the injected backend when the `ContextVar` is populated.

These tests ensure that the per-user backend injection mechanism used in multi-user HTTP mode is working as expected and maintains context isolation.

---
*PR created automatically by Jules for task [9106850990268390055](https://jules.google.com/task/9106850990268390055) started by @n24q02m*