### PR TITLE
[PERF] Suboptimal List Iteration for Removal

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,13 @@
+
+## [2024-05-22] Suboptimal List Iteration for Removal
+
+**What:** Refactored dictionary cleanup and session management logic in `TelegramAuthProvider`.
+
+**Why:**
+- `revoke_session`: Replaced list comprehension + manual loop with a single dictionary comprehension for `session_owners`. This avoids intermediate list allocation and repeated dictionary resizing during `del` operations.
+- `cleanup_expired`: Replaced (N)$ scan of `_pending_otps` with an (k)$ cleanup loop using `next(iter())`, where $ is the number of stale items.
+- `start_user_auth`: Ensured chronological ordering of `_pending_otps` by `pop()`-ing existing keys before re-insertion, enabling the early-exit optimization in `cleanup_expired`.
+
+**Impact:** Improved performance and reduced memory overhead for multi-user session lifecycles.
+
+**Measurement:** Constant factor improvement for revocation ((N)$ rebuild vs (N)$ scan + (1)$ deletes); algorithmic improvement for cleanup ((N)$ scan $\to$ (k)$ early exit).

--- a/src/better_telegram_mcp/auth/telegram_auth_provider.py
+++ b/src/better_telegram_mcp/auth/telegram_auth_provider.py
@@ -293,7 +293,9 @@ class TelegramAuthProvider:
             await pending["backend"].disconnect()
 
         # Remove from ownership map
-        self.session_owners = {sid: b for sid, b in self.session_owners.items() if b != bearer}
+        self.session_owners = {
+            sid: b for sid, b in self.session_owners.items() if b != bearer
+        }
 
         return self._store.delete(bearer)
 

--- a/src/better_telegram_mcp/auth/telegram_auth_provider.py
+++ b/src/better_telegram_mcp/auth/telegram_auth_provider.py
@@ -211,7 +211,8 @@ class TelegramAuthProvider:
             msg = f"Failed to send code: {exc}"
             raise ValueError(msg) from exc
 
-        # Store pending OTP state
+        # Store pending OTP state (pop first to ensure it moves to the end of insertion-ordered dict)
+        self._pending_otps.pop(bearer, None)
         self._pending_otps[bearer] = {
             "bearer": bearer,
             "backend": backend,
@@ -292,9 +293,7 @@ class TelegramAuthProvider:
             await pending["backend"].disconnect()
 
         # Remove from ownership map
-        to_remove = [sid for sid, b in self.session_owners.items() if b == bearer]
-        for sid in to_remove:
-            del self.session_owners[sid]
+        self.session_owners = {sid: b for sid, b in self.session_owners.items() if b != bearer}
 
         return self._store.delete(bearer)
 
@@ -310,13 +309,15 @@ class TelegramAuthProvider:
                 removed += 1
 
         # Also clean up stale pending OTPs (5 min TTL)
-        stale_otps = [
-            b for b, p in self._pending_otps.items() if now - p["created_at"] > 300
-        ]
-        for bearer in stale_otps:
-            pending = self._pending_otps.pop(bearer)
-            await pending["backend"].disconnect()
-            removed += 1
+        while self._pending_otps:
+            bearer = next(iter(self._pending_otps))
+            pending = self._pending_otps[bearer]
+            if now - pending["created_at"] > 300:
+                self._pending_otps.pop(bearer)
+                await pending["backend"].disconnect()
+                removed += 1
+            else:
+                break
 
         return removed
 


### PR DESCRIPTION
Optimized session removal and cleanup in \`TelegramAuthProvider\` to improve performance and reduce memory overhead.

Key changes:
1. **\`revoke_session\`**: Replaced the inefficient list comprehension and manual loop for removing items from \`session_owners\` with a concise dictionary comprehension. This avoids intermediate list allocation and multiple dictionary mutations.
2. **\`cleanup_expired\`**: Implemented the Bolt performance pattern for stale OTP cleanup. By using a \`while\` loop with \`next(iter(self._pending_otps))\`, the method now performs an $O(k)$ cleanup (where $k$ is the number of stale items) instead of an $O(N)$ full scan of all pending authentications.
3. **\`start_user_auth\`**: Modified to \`pop()\` existing bearer tokens before re-insertion. This ensures that updated or retried authentications are moved to the end of the insertion-ordered dictionary, maintaining the strict chronological order required for the \`cleanup_expired\` optimization to work correctly.

These changes collectively reduce the overhead of managing per-user sessions in multi-user HTTP mode.

---
*PR created automatically by Jules for task [6181273555981931960](https://jules.google.com/task/6181273555981931960) started by @n24q02m*