### PR TITLE
[CLEANUP] Swallowed Exception

### DIFF
--- a/src/better_telegram_mcp/auth/telegram_auth_provider.py
+++ b/src/better_telegram_mcp/auth/telegram_auth_provider.py
@@ -343,9 +343,9 @@ class TelegramAuthProvider:
         self.session_owners.clear()
 
         # Disconnect pending OTP backends
-        for _bearer, pending in list(self._pending_otps.items()):
+        for bearer, pending in list(self._pending_otps.items()):
             try:
                 await pending["backend"].disconnect()
             except Exception:
-                pass
+                logger.warning("Error disconnecting pending OTP backend {}", bearer[:8])
         self._pending_otps.clear()

--- a/tests/test_telegram_auth_provider_cleanup.py
+++ b/tests/test_telegram_auth_provider_cleanup.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from loguru import logger
+
+from better_telegram_mcp.auth.telegram_auth_provider import TelegramAuthProvider
+
+
+@pytest.fixture
+def data_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "data"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def provider(data_dir: Path) -> TelegramAuthProvider:
+    return TelegramAuthProvider(data_dir, api_id=12345, api_hash="test_hash")
+
+
+async def test_shutdown_logs_pending_otp_disconnect_error(
+    provider: TelegramAuthProvider, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Should log a warning if a pending OTP backend fails to disconnect during shutdown."""
+    # Propagate loguru to caplog
+    handler_id = logger.add(caplog.handler, format="{message}", level="WARNING")
+
+    try:
+        mock_backend = AsyncMock()
+        mock_backend.disconnect.side_effect = Exception("Disconnect failed")
+
+        provider._pending_otps["test-bearer"] = {
+            "bearer": "test-bearer",
+            "backend": mock_backend,
+            "phone": "+1234567890",
+            "phone_code_hash": "hash",
+            "session_name": "test-session",
+            "created_at": time.time(),
+        }
+
+        await provider.shutdown()
+
+        assert mock_backend.disconnect.called
+        assert "test-bearer" not in provider._pending_otps
+
+        # Verify that the warning was logged
+        assert "Error disconnecting pending OTP backend test-bea" in caplog.text
+    finally:
+        logger.remove(handler_id)


### PR DESCRIPTION
Modified `src/better_telegram_mcp/auth/telegram_auth_provider.py` to log a warning when a pending OTP backend fails to disconnect during shutdown, instead of swallowing the exception. Swallowing exceptions can hide bugs, so it's now logged with `logger.warning`. Added `tests/test_telegram_auth_provider_cleanup.py` to verify the fix.

---
*PR created automatically by Jules for task [9946677487153187983](https://jules.google.com/task/9946677487153187983) started by @n24q02m*