### PR TITLE
[CLEANUP] Swallowed Exception Cleanup

### DIFF
--- a/src/better_telegram_mcp/credential_state.py
+++ b/src/better_telegram_mcp/credential_state.py
@@ -109,8 +109,8 @@ def resolve_credential_state() -> CredentialState:
                 logger.info("Config loaded from encrypted file")
                 _state = CredentialState.CONFIGURED
                 return _state
-    except Exception:
-        pass
+    except Exception as e:
+        logger.debug("Failed to read config during state resolution: {}", e)
 
     # 3. Check saved Telethon session files
     if check_saved_sessions():
@@ -240,8 +240,8 @@ async def _poll_relay_background(
                     "text": "Telegram config saved. Setup complete!",
                 },
             )
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("Failed to notify relay of completion: {}", e)
 
         _state = CredentialState.CONFIGURED
         logger.info("Relay config applied successfully")
@@ -265,7 +265,8 @@ async def _poll_relay_background(
             logger.info("Relay skipped by user. Credentials still required.")
         else:
             _state = CredentialState.AWAITING_SETUP
-    except Exception:
+    except Exception as e:
+        logger.warning("Relay polling failed: {}", e)
         _state = CredentialState.AWAITING_SETUP
 
 
@@ -384,8 +385,8 @@ def reset_state() -> None:
         from mcp_core.storage.config_file import delete_config
 
         delete_config(SERVER_NAME)
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning("Failed to delete config during state reset: {}", e)
 
 
 async def on_step_submitted(step_data: dict[str, str]) -> dict | None:
@@ -429,8 +430,8 @@ async def on_step_submitted(step_data: dict[str, str]) -> dict | None:
             # Terminal failure (non-2FA) -- clean up so next attempt starts fresh.
             try:
                 await _step_backend.disconnect()
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug("Best-effort disconnect failed: {}", e)
             _step_backend = None
             _step_phone = ""
             _step_otp_code = None
@@ -456,8 +457,8 @@ async def on_step_submitted(step_data: dict[str, str]) -> dict | None:
             # Terminal failure -- clean up so next attempt starts fresh.
             try:
                 await _step_backend.disconnect()
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug("Best-effort disconnect failed: {}", e)
             _step_backend = None
             _step_phone = ""
             _step_otp_code = None
@@ -478,8 +479,8 @@ async def _finalize_auth() -> None:
     if _step_backend is not None:
         try:
             await _step_backend.disconnect()
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("Best-effort disconnect failed: {}", e)
 
     _step_backend = None
     _step_phone = ""

--- a/tests/test_credential_state.py
+++ b/tests/test_credential_state.py
@@ -91,17 +91,21 @@ def test_reset_state():
 
 
 def test_reset_state_delete_config_error():
-    """reset_state swallows delete_config errors."""
+    """reset_state logs delete_config errors."""
     import better_telegram_mcp.credential_state as cs
 
     cs._state = CredentialState.CONFIGURED
     cs._setup_url = "https://example.com/setup"
 
-    with patch(
-        "mcp_core.storage.config_file.delete_config",
-        side_effect=Exception("disk error"),
+    with (
+        patch(
+            "mcp_core.storage.config_file.delete_config",
+            side_effect=Exception("disk error"),
+        ),
+        patch("better_telegram_mcp.credential_state.logger") as mock_logger,
     ):
         reset_state()
+    mock_logger.warning.assert_called_once()
 
     assert get_state() == CredentialState.AWAITING_SETUP
     assert get_setup_url() is None


### PR DESCRIPTION
Replaced multiple instances of swallowed exceptions (`except Exception: pass`) with appropriate logging in `src/better_telegram_mcp/credential_state.py`. 

- In `resolve_credential_state`, `_poll_relay_background` (relay notification), `on_step_submitted`, and `_finalize_auth` (disconnects), swallowed exceptions are now logged at `DEBUG` level since these are non-critical or expected during certain cleanup flows.
- In `reset_state` and the main `_poll_relay_background` loop, exceptions are now logged at `WARNING` level as they indicate unexpected failures during configuration management or relay polling.

Updated `tests/test_credential_state.py` to verify that `reset_state` correctly logs a warning when configuration deletion fails. All 42 unit tests passed.

---
*PR created automatically by Jules for task [14953145391908233654](https://jules.google.com/task/14953145391908233654) started by @n24q02m*