### PR TITLE
🎨 Palette: Add CSS loading spinner to auth buttons

### DIFF
--- a/src/better_telegram_mcp/auth_server.py
+++ b/src/better_telegram_mcp/auth_server.py
@@ -52,6 +52,9 @@ button{width:100%;padding:.75rem;background:#3b82f6;color:#fff;border:none;
   border-radius:8px;font-size:1rem;cursor:pointer;font-weight:500}
 button:hover{background:#2563eb}
 button:disabled{background:#333;color:#666;cursor:not-allowed}
+button[aria-busy="true"]{color:transparent!important;position:relative;pointer-events:none;opacity:1!important;background:#3b82f6!important}
+button[aria-busy="true"]::after{content:"";position:absolute;left:50%;top:50%;width:1.25rem;height:1.25rem;margin:-0.625rem 0 0 -0.625rem;border:2px solid rgba(255,255,255,0.3);border-top-color:#fff;border-radius:50%;animation:spin 0.8s linear infinite}
+@keyframes spin{to{transform:rotate(360deg)}}
 .st{margin-top:1rem;padding:.75rem;border-radius:8px;font-size:.875rem;display:none}
 .st.error{display:block;background:#2d1111;border:1px solid #dc2626;color:#f87171}
 .st.success{display:block;background:#0d2818;border:1px solid #16a34a;color:#4ade80}


### PR DESCRIPTION
💡 **What**: Added CSS rules in `src/better_telegram_mcp/auth_server.py` to display a loading spinner inside buttons when they have the semantic `aria-busy="true"` attribute.
🎯 **Why**: When users click "Send OTP Code" or "Verify Code", there's an asynchronous network request. While the button text changes (e.g., to "Sending..."), adding a visual spinner makes the loading state much clearer and feels more responsive, matching modern UI patterns.
♿ **Accessibility**: Leverages the existing semantic `aria-busy` attribute, ensuring screen readers are aware of the busy state while simultaneously providing the visual cue for sighted users.

---
*PR created automatically by Jules for task [8150037509741231530](https://jules.google.com/task/8150037509741231530) started by @n24q02m*