### PR TITLE
🛡️ Sentinel: Low Fix sensitive information leak in logs

### DIFF
--- a/src/better_telegram_mcp/auth_client.py
+++ b/src/better_telegram_mcp/auth_client.py
@@ -54,7 +54,7 @@ class AuthClient:
         data = resp.json()
         self.url = data["url"]
         self._token = data["token"]
-        logger.info("Auth session created: {}", self.url)
+        logger.info("Auth session created")
         return self.url
 
     async def poll_and_execute(self) -> None:

--- a/tests/test_auth_client.py
+++ b/tests/test_auth_client.py
@@ -1,0 +1,41 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from loguru import logger
+
+from better_telegram_mcp.auth_client import AuthClient
+from better_telegram_mcp.config import Settings
+
+
+@pytest.fixture
+def caplog_loguru(caplog):
+    handler_id = logger.add(caplog.handler, format="{message}", level="INFO")
+    yield caplog
+    logger.remove(handler_id)
+
+
+@pytest.mark.asyncio
+async def test_create_session_does_not_log_url(caplog_loguru, caplog):
+    # Mock settings and backend
+    settings = Settings(phone="+1234567890", auth_url="https://example.com")
+    backend = MagicMock()
+
+    client = AuthClient(backend, settings)
+
+    # Mock httpx response
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.return_value = {
+        "url": "https://example.com/auth?token=secret_token",
+        "token": "secret_token",
+    }
+
+    with patch.object(client._client, "post", AsyncMock(return_value=mock_resp)):
+        url = await client.create_session()
+
+    assert url == "https://example.com/auth?token=secret_token"
+
+    # Check logs: "Auth session created" should be there, but NOT the URL
+    assert "Auth session created" in caplog.text
+    assert "https://example.com/auth?token=secret_token" not in caplog.text
+    assert "secret_token" not in caplog.text


### PR DESCRIPTION
The auth session URL, which contains a sensitive token, was being logged in plaintext. This PR removes the URL from the log statement in `AuthClient.create_session` to prevent exposure in application logs.

Changes:
- Modified `src/better_telegram_mcp/auth_client.py` to remove `self.url` from `logger.info`.
- Added `tests/test_auth_client.py` with a test case that verifies the fix by checking `loguru` output.

---
*PR created automatically by Jules for task [12421053077997634354](https://jules.google.com/task/12421053077997634354) started by @n24q02m*