### PR TITLE
[FIX] Sensitive token logged in URL

### DIFF
--- a/src/better_telegram_mcp/auth_server.py
+++ b/src/better_telegram_mcp/auth_server.py
@@ -384,7 +384,9 @@ class AuthServer:
                 raise RuntimeError(
                     f"Could not start server on port {self.port}: {e}"
                 ) from e
-        logger.info("Auth server started at {}", self.url)
+        logger.info(
+            "Auth server started at http://127.0.0.1:{} (token masked)", self.port
+        )
         return self.url
 
     async def wait_for_auth(self) -> None:

--- a/tests/test_auth_server.py
+++ b/tests/test_auth_server.py
@@ -294,3 +294,35 @@ class TestAuthServerStart:
 
             with pytest.raises(RuntimeError, match="Could not start server"):
                 await server.start()
+
+    @pytest.mark.asyncio
+    async def test_start_logs_masked_url(self, caplog):
+        backend = MagicMock()
+        settings = MagicMock()
+        settings.phone = "+1234567890"
+        server = AuthServer(backend, settings)
+
+        with patch("uvicorn.Server") as mock_server_class:
+            mock_instance = mock_server_class.return_value
+            mock_instance.serve = AsyncMock()
+
+            # caplog doesn't work out-of-the-box with loguru,
+            # but we can patch loguru's logger or use a different approach.
+            # Let's patch loguru.logger.info.
+            with patch("better_telegram_mcp.auth_server.logger.info") as mock_logger:
+                await server.start()
+
+                # Check that info was called
+                assert mock_logger.called
+
+                # Check that the token is NOT in any of the logged messages
+                for call in mock_logger.call_args_list:
+                    message = call.args[0]
+                    # Loguru uses {} for formatting, but here we are checking the template or the formatted string
+                    # Our change was: logger.info("Auth server started at http://127.0.0.1:{} (token masked)", self.port)
+                    assert server._token not in message
+                    if "Auth server started at" in message:
+                        assert "token masked" in message
+                        assert "token=" not in message
+
+            await server.stop()


### PR DESCRIPTION
This PR addresses a security issue where a sensitive authentication token was being logged in plain text when starting the local auth server.

Key changes:
- Modified `src/better_telegram_mcp/auth_server.py` to mask the token in the `logger.info` call.
- Added a new test case `test_start_logs_masked_url` in `tests/test_auth_server.py` to ensure the token does not appear in logs.
- Verified that all existing tests pass and linting/formatting is correct.

---
*PR created automatically by Jules for task [6884953951495470863](https://jules.google.com/task/6884953951495470863) started by @n24q02m*