### PR TITLE
feat: fix user-mode OTP flow over remote relay and patch bot token leak

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,3 +68,29 @@ NO `TELEGRAM_PASSWORD` -- 2FA nhap qua web UI, KHONG luu env.
 - Coverage omit: auth_server.py, auth_client.py (integration test only)
 - Security: SSRF, path traversal, error sanitization, rate limiting on relay
 - Infisical project: `29457d18-fd82-4942-9330-7da7982e6b1d`
+
+## Known bugs (phat hien 2026-04-18 E2E)
+
+**CRITICAL SECURITY BUG: Bot token leak trong stderr logs**:
+- `src/better_telegram_mcp/backends/bot_backend.py:24`: `self._base_url = API_BASE.format(bot_token)` -> httpx.AsyncClient(base_url=...) -> **httpx default INFO logging** print full URL incluing bot token len stderr (vi du: `https://api.telegram.org/bot8739495379:AAF-qAG...ta redacted/sendMessage "HTTP/1.1 200 OK"`)
+- Bot token co the bi leak qua: (1) log file, (2) monitoring dashboards, (3) screenshots, (4) error reports
+- **Fix required:**
+  (a) set logger level cho `httpx` library = WARNING (tat INFO-level HTTP request logs), HOAC
+  (b) dung httpx event_hooks de redact token trong URL truoc khi log, HOAC
+  (c) pass bot_token qua httpx `params` thay vi URL (khong dang vi Telegram API spec requires URL)
+- **Option (a) don gian nhat:** them vao `init-server.ts` / server startup: `logging.getLogger("httpx").setLevel(logging.WARNING)`
+- Phat hien 2026-04-18 E2E test: phase 2 tools call dump URL with token in stderr
+
+1. **User mode OTP/2FA flow BROKEN o relay page**:
+   - Steps thuc te: submit phone -> relay bao "done" -> server **KHONG** prompt OTP -> session never authorized (`authorized=false`, `pending_auth=true`)
+   - Root cause: `src/better_telegram_mcp/relay_schema.py` `RELAY_SCHEMA` chi co flat fields `TELEGRAM_BOT_TOKEN` + `TELEGRAM_PHONE`. KHONG co multi-step cho OTP + 2FA password
+   - Per credential_state.py:208: "User-mode OTP/2FA now runs through the local OAuth form + /otp endpoint" -- nghia la browser SHOULD redirect tu relay den local 127.0.0.1:PORT/otp. Nhung browser khong redirect -> user mac ket
+   - **Impact:** User mode (MTProto) ho`ang hoan toan. Chi bot mode co the su dung.
+   - **Fix required:**
+     (a) update RELAY_SCHEMA them multi-step: phone -> submit -> show OTP input -> submit -> if 2FA enabled show password input -> submit, HOAC
+     (b) relay page redirect den local 127.0.0.1/otp sau khi phone save, HOAC
+     (c) su dung RELAY_SCHEMA_MODES (da co san o line 46) thay vi flat RELAY_SCHEMA
+
+2. **Bot mode**: chua verify end-to-end (phase M E2E 2026-04-18 time-out chua test bot)
+
+3. **Relay "Setup complete" browser UI** (if Python core-py has same bug): chua observe, nhung neu user mode fix xong, can verify browser hien "Setup complete!" sau OTP done

--- a/src/better_telegram_mcp/auth/telegram_auth_provider.py
+++ b/src/better_telegram_mcp/auth/telegram_auth_provider.py
@@ -218,7 +218,6 @@ class TelegramAuthProvider:
         if (existing := self._pending_otps.pop(bearer, None)) is not None:
             await existing["backend"].disconnect()
 
-
         self._pending_otps[bearer] = {
             "bearer": bearer,
             "backend": backend,

--- a/src/better_telegram_mcp/credential_state.py
+++ b/src/better_telegram_mcp/credential_state.py
@@ -590,8 +590,8 @@ async def on_step_submitted(step_data: dict[str, str]) -> dict | None:
             # Terminal failure (non-2FA) -- clean up so next attempt starts fresh.
             try:
                 await _step_backend.disconnect()
-            except Exception as e:
-                logger.debug("Best-effort disconnect failed: {}", e)
+            except Exception as disconnect_err:
+                logger.debug("Best-effort disconnect failed: {}", disconnect_err)
             _step_backend = None
             _step_phone = ""
             _step_otp_code = None
@@ -614,17 +614,18 @@ async def on_step_submitted(step_data: dict[str, str]) -> dict | None:
             await _finalize_auth()
             return None
         except Exception as e:
+            error_msg = str(e)
             # Terminal failure -- clean up so next attempt starts fresh.
             try:
                 await _step_backend.disconnect()
-            except Exception as e:
-                logger.debug("Best-effort disconnect failed: {}", e)
+            except Exception as disconnect_err:
+                logger.debug("Best-effort disconnect failed: {}", disconnect_err)
             _step_backend = None
             _step_phone = ""
             _step_otp_code = None
             return {
                 "type": "error",
-                "text": f"2FA failed: {_sanitize_error(str(e))}",
+                "text": f"2FA failed: {_sanitize_error(error_msg)}",
             }
 
     return {"type": "error", "text": "Unexpected input."}

--- a/src/better_telegram_mcp/credential_state.py
+++ b/src/better_telegram_mcp/credential_state.py
@@ -203,15 +203,28 @@ async def trigger_relay_setup(
 async def _poll_relay_background(
     relay_base: str, session: object, timeout: float | None
 ) -> None:
-    """Background task that polls relay and applies config when user submits.
+    """Background task that polls relay, saves config, and orchestrates
+    multi-step user-mode OTP/2FA via relay bidirectional messaging.
 
-    User-mode OTP/2FA now runs through the local OAuth form + ``/otp`` endpoint
-    (``save_credentials`` + ``on_step_submitted``), so this background task only
-    persists credentials and notifies the relay session of completion.
+    Flow:
+    - Poll relay for initial credential submission (bot token or user phone).
+    - Bot mode: save, mark configured, send ``complete`` to browser.
+    - User mode: save phone, trigger Telethon send_code, then push
+      ``input_required`` message to browser for OTP. Poll response, forward
+      to ``on_step_submitted``. If 2FA required, push another ``input_required``
+      for password. Finalize and send ``complete``.
+
+    This reuses mcp-core primitives ``send_message`` + ``poll_for_responses``
+    together with the shared browser UI ``startMessagePolling`` (which already
+    renders ``input_required`` dynamic inputs).
     """
     global _state
     try:
-        from mcp_core.relay.client import poll_for_result
+        from mcp_core.relay.client import (
+            poll_for_responses,
+            poll_for_result,
+            send_message,
+        )
         from mcp_core.storage.config_file import write_config
 
         poll_timeout = timeout if timeout is not None else 300.0
@@ -225,33 +238,35 @@ async def _poll_relay_background(
             if value and key not in os.environ:
                 os.environ[key] = value
 
-        # Notify relay completion (bot + user mode). For user mode the actual
-        # Telethon OTP/2FA exchange now happens via the OAuth form's /otp
-        # endpoint (see ``save_credentials`` + ``on_step_submitted``); no more
-        # relay-driven OTP prompts here.
-        try:
-            from mcp_core.relay.client import send_message
+        is_user_mode = bool(config.get("TELEGRAM_PHONE")) and not config.get(
+            "TELEGRAM_BOT_TOKEN"
+        )
 
-            await send_message(
-                relay_base,
-                session.session_id,
-                {
-                    "type": "complete",
-                    "text": "Telegram config saved. Setup complete!",
-                },
+        if is_user_mode:
+            await _run_user_mode_relay_flow(
+                relay_base, session, config, send_message, poll_for_responses
             )
-        except Exception as e:
-            logger.debug("Failed to notify relay of completion: {}", e)
-
-        _state = CredentialState.CONFIGURED
-        logger.info("Relay config applied successfully")
-
-        # Hot-reload: reinitialize backend so tools work without restart
-        if _on_configured_callback:
+        else:
+            # Bot mode: configure immediately and notify browser
+            _state = CredentialState.CONFIGURED
+            if _on_configured_callback:
+                try:
+                    await _on_configured_callback()
+                except Exception as e:
+                    logger.warning("Backend reinit after relay failed: {}", e)
             try:
-                await _on_configured_callback()
+                await send_message(
+                    relay_base,
+                    session.session_id,
+                    {
+                        "type": "complete",
+                        "text": "Telegram config saved. Setup complete!",
+                    },
+                )
             except Exception as e:
-                logger.warning("Backend reinit after relay failed: {}", e)
+                logger.debug("Failed to notify relay of completion: {}", e)
+
+        logger.info("Relay config applied successfully")
 
         # Release session lock
         from mcp_core import release_session_lock
@@ -268,6 +283,151 @@ async def _poll_relay_background(
     except Exception as e:
         logger.warning("Relay polling failed: {}", e)
         _state = CredentialState.AWAITING_SETUP
+
+
+async def _run_user_mode_relay_flow(
+    relay_base: str,
+    session: object,
+    config: dict[str, str],
+    send_message_fn,
+    poll_for_responses_fn,
+) -> None:
+    """Drive the OTP + optional 2FA exchange over the relay channel.
+
+    Uses the same helpers as the local OAuth form (``save_credentials`` +
+    ``on_step_submitted``) so Telethon state lives in one place regardless
+    of which front-end the user chose.
+    """
+    global _state
+
+    # Step 1: trigger Telethon connect + send_code
+    prompt = await save_credentials(config)
+    if prompt is None:
+        # save_credentials already marked configured (shouldn't happen for user mode)
+        await send_message_fn(
+            relay_base,
+            session.session_id,
+            {"type": "complete", "text": "Telegram user mode setup complete!"},
+        )
+        return
+    if prompt.get("type") == "error":
+        await send_message_fn(
+            relay_base,
+            session.session_id,
+            {"type": "error", "text": prompt.get("text", "Failed to send OTP")},
+        )
+        _state = CredentialState.AWAITING_SETUP
+        return
+
+    # Step 2: ask browser for OTP code via input_required
+    otp_code = await _ask_browser_for_input(
+        relay_base,
+        session.session_id,
+        text=prompt.get("text", "Enter the OTP code sent to your Telegram app"),
+        input_type=prompt.get("input_type", "text"),
+        placeholder="OTP code",
+        send_message_fn=send_message_fn,
+        poll_for_responses_fn=poll_for_responses_fn,
+    )
+    if otp_code is None:
+        _state = CredentialState.AWAITING_SETUP
+        return
+
+    # Step 3: submit OTP to Telethon via on_step_submitted
+    result = await on_step_submitted({"otp_code": otp_code})
+    if result is None:
+        # Success, no 2FA required
+        await send_message_fn(
+            relay_base,
+            session.session_id,
+            {"type": "complete", "text": "Telegram user mode setup complete!"},
+        )
+        return
+    if result.get("type") == "error":
+        await send_message_fn(
+            relay_base,
+            session.session_id,
+            {"type": "error", "text": result.get("text", "OTP verification failed")},
+        )
+        _state = CredentialState.AWAITING_SETUP
+        return
+
+    if result.get("type") != "password_required":
+        await send_message_fn(
+            relay_base,
+            session.session_id,
+            {"type": "error", "text": "Unexpected auth response from server."},
+        )
+        _state = CredentialState.AWAITING_SETUP
+        return
+
+    # Step 4: ask browser for 2FA password
+    password = await _ask_browser_for_input(
+        relay_base,
+        session.session_id,
+        text=result.get("text", "Enter your Telegram 2FA password"),
+        input_type=result.get("input_type", "password"),
+        placeholder="2FA password",
+        send_message_fn=send_message_fn,
+        poll_for_responses_fn=poll_for_responses_fn,
+    )
+    if password is None:
+        _state = CredentialState.AWAITING_SETUP
+        return
+
+    # Step 5: submit password
+    final = await on_step_submitted({"password": password})
+    if final is None:
+        await send_message_fn(
+            relay_base,
+            session.session_id,
+            {"type": "complete", "text": "Telegram user mode setup complete!"},
+        )
+    else:
+        await send_message_fn(
+            relay_base,
+            session.session_id,
+            {
+                "type": "error",
+                "text": final.get("text", "2FA verification failed"),
+            },
+        )
+        _state = CredentialState.AWAITING_SETUP
+
+
+async def _ask_browser_for_input(
+    relay_base: str,
+    session_id: str,
+    *,
+    text: str,
+    input_type: str,
+    placeholder: str,
+    send_message_fn,
+    poll_for_responses_fn,
+    timeout_s: float = 300.0,
+) -> str | None:
+    """Push an ``input_required`` message and wait for the browser response."""
+    try:
+        message_id = await send_message_fn(
+            relay_base,
+            session_id,
+            {
+                "type": "input_required",
+                "text": text,
+                "data": {"input_type": input_type, "placeholder": placeholder},
+            },
+        )
+    except Exception as e:
+        logger.warning("Failed to request browser input: {}", e)
+        return None
+
+    try:
+        return await poll_for_responses_fn(
+            relay_base, session_id, message_id, timeout_s=timeout_s
+        )
+    except Exception as e:
+        logger.warning("Timed out waiting for browser input: {}", e)
+        return None
 
 
 async def save_credentials(config: dict[str, str]) -> dict | None:

--- a/src/better_telegram_mcp/server.py
+++ b/src/better_telegram_mcp/server.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -17,6 +18,10 @@ from .tools.help_tool import handle_help
 from .tools.media import MediaOptions, handle_media
 from .tools.messages import MessagesArgs, handle_messages
 from .utils.formatting import err, ok
+
+# Silence httpx INFO-level request logs so the bot token in the request URL
+# (https://api.telegram.org/bot<TOKEN>/...) cannot leak into stderr.
+logging.getLogger("httpx").setLevel(logging.WARNING)
 
 _backend: TelegramBackend | None = None
 _settings: Settings | None = None

--- a/tests/test_credential_state.py
+++ b/tests/test_credential_state.py
@@ -450,8 +450,14 @@ async def test_poll_relay_background_bot_mode():
 
 
 @pytest.mark.asyncio
-async def test_poll_relay_background_user_mode_sends_complete():
-    """User mode config -> sends 'complete' notification (OTP now via /otp endpoint)."""
+async def test_poll_relay_background_user_mode_runs_otp_flow():
+    """User mode: relay drives full OTP multi-step via input_required messages.
+
+    Flow: poll_for_result returns phone -> save_credentials triggers Telethon
+    send_code -> server pushes input_required for OTP via send_message ->
+    poll_for_responses gets OTP -> on_step_submitted verifies with Telethon ->
+    server pushes 'complete' message. No 2FA in this test case.
+    """
     import better_telegram_mcp.credential_state as cs
     from better_telegram_mcp.credential_state import _poll_relay_background
 
@@ -470,9 +476,30 @@ async def test_poll_relay_background_user_mode_sends_complete():
         ),
         patch("mcp_core.storage.config_file.write_config"),
         patch(
+            "better_telegram_mcp.credential_state.save_credentials",
+            new_callable=AsyncMock,
+            return_value={
+                "type": "otp_required",
+                "text": "Enter OTP",
+                "field": "otp_code",
+                "input_type": "text",
+            },
+        ) as mock_save,
+        patch(
+            "better_telegram_mcp.credential_state.on_step_submitted",
+            new_callable=AsyncMock,
+            return_value=None,
+        ) as mock_step,
+        patch(
             "mcp_core.relay.client.send_message",
             new_callable=AsyncMock,
+            return_value="msg-otp-1",
         ) as mock_send,
+        patch(
+            "mcp_core.relay.client.poll_for_responses",
+            new_callable=AsyncMock,
+            return_value="12345",
+        ) as mock_poll_resp,
         patch(
             "mcp_core.release_session_lock",
             new_callable=AsyncMock,
@@ -481,8 +508,11 @@ async def test_poll_relay_background_user_mode_sends_complete():
         os.environ.pop("TELEGRAM_PHONE", None)
         await _poll_relay_background("https://relay", mock_session, 60.0)
 
-    assert cs._state == CredentialState.CONFIGURED
-    mock_send.assert_awaited_once()
+    mock_save.assert_awaited_once_with(config)
+    mock_poll_resp.assert_awaited_once()
+    mock_step.assert_awaited_once_with({"otp_code": "12345"})
+    # send_message called at least twice: once for input_required, once for complete
+    assert mock_send.await_count >= 2
     # Cleanup
     os.environ.pop("TELEGRAM_PHONE", None)
 

--- a/tests/test_credential_state.py
+++ b/tests/test_credential_state.py
@@ -868,3 +868,728 @@ async def test_on_step_submitted_unexpected_input_returns_error():
     result = await cs.on_step_submitted({"random_key": "value"})
     assert result is not None
     assert result["type"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# set_on_configured
+# ---------------------------------------------------------------------------
+
+
+def test_set_on_configured_registers_callback():
+    """set_on_configured stores callback in module-level variable."""
+    import better_telegram_mcp.credential_state as cs
+
+    async def my_callback():
+        pass
+
+    cs.set_on_configured(my_callback)
+    assert cs._on_configured_callback is my_callback
+    # Cleanup
+    cs._on_configured_callback = None
+
+
+# ---------------------------------------------------------------------------
+# _poll_relay_background -- bot mode with on_configured_callback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_poll_relay_background_bot_mode_callback_invoked():
+    """Bot mode: on_configured_callback is called after credentials saved."""
+    import better_telegram_mcp.credential_state as cs
+    from better_telegram_mcp.credential_state import _poll_relay_background
+
+    cs._state = CredentialState.SETUP_IN_PROGRESS
+    callback = AsyncMock()
+    cs._on_configured_callback = callback
+
+    mock_session = MagicMock()
+    mock_session.session_id = "sess-cb"
+    config = {"TELEGRAM_BOT_TOKEN": "bot:cb-token"}
+
+    with (
+        patch.dict(os.environ, {}, clear=False),
+        patch(
+            "mcp_core.relay.client.poll_for_result",
+            new_callable=AsyncMock,
+            return_value=config,
+        ),
+        patch("mcp_core.storage.config_file.write_config"),
+        patch(
+            "better_telegram_mcp.relay_setup._is_user_mode_config",
+            return_value=False,
+        ),
+        patch(
+            "mcp_core.relay.client.send_message",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "mcp_core.release_session_lock",
+            new_callable=AsyncMock,
+        ),
+    ):
+        os.environ.pop("TELEGRAM_BOT_TOKEN", None)
+        await _poll_relay_background("https://relay", mock_session, None)
+
+    callback.assert_awaited_once()
+    assert cs._state == CredentialState.CONFIGURED
+
+    # Cleanup
+    cs._on_configured_callback = None
+    os.environ.pop("TELEGRAM_BOT_TOKEN", None)
+
+
+@pytest.mark.asyncio
+async def test_poll_relay_background_bot_mode_callback_raises():
+    """Bot mode: on_configured_callback exception is swallowed, state still CONFIGURED."""
+    import better_telegram_mcp.credential_state as cs
+    from better_telegram_mcp.credential_state import _poll_relay_background
+
+    cs._state = CredentialState.SETUP_IN_PROGRESS
+    cs._on_configured_callback = AsyncMock(side_effect=RuntimeError("reinit failed"))
+
+    mock_session = MagicMock()
+    mock_session.session_id = "sess-cb-err"
+    config = {"TELEGRAM_BOT_TOKEN": "bot:cb-err-token"}
+
+    with (
+        patch.dict(os.environ, {}, clear=False),
+        patch(
+            "mcp_core.relay.client.poll_for_result",
+            new_callable=AsyncMock,
+            return_value=config,
+        ),
+        patch("mcp_core.storage.config_file.write_config"),
+        patch(
+            "better_telegram_mcp.relay_setup._is_user_mode_config",
+            return_value=False,
+        ),
+        patch(
+            "mcp_core.relay.client.send_message",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "mcp_core.release_session_lock",
+            new_callable=AsyncMock,
+        ),
+    ):
+        os.environ.pop("TELEGRAM_BOT_TOKEN", None)
+        await _poll_relay_background("https://relay", mock_session, None)
+
+    assert cs._state == CredentialState.CONFIGURED
+
+    # Cleanup
+    cs._on_configured_callback = None
+    os.environ.pop("TELEGRAM_BOT_TOKEN", None)
+
+
+# ---------------------------------------------------------------------------
+# _run_user_mode_relay_flow -- all branches
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_user_mode_relay_flow_save_credentials_returns_none():
+    """save_credentials returns None -> send complete + return immediately."""
+    import better_telegram_mcp.credential_state as cs
+    from better_telegram_mcp.credential_state import _run_user_mode_relay_flow
+
+    cs._state = CredentialState.SETUP_IN_PROGRESS
+    mock_session = MagicMock()
+    mock_session.session_id = "sess-none"
+    mock_send = AsyncMock(return_value="msg-1")
+    mock_poll_resp = AsyncMock()
+
+    with patch(
+        "better_telegram_mcp.credential_state.save_credentials",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        await _run_user_mode_relay_flow(
+            "https://relay",
+            mock_session,
+            {"TELEGRAM_PHONE": "+1"},
+            mock_send,
+            mock_poll_resp,
+        )
+
+    mock_send.assert_awaited_once()
+    sent_msg = mock_send.await_args_list[0][0][2]
+    assert sent_msg["type"] == "complete"
+    mock_poll_resp.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_user_mode_relay_flow_save_credentials_error():
+    """save_credentials returns error -> send error to relay + AWAITING_SETUP."""
+    import better_telegram_mcp.credential_state as cs
+    from better_telegram_mcp.credential_state import _run_user_mode_relay_flow
+
+    cs._state = CredentialState.SETUP_IN_PROGRESS
+    mock_session = MagicMock()
+    mock_session.session_id = "sess-err"
+    mock_send = AsyncMock(return_value="msg-1")
+    mock_poll_resp = AsyncMock()
+
+    with patch(
+        "better_telegram_mcp.credential_state.save_credentials",
+        new_callable=AsyncMock,
+        return_value={"type": "error", "text": "phone invalid"},
+    ):
+        await _run_user_mode_relay_flow(
+            "https://relay",
+            mock_session,
+            {"TELEGRAM_PHONE": "+1"},
+            mock_send,
+            mock_poll_resp,
+        )
+
+    assert cs._state == CredentialState.AWAITING_SETUP
+    mock_send.assert_awaited_once()
+    sent_msg = mock_send.await_args_list[0][0][2]
+    assert sent_msg["type"] == "error"
+    mock_poll_resp.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_user_mode_relay_flow_otp_timeout():
+    """_ask_browser_for_input returns None (OTP timeout) -> AWAITING_SETUP."""
+    import better_telegram_mcp.credential_state as cs
+    from better_telegram_mcp.credential_state import _run_user_mode_relay_flow
+
+    cs._state = CredentialState.SETUP_IN_PROGRESS
+    mock_session = MagicMock()
+    mock_session.session_id = "sess-otp-timeout"
+    # send_message raises -> _ask_browser_for_input returns None
+    mock_send = AsyncMock(side_effect=Exception("send failed"))
+    mock_poll_resp = AsyncMock()
+
+    with patch(
+        "better_telegram_mcp.credential_state.save_credentials",
+        new_callable=AsyncMock,
+        return_value={
+            "type": "otp_required",
+            "text": "Enter OTP",
+            "field": "otp_code",
+            "input_type": "text",
+        },
+    ):
+        await _run_user_mode_relay_flow(
+            "https://relay",
+            mock_session,
+            {"TELEGRAM_PHONE": "+1"},
+            mock_send,
+            mock_poll_resp,
+        )
+
+    assert cs._state == CredentialState.AWAITING_SETUP
+    mock_poll_resp.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_user_mode_relay_flow_otp_success_no_2fa():
+    """OTP submitted successfully, on_step_submitted returns None -> complete."""
+    import better_telegram_mcp.credential_state as cs
+    from better_telegram_mcp.credential_state import _run_user_mode_relay_flow
+
+    cs._state = CredentialState.SETUP_IN_PROGRESS
+    mock_session = MagicMock()
+    mock_session.session_id = "sess-otp-ok"
+    mock_send = AsyncMock(return_value="msg-1")
+    mock_poll_resp = AsyncMock(return_value="12345")
+
+    with (
+        patch(
+            "better_telegram_mcp.credential_state.save_credentials",
+            new_callable=AsyncMock,
+            return_value={
+                "type": "otp_required",
+                "text": "Enter OTP",
+                "field": "otp_code",
+                "input_type": "text",
+            },
+        ),
+        patch(
+            "better_telegram_mcp.credential_state.on_step_submitted",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+    ):
+        await _run_user_mode_relay_flow(
+            "https://relay",
+            mock_session,
+            {"TELEGRAM_PHONE": "+1"},
+            mock_send,
+            mock_poll_resp,
+        )
+
+    # 2 calls: input_required + complete
+    assert mock_send.await_count == 2
+    last_msg = mock_send.await_args_list[-1][0][2]
+    assert last_msg["type"] == "complete"
+
+
+@pytest.mark.asyncio
+async def test_run_user_mode_relay_flow_otp_verification_error():
+    """on_step_submitted returns error -> send error + AWAITING_SETUP."""
+    import better_telegram_mcp.credential_state as cs
+    from better_telegram_mcp.credential_state import _run_user_mode_relay_flow
+
+    cs._state = CredentialState.SETUP_IN_PROGRESS
+    mock_session = MagicMock()
+    mock_session.session_id = "sess-otp-err"
+    mock_send = AsyncMock(return_value="msg-1")
+    mock_poll_resp = AsyncMock(return_value="99999")
+
+    with (
+        patch(
+            "better_telegram_mcp.credential_state.save_credentials",
+            new_callable=AsyncMock,
+            return_value={
+                "type": "otp_required",
+                "text": "Enter OTP",
+                "field": "otp_code",
+                "input_type": "text",
+            },
+        ),
+        patch(
+            "better_telegram_mcp.credential_state.on_step_submitted",
+            new_callable=AsyncMock,
+            return_value={"type": "error", "text": "wrong code"},
+        ),
+    ):
+        await _run_user_mode_relay_flow(
+            "https://relay",
+            mock_session,
+            {"TELEGRAM_PHONE": "+1"},
+            mock_send,
+            mock_poll_resp,
+        )
+
+    assert cs._state == CredentialState.AWAITING_SETUP
+    last_msg = mock_send.await_args_list[-1][0][2]
+    assert last_msg["type"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_run_user_mode_relay_flow_otp_unexpected_type():
+    """on_step_submitted returns unexpected type (not complete/error/password_required) -> error + AWAITING_SETUP."""
+    import better_telegram_mcp.credential_state as cs
+    from better_telegram_mcp.credential_state import _run_user_mode_relay_flow
+
+    cs._state = CredentialState.SETUP_IN_PROGRESS
+    mock_session = MagicMock()
+    mock_session.session_id = "sess-unexpected"
+    mock_send = AsyncMock(return_value="msg-1")
+    mock_poll_resp = AsyncMock(return_value="12345")
+
+    with (
+        patch(
+            "better_telegram_mcp.credential_state.save_credentials",
+            new_callable=AsyncMock,
+            return_value={
+                "type": "otp_required",
+                "text": "Enter OTP",
+                "field": "otp_code",
+                "input_type": "text",
+            },
+        ),
+        patch(
+            "better_telegram_mcp.credential_state.on_step_submitted",
+            new_callable=AsyncMock,
+            return_value={"type": "redirect", "url": "https://example.com"},
+        ),
+    ):
+        await _run_user_mode_relay_flow(
+            "https://relay",
+            mock_session,
+            {"TELEGRAM_PHONE": "+1"},
+            mock_send,
+            mock_poll_resp,
+        )
+
+    assert cs._state == CredentialState.AWAITING_SETUP
+    last_msg = mock_send.await_args_list[-1][0][2]
+    assert last_msg["type"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_run_user_mode_relay_flow_2fa_happy_path():
+    """OTP succeeds with password_required -> ask password -> complete."""
+    import better_telegram_mcp.credential_state as cs
+    from better_telegram_mcp.credential_state import _run_user_mode_relay_flow
+
+    cs._state = CredentialState.SETUP_IN_PROGRESS
+    mock_session = MagicMock()
+    mock_session.session_id = "sess-2fa"
+    # First send_message (input_required for OTP) returns msg id;
+    # second (input_required for password) also returns msg id.
+    mock_send = AsyncMock(return_value="msg-1")
+    # First poll_for_responses returns OTP, second returns password.
+    mock_poll_resp = AsyncMock(side_effect=["12345", "my-2fa-pass"])
+
+    with (
+        patch(
+            "better_telegram_mcp.credential_state.save_credentials",
+            new_callable=AsyncMock,
+            return_value={
+                "type": "otp_required",
+                "text": "Enter OTP",
+                "field": "otp_code",
+                "input_type": "text",
+            },
+        ),
+        patch(
+            "better_telegram_mcp.credential_state.on_step_submitted",
+            new_callable=AsyncMock,
+            side_effect=[
+                {
+                    "type": "password_required",
+                    "text": "Enter 2FA password",
+                    "field": "password",
+                    "input_type": "password",
+                },
+                None,
+            ],
+        ),
+    ):
+        await _run_user_mode_relay_flow(
+            "https://relay",
+            mock_session,
+            {"TELEGRAM_PHONE": "+1"},
+            mock_send,
+            mock_poll_resp,
+        )
+
+    last_msg = mock_send.await_args_list[-1][0][2]
+    assert last_msg["type"] == "complete"
+
+
+@pytest.mark.asyncio
+async def test_run_user_mode_relay_flow_2fa_password_timeout():
+    """2FA password input times out -> AWAITING_SETUP."""
+    import better_telegram_mcp.credential_state as cs
+    from better_telegram_mcp.credential_state import _run_user_mode_relay_flow
+
+    cs._state = CredentialState.SETUP_IN_PROGRESS
+    mock_session = MagicMock()
+    mock_session.session_id = "sess-2fa-timeout"
+    call_count = 0
+
+    async def send_side_effect(relay_base, session_id, msg):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            # First send (input_required for OTP) succeeds, returns msg id
+            return "msg-otp"
+        # Second send (input_required for 2FA password) raises -> _ask_browser_for_input returns None
+        raise Exception("network error")
+
+    mock_send = AsyncMock(side_effect=send_side_effect)
+    mock_poll_resp = AsyncMock(return_value="12345")
+
+    with (
+        patch(
+            "better_telegram_mcp.credential_state.save_credentials",
+            new_callable=AsyncMock,
+            return_value={
+                "type": "otp_required",
+                "text": "Enter OTP",
+                "field": "otp_code",
+                "input_type": "text",
+            },
+        ),
+        patch(
+            "better_telegram_mcp.credential_state.on_step_submitted",
+            new_callable=AsyncMock,
+            return_value={
+                "type": "password_required",
+                "text": "Enter 2FA password",
+                "field": "password",
+                "input_type": "password",
+            },
+        ),
+    ):
+        await _run_user_mode_relay_flow(
+            "https://relay",
+            mock_session,
+            {"TELEGRAM_PHONE": "+1"},
+            mock_send,
+            mock_poll_resp,
+        )
+
+    assert cs._state == CredentialState.AWAITING_SETUP
+
+
+@pytest.mark.asyncio
+async def test_run_user_mode_relay_flow_2fa_failure():
+    """2FA password submit fails -> error + AWAITING_SETUP."""
+    import better_telegram_mcp.credential_state as cs
+    from better_telegram_mcp.credential_state import _run_user_mode_relay_flow
+
+    cs._state = CredentialState.SETUP_IN_PROGRESS
+    mock_session = MagicMock()
+    mock_session.session_id = "sess-2fa-fail"
+    mock_send = AsyncMock(return_value="msg-1")
+    mock_poll_resp = AsyncMock(side_effect=["12345", "bad-pass"])
+
+    with (
+        patch(
+            "better_telegram_mcp.credential_state.save_credentials",
+            new_callable=AsyncMock,
+            return_value={
+                "type": "otp_required",
+                "text": "Enter OTP",
+                "field": "otp_code",
+                "input_type": "text",
+            },
+        ),
+        patch(
+            "better_telegram_mcp.credential_state.on_step_submitted",
+            new_callable=AsyncMock,
+            side_effect=[
+                {
+                    "type": "password_required",
+                    "text": "Enter 2FA password",
+                    "field": "password",
+                    "input_type": "password",
+                },
+                {"type": "error", "text": "2FA wrong"},
+            ],
+        ),
+    ):
+        await _run_user_mode_relay_flow(
+            "https://relay",
+            mock_session,
+            {"TELEGRAM_PHONE": "+1"},
+            mock_send,
+            mock_poll_resp,
+        )
+
+    assert cs._state == CredentialState.AWAITING_SETUP
+    last_msg = mock_send.await_args_list[-1][0][2]
+    assert last_msg["type"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# _ask_browser_for_input -- error paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ask_browser_for_input_send_failure_returns_none():
+    """send_message raises -> return None immediately, poll never called."""
+    from better_telegram_mcp.credential_state import _ask_browser_for_input
+
+    mock_send = AsyncMock(side_effect=Exception("network error"))
+    mock_poll_resp = AsyncMock()
+
+    result = await _ask_browser_for_input(
+        "https://relay",
+        "sess-1",
+        text="Enter value",
+        input_type="text",
+        placeholder="x",
+        send_message_fn=mock_send,
+        poll_for_responses_fn=mock_poll_resp,
+    )
+
+    assert result is None
+    mock_poll_resp.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_ask_browser_for_input_poll_failure_returns_none():
+    """poll_for_responses raises -> return None."""
+    from better_telegram_mcp.credential_state import _ask_browser_for_input
+
+    mock_send = AsyncMock(return_value="msg-1")
+    mock_poll_resp = AsyncMock(side_effect=TimeoutError("timed out"))
+
+    result = await _ask_browser_for_input(
+        "https://relay",
+        "sess-1",
+        text="Enter value",
+        input_type="text",
+        placeholder="x",
+        send_message_fn=mock_send,
+        poll_for_responses_fn=mock_poll_resp,
+    )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_ask_browser_for_input_success():
+    """Happy path: send succeeds, poll returns value."""
+    from better_telegram_mcp.credential_state import _ask_browser_for_input
+
+    mock_send = AsyncMock(return_value="msg-abc")
+    mock_poll_resp = AsyncMock(return_value="user-input-value")
+
+    result = await _ask_browser_for_input(
+        "https://relay",
+        "sess-2",
+        text="Enter OTP",
+        input_type="text",
+        placeholder="OTP code",
+        send_message_fn=mock_send,
+        poll_for_responses_fn=mock_poll_resp,
+    )
+
+    assert result == "user-input-value"
+    mock_send.assert_awaited_once()
+    sent_payload = mock_send.await_args_list[0][0][2]
+    assert sent_payload["type"] == "input_required"
+    assert sent_payload["data"]["input_type"] == "text"
+    assert sent_payload["data"]["placeholder"] == "OTP code"
+    mock_poll_resp.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# save_credentials -- bot mode with on_configured_callback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_save_credentials_bot_mode_callback_invoked():
+    """Bot mode: on_configured_callback is called after credentials saved."""
+    import better_telegram_mcp.credential_state as cs
+    from better_telegram_mcp.credential_state import save_credentials
+
+    callback = AsyncMock()
+    cs._on_configured_callback = callback
+
+    with patch("mcp_core.storage.config_file.write_config"):
+        os.environ.pop("TELEGRAM_BOT_TOKEN", None)
+        result = await save_credentials({"TELEGRAM_BOT_TOKEN": "cb:token"})
+
+    assert result is None
+    callback.assert_awaited_once()
+
+    # Cleanup
+    cs._on_configured_callback = None
+    os.environ.pop("TELEGRAM_BOT_TOKEN", None)
+
+
+@pytest.mark.asyncio
+async def test_save_credentials_bot_mode_callback_raises():
+    """Bot mode: on_configured_callback exception is swallowed, still returns None."""
+    import better_telegram_mcp.credential_state as cs
+    from better_telegram_mcp.credential_state import save_credentials
+
+    cs._on_configured_callback = AsyncMock(side_effect=RuntimeError("reinit error"))
+
+    with patch("mcp_core.storage.config_file.write_config"):
+        os.environ.pop("TELEGRAM_BOT_TOKEN", None)
+        result = await save_credentials({"TELEGRAM_BOT_TOKEN": "cb-fail:token"})
+
+    assert result is None
+
+    # Cleanup
+    cs._on_configured_callback = None
+    os.environ.pop("TELEGRAM_BOT_TOKEN", None)
+
+
+# ---------------------------------------------------------------------------
+# on_step_submitted -- disconnect raises (best-effort paths)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_on_step_submitted_otp_invalid_disconnect_raises():
+    """Non-2FA OTP error + disconnect raises -> still cleans up + returns error."""
+    import better_telegram_mcp.credential_state as cs
+
+    mock_backend = MagicMock()
+    mock_backend.sign_in = AsyncMock(side_effect=Exception("phone code invalid"))
+    mock_backend.disconnect = AsyncMock(side_effect=Exception("disconnect failed"))
+    cs._step_backend = mock_backend
+    cs._step_phone = "+1234567890"
+
+    result = await cs.on_step_submitted({"otp_code": "00000"})
+
+    assert result is not None
+    assert result["type"] == "error"
+    assert cs._step_backend is None
+
+
+@pytest.mark.asyncio
+async def test_on_step_submitted_password_failure_disconnect_raises():
+    """2FA password failure + disconnect raises -> still cleans up + returns error."""
+    import better_telegram_mcp.credential_state as cs
+
+    mock_backend = MagicMock()
+    mock_backend.sign_in = AsyncMock(side_effect=Exception("wrong password"))
+    mock_backend.disconnect = AsyncMock(side_effect=Exception("disconnect failed"))
+    cs._step_backend = mock_backend
+    cs._step_phone = "+1234567890"
+    cs._step_otp_code = "12345"
+
+    result = await cs.on_step_submitted({"password": "wrong"})
+
+    assert result is not None
+    assert result["type"] == "error"
+    assert cs._step_backend is None
+
+
+# ---------------------------------------------------------------------------
+# _finalize_auth -- disconnect raises + callback raises
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_finalize_auth_disconnect_raises():
+    """_finalize_auth: disconnect failure is swallowed, state still CONFIGURED."""
+    import better_telegram_mcp.credential_state as cs
+    from better_telegram_mcp.credential_state import _finalize_auth
+
+    mock_backend = MagicMock()
+    mock_backend.disconnect = AsyncMock(side_effect=Exception("disconnect error"))
+    cs._step_backend = mock_backend
+    cs._step_phone = "+1234567890"
+    cs._step_otp_code = "12345"
+    cs._on_configured_callback = None
+
+    await _finalize_auth()
+
+    assert cs._state == CredentialState.CONFIGURED
+    assert cs._step_backend is None
+    assert cs._step_phone == ""
+    assert cs._step_otp_code is None
+
+
+@pytest.mark.asyncio
+async def test_finalize_auth_callback_raises():
+    """_finalize_auth: on_configured_callback exception is swallowed."""
+    import better_telegram_mcp.credential_state as cs
+    from better_telegram_mcp.credential_state import _finalize_auth
+
+    cs._step_backend = None
+    cs._on_configured_callback = AsyncMock(side_effect=RuntimeError("reinit error"))
+
+    await _finalize_auth()
+
+    assert cs._state == CredentialState.CONFIGURED
+
+    # Cleanup
+    cs._on_configured_callback = None
+
+
+@pytest.mark.asyncio
+async def test_finalize_auth_callback_invoked():
+    """_finalize_auth: on_configured_callback is called on success."""
+    import better_telegram_mcp.credential_state as cs
+    from better_telegram_mcp.credential_state import _finalize_auth
+
+    callback = AsyncMock()
+    cs._step_backend = None
+    cs._on_configured_callback = callback
+
+    await _finalize_auth()
+
+    callback.assert_awaited_once()
+    assert cs._state == CredentialState.CONFIGURED
+
+    # Cleanup
+    cs._on_configured_callback = None

--- a/tests/test_oauth_server.py
+++ b/tests/test_oauth_server.py
@@ -74,7 +74,12 @@ def mock_inner_app():
 
 @pytest.fixture
 def app(
-    data_dir, mock_issuer, mock_oauth, mock_user_store, mock_auth_provider, mock_inner_app
+    data_dir,
+    mock_issuer,
+    mock_oauth,
+    mock_user_store,
+    mock_auth_provider,
+    mock_inner_app,
 ):
     with (
         patch(

--- a/tests/test_relay_schema.py
+++ b/tests/test_relay_schema.py
@@ -1,17 +1,28 @@
-from better_telegram_mcp.relay_schema import RELAY_SCHEMA
+from better_telegram_mcp.relay_schema import RELAY_SCHEMA, RELAY_SCHEMA_MODES
 
 
 def test_relay_schema_structure():
+    """Flat schema: server metadata + fields array covering both modes.
+
+    Local OAuth form uses flat fields; the user fills ONE of:
+      - TELEGRAM_BOT_TOKEN (bot mode)
+      - TELEGRAM_PHONE (user mode)
+    """
     assert RELAY_SCHEMA["server"] == "better-telegram-mcp"
     assert RELAY_SCHEMA["displayName"] == "Telegram MCP"
-    assert len(RELAY_SCHEMA["modes"]) == 2
+    field_keys = {f["key"] for f in RELAY_SCHEMA["fields"]}
+    assert "TELEGRAM_BOT_TOKEN" in field_keys
+    assert "TELEGRAM_PHONE" in field_keys
 
-    # Check Bot Mode
-    bot_mode = next(m for m in RELAY_SCHEMA["modes"] if m["id"] == "bot")
+
+def test_relay_schema_modes_backward_compat():
+    """Relay page uses modes for tabbed UI (bot + user)."""
+    assert len(RELAY_SCHEMA_MODES["modes"]) == 2
+
+    bot_mode = next(m for m in RELAY_SCHEMA_MODES["modes"] if m["id"] == "bot")
     assert bot_mode["label"] == "Bot Mode"
     assert any(f["key"] == "TELEGRAM_BOT_TOKEN" for f in bot_mode["fields"])
 
-    # Check User Mode
-    user_mode = next(m for m in RELAY_SCHEMA["modes"] if m["id"] == "user")
-    assert user_mode["label"] == "User Mode (MTProto)"
+    user_mode = next(m for m in RELAY_SCHEMA_MODES["modes"] if m["id"] == "user")
+    assert "User Mode" in user_mode["label"]
     assert any(f["key"] == "TELEGRAM_PHONE" for f in user_mode["fields"])


### PR DESCRIPTION
Phase L2 telegram fixes discovered during E2E testing.

## Summary

1. **User-mode OTP/2FA broken over remote relay**: `_poll_relay_background` wrote config + sent 'complete' without running Telethon OTP exchange. Now drives full multi-step via mcp-core primitives: save_credentials triggers send_code, send_message(input_required) asks browser for OTP, poll_for_responses waits, on_step_submitted verifies. Same path for 2FA password if required.

2. **Bot token leak in stderr**: httpx INFO-level request logging printed full URL including bot token. Patched by setting httpx logger to WARNING in server.py.

3. Updated test_poll_relay_background_user_mode_runs_otp_flow + fixed pre-existing test_relay_schema_structure (flat schema; modes preserved in RELAY_SCHEMA_MODES).

Commit: b56edf3.

## Test plan
- [x] 548 unit tests passing
- [ ] Live E2E: bot mode + user mode (OTP + 2FA) with real credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)