### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix case-sensitive Bearer token parsing

### DIFF
--- a/src/better_telegram_mcp/transports/http_multi_user.py
+++ b/src/better_telegram_mcp/transports/http_multi_user.py
@@ -74,7 +74,7 @@ def _get_client_ip(request: Request) -> str:
 def _extract_bearer(request: Request) -> str | None:
     """Extract bearer token from Authorization header."""
     auth_header = request.headers.get("authorization", "")
-    if auth_header.startswith("Bearer "):
+    if auth_header.lower().startswith("bearer "):
         return auth_header[7:].strip()
     return None
 
@@ -284,7 +284,7 @@ def create_app(
             bearer = None
             headers = Headers(scope=scope)
             auth_str = headers.get("authorization")
-            if auth_str and auth_str.startswith("Bearer "):
+            if auth_str and auth_str.lower().startswith("bearer "):
                 bearer = auth_str[7:].strip()
 
             if not bearer:

--- a/src/better_telegram_mcp/transports/oauth_server.py
+++ b/src/better_telegram_mcp/transports/oauth_server.py
@@ -219,7 +219,7 @@ def create_app(
             bearer = None
             headers = Headers(scope=scope)
             auth_str = headers.get("authorization")
-            if auth_str and auth_str.startswith("Bearer "):
+            if auth_str and auth_str.lower().startswith("bearer "):
                 bearer = auth_str[7:].strip()
 
             if not bearer:


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The Authorization header parsing used exact string matching (`.startswith("Bearer ")`) to check for Bearer tokens. RFC 7235 specifies that HTTP authentication schemes are case-insensitive. 
🎯 Impact: Clients that send the scheme in lowercase ("bearer") or uppercase ("BEARER") would fail to authenticate, potentially leading to interoperability issues and denial of service for compliant but non-standard-casing clients.
🔧 Fix: Updated the extraction logic in `http_multi_user.py` and `oauth_server.py` to use `.lower().startswith("bearer ")`. The token is then correctly extracted using `[7:].strip()`.
✅ Verification: Tested via unit tests for OAuth server and Multi-user HTTP server to ensure no regressions.

---
*PR created automatically by Jules for task [13878927689319154431](https://jules.google.com/task/13878927689319154431) started by @n24q02m*