### PR TITLE
🎨 Palette: Add accessible loading spinner to credential form

### DIFF
--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -593,6 +593,7 @@ def render_telegram_credential_form(
                 }}
 
                 submitBtn.disabled = true;
+                submitBtn.setAttribute("aria-busy", "true");
                 submitBtn.textContent = "Connecting...";
                 statusBox.style.display = "none";
 
@@ -610,12 +611,14 @@ def render_telegram_credential_form(
                                 }} else if (data.next_step && data.next_step.type === "info") {{
                                     form.querySelectorAll(".field-input").forEach(function (i) {{ i.disabled = true; }});
                                     submitBtn.disabled = true;
+                                    submitBtn.removeAttribute("aria-busy");
                                     submitBtn.textContent = "Connected";
                                     tabs.forEach(function (t) {{ t.disabled = true; }});
                                     showStatus("success", data.next_step.message || "Setup saved. Additional steps may be required.");
                                 }} else {{
                                     form.querySelectorAll(".field-input").forEach(function (i) {{ i.disabled = true; }});
                                     submitBtn.disabled = true;
+                                    submitBtn.removeAttribute("aria-busy");
                                     submitBtn.textContent = "Connected";
                                     tabs.forEach(function (t) {{ t.disabled = true; }});
                                     var successMsg = data.message || "Connected successfully. You can close this window.";
@@ -624,6 +627,7 @@ def render_telegram_credential_form(
                             }} else {{
                                 showStatus("error", data.error || data.error_description || "Request failed.");
                                 submitBtn.disabled = false;
+                                submitBtn.removeAttribute("aria-busy");
                                 submitBtn.textContent = "Connect";
                             }}
                         }});
@@ -631,6 +635,7 @@ def render_telegram_credential_form(
                     .catch(function (err) {{
                         showStatus("error", "Network error: " + err.message);
                         submitBtn.disabled = false;
+                        submitBtn.removeAttribute("aria-busy");
                         submitBtn.textContent = "Connect";
                     }});
             }});

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.6.1"
+version = "4.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
Adds `aria-busy` attribute toggling to the main submit button in the credential form. This small UX enhancement displays a loading spinner during connection attempts, improving visual feedback while remaining completely accessible to screen readers.

---
*PR created automatically by Jules for task [5272778910957158615](https://jules.google.com/task/5272778910957158615) started by @n24q02m*