### PR TITLE
[CLEANUP] Swallowed Exception

### DIFF
--- a/src/better_telegram_mcp/credential_state.py
+++ b/src/better_telegram_mcp/credential_state.py
@@ -109,8 +109,8 @@ def resolve_credential_state() -> CredentialState:
                 logger.info("Config loaded from encrypted file")
                 _state = CredentialState.CONFIGURED
                 return _state
-    except Exception:
-        pass
+    except Exception as e:
+        logger.debug("Failed to read config file: {}", e)
 
     # 3. Check saved Telethon session files
     if check_saved_sessions():
@@ -240,8 +240,8 @@ async def _poll_relay_background(
                     "text": "Telegram config saved. Setup complete!",
                 },
             )
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("Failed to send relay completion message: {}", e)
 
         _state = CredentialState.CONFIGURED
         logger.info("Relay config applied successfully")
@@ -265,7 +265,8 @@ async def _poll_relay_background(
             logger.info("Relay skipped by user. Credentials still required.")
         else:
             _state = CredentialState.AWAITING_SETUP
-    except Exception:
+    except Exception as e:
+        logger.error("Relay polling failed: {}", e)
         _state = CredentialState.AWAITING_SETUP
 
 
@@ -384,8 +385,8 @@ def reset_state() -> None:
         from mcp_core.storage.config_file import delete_config
 
         delete_config(SERVER_NAME)
-    except Exception:
-        pass
+    except Exception as e:
+        logger.debug("Failed to delete config: {}", e)
 
 
 async def on_step_submitted(step_data: dict[str, str]) -> dict | None:
@@ -429,8 +430,8 @@ async def on_step_submitted(step_data: dict[str, str]) -> dict | None:
             # Terminal failure (non-2FA) -- clean up so next attempt starts fresh.
             try:
                 await _step_backend.disconnect()
-            except Exception:
-                pass
+            except Exception as e_inner:
+                logger.debug("Failed to disconnect backend: {}", e_inner)
             _step_backend = None
             _step_phone = ""
             _step_otp_code = None
@@ -456,8 +457,8 @@ async def on_step_submitted(step_data: dict[str, str]) -> dict | None:
             # Terminal failure -- clean up so next attempt starts fresh.
             try:
                 await _step_backend.disconnect()
-            except Exception:
-                pass
+            except Exception as e_inner:
+                logger.debug("Failed to disconnect backend: {}", e_inner)
             _step_backend = None
             _step_phone = ""
             _step_otp_code = None
@@ -478,8 +479,8 @@ async def _finalize_auth() -> None:
     if _step_backend is not None:
         try:
             await _step_backend.disconnect()
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("Failed to disconnect backend during finalization: {}", e)
 
     _step_backend = None
     _step_phone = ""

--- a/tests/test_credential_state.py
+++ b/tests/test_credential_state.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -834,3 +834,71 @@ async def test_on_step_submitted_unexpected_input_returns_error():
     result = await cs.on_step_submitted({"random_key": "value"})
     assert result is not None
     assert result["type"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_poll_relay_background_send_message_error_logs_debug():
+    """Verify that send_message failure in _poll_relay_background logs a debug message."""
+    import better_telegram_mcp.credential_state as cs
+    from better_telegram_mcp.credential_state import _poll_relay_background
+
+    cs._state = CredentialState.SETUP_IN_PROGRESS
+
+    mock_session = MagicMock()
+    mock_session.session_id = "sess-err-log"
+    config = {"TELEGRAM_BOT_TOKEN": "bot:errlogtoken"}
+
+    with (
+        patch.dict(os.environ, {}, clear=False),
+        patch(
+            "mcp_core.relay.client.poll_for_result",
+            new_callable=AsyncMock,
+            return_value=config,
+        ),
+        patch("mcp_core.storage.config_file.write_config"),
+        patch(
+            "better_telegram_mcp.relay_setup._is_user_mode_config",
+            return_value=False,
+        ),
+        patch(
+            "mcp_core.relay.client.send_message",
+            new_callable=AsyncMock,
+            side_effect=Exception("network flake"),
+        ),
+        patch(
+            "mcp_core.release_session_lock",
+            new_callable=AsyncMock,
+        ),
+        patch("better_telegram_mcp.credential_state.logger") as mock_logger,
+    ):
+        os.environ.pop("TELEGRAM_BOT_TOKEN", None)
+        await _poll_relay_background("https://relay", mock_session, None)
+
+    # Check if logger.debug was called with the expected message
+    # The message is "Failed to send relay completion message: network flake"
+    mock_logger.debug.assert_any_call(
+        "Failed to send relay completion message: {}", ANY
+    )
+
+    # Clean up
+    os.environ.pop("TELEGRAM_BOT_TOKEN", None)
+
+
+@pytest.mark.asyncio
+async def test_poll_relay_background_generic_exception_logs_error():
+    """Verify that generic exception in _poll_relay_background logs an error message."""
+    from better_telegram_mcp.credential_state import _poll_relay_background
+
+    mock_session = MagicMock()
+
+    with (
+        patch(
+            "mcp_core.relay.client.poll_for_result",
+            new_callable=AsyncMock,
+            side_effect=ValueError("unexpected format"),
+        ),
+        patch("better_telegram_mcp.credential_state.logger") as mock_logger,
+    ):
+        await _poll_relay_background("https://relay", mock_session, None)
+
+    mock_logger.error.assert_called_once_with("Relay polling failed: {}", ANY)

--- a/uv.lock
+++ b/uv.lock
@@ -76,7 +76,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.3.0"
+version = "4.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
The `credential_state.py` module had several instances where exceptions were being swallowed using `except Exception: pass`. Swallowing exceptions can hide bugs and make troubleshooting difficult.

This PR:
- Replaces `pass` with `logger.debug` in non-critical blocks (e.g., during cleanup or optional file reads).
- Replaces `pass` with `logger.error` in the relay polling loop to capture terminal failures.
- Ensures nested exception handlers use unique variable names (`e_inner`) to avoid shadowing.
- Adds unit tests to verify that the logger is correctly invoked when these exceptions occur.

All tests passed, and formatting was checked with ruff.

---
*PR created automatically by Jules for task [1143380226175653106](https://jules.google.com/task/1143380226175653106) started by @n24q02m*