### PR TITLE
fix: clear aria-busy on step-input reset to unblock 2FA submit

### DIFF
--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -443,6 +443,7 @@ def render_telegram_credential_form(
                     inputEl.value = "";
                     inputEl.disabled = false;
                     buttonEl.disabled = false;
+                    buttonEl.removeAttribute("aria-busy");
                     buttonEl.textContent = "Verify";
                 }} else {{
                     var card = form.parentNode;


### PR DESCRIPTION
## Summary
- Clear \`aria-busy\` attribute when showStepInput reuses an existing step container
- Unblocks 2FA password submit after OTP verification in user-mode MTProto auth

## Root cause
CSS \`.submit-btn[aria-busy=\"true\"] { pointer-events: none }\` blocks clicks. When OTP is submitted the JS sets \`aria-busy=\"true\"\`. When server returns \`password_required\` NextStep, \`showStepInput\` reuses the existing container and resets \`disabled=false\` + \`textContent=\"Verify\"\` but forgets to \`removeAttribute(\"aria-busy\")\`. The button visually spins forever and clicks are silently swallowed by pointer-events:none.

## Reproduction
Reported 2026-04-20 E2E: phone -> OTP -> 2FA password prompt. Submit button spinning before AND after entering password; click does nothing.

## Test plan
- [x] \`uv run pytest\` -- 618 passed, 12 skipped
- [ ] Deploy + verify 2FA flow completes end-to-end at better-telegram-mcp.n24q02m.com
- [x] Parity fix also pushed to mcp-core (core-ts + core-py) so any server using the default credential form inherits the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)