### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix case-sensitive Bearer token parsing for RFC 7235 compliance

### DIFF
--- a/src/better_telegram_mcp/transports/http_multi_user.py
+++ b/src/better_telegram_mcp/transports/http_multi_user.py
@@ -74,7 +74,7 @@ def _get_client_ip(request: Request) -> str:
 def _extract_bearer(request: Request) -> str | None:
     """Extract bearer token from Authorization header."""
     auth_header = request.headers.get("authorization", "")
-    if auth_header.startswith("Bearer "):
+    if auth_header.lower().startswith("bearer "):
         return auth_header[7:].strip()
     return None
 
@@ -284,7 +284,7 @@ def create_app(
             bearer = None
             headers = Headers(scope=scope)
             auth_str = headers.get("authorization")
-            if auth_str and auth_str.startswith("Bearer "):
+            if auth_str and auth_str.lower().startswith("bearer "):
                 bearer = auth_str[7:].strip()
 
             if not bearer:

--- a/src/better_telegram_mcp/transports/oauth_server.py
+++ b/src/better_telegram_mcp/transports/oauth_server.py
@@ -219,7 +219,7 @@ def create_app(
             bearer = None
             headers = Headers(scope=scope)
             auth_str = headers.get("authorization")
-            if auth_str and auth_str.startswith("Bearer "):
+            if auth_str and auth_str.lower().startswith("bearer "):
                 bearer = auth_str[7:].strip()
 
             if not bearer:

--- a/tests/test_http_multi_user.py
+++ b/tests/test_http_multi_user.py
@@ -71,6 +71,12 @@ def test_extract_bearer():
     request.headers = {"authorization": "Bearer my-token"}
     assert _extract_bearer(request) == "my-token"
 
+    request.headers = {"authorization": "bearer my-token"}
+    assert _extract_bearer(request) == "my-token"
+
+    request.headers = {"authorization": "BEARER my-token"}
+    assert _extract_bearer(request) == "my-token"
+
     request.headers = {"authorization": "Basic something"}
     assert _extract_bearer(request) is None
 

--- a/tests/test_oauth_server.py
+++ b/tests/test_oauth_server.py
@@ -264,7 +264,7 @@ def test_mcp_success(client, mock_issuer, mock_auth_provider):
     resp = client.post(
         "/mcp",
         json={"jsonrpc": "2.0", "method": "list_tools", "id": 1},
-        headers={"Authorization": "Bearer goodtoken"},
+        headers={"Authorization": "bearer goodtoken"},
     )
     assert resp.status_code == 200
     assert resp.json()["result"] == "ok"
@@ -277,7 +277,7 @@ def test_mcp_reload_backend(client, mock_issuer, mock_auth_provider, mock_user_s
     resp = client.post(
         "/mcp",
         json={"jsonrpc": "2.0", "method": "list_tools", "id": 1},
-        headers={"Authorization": "Bearer goodtoken"},
+        headers={"Authorization": "BEARER goodtoken"},
     )
 
     assert resp.status_code == 200
@@ -291,7 +291,7 @@ def test_mcp_user_not_found(client, mock_issuer, mock_auth_provider, mock_user_s
     resp = client.post(
         "/mcp",
         json={"jsonrpc": "2.0", "method": "list_tools", "id": 1},
-        headers={"Authorization": "Bearer goodtoken"},
+        headers={"Authorization": "BeArEr goodtoken"},
     )
 
     assert resp.status_code == 403


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Bearer tokens were parsed in a case-sensitive manner (`startswith("Bearer ")`) in the auth middleware and `http_multi_user` routes.
🎯 **Impact:** Clients sending differently-cased schemes like `bearer` or `BEARER` would be incorrectly rejected, or, in worst cases, could cause interoperability and bypass issues with upstream proxies/gateways that conform to RFC 7235 (which dictates case-insensitive scheme matching).
🔧 **Fix:** Updated the parsing logic across `http_multi_user.py` and `oauth_server.py` to use `.lower().startswith("bearer ")`.
✅ **Verification:** Added tests for case-insensitive `bearer ` matching and ran the full pytest suite.

---
*PR created automatically by Jules for task [4797635696382026921](https://jules.google.com/task/4797635696382026921) started by @n24q02m*