### PR TITLE
⚡ Bolt: Use frozenset for O(1) trusted proxy lookups

### DIFF
--- a/src/better_telegram_mcp/config.py
+++ b/src/better_telegram_mcp/config.py
@@ -42,10 +42,13 @@ class Settings(BaseSettings):
     mode: Literal["bot", "user"] = "bot"
 
     @functools.cached_property
-    def trusted_proxy_list(self) -> list[str]:
+    def trusted_proxy_list(self) -> frozenset[str]:
+        """⚡ Bolt: Memoize proxy parsing and convert to frozenset for O(1) lookups."""
         if not self.trusted_proxies:
-            return []
-        return [p.strip() for p in self.trusted_proxies.split(",") if p.strip()]
+            return frozenset()
+        return frozenset(
+            p.strip() for p in self.trusted_proxies.split(",") if p.strip()
+        )
 
     @model_validator(mode="after")
     def _detect_mode(self) -> Settings:


### PR DESCRIPTION
💡 What: Converted the `@functools.cached_property` `trusted_proxy_list` in `src/better_telegram_mcp/config.py` to return an immutable `frozenset` instead of a `list`.
🎯 Why: `trusted_proxy_list` parses and splits a comma-separated proxy configuration string and is used downstream in the authentication server hot paths for rate limit exemption and client IP spoofing checks (`client_ip in self._settings.trusted_proxy_list`). Upgrading the returned collection to a set-like structure changes the time complexity of these checks from O(N) to O(1), making these routes faster. Additionally, using an immutable data structure inside a memoization decorator prevents accidental in-place mutations which could result in global cache corruption.
📊 Impact: Constant O(1) lookups during client IP validation and robust guarantee against cache poisoning.
🔬 Measurement: Verify changes using `uv run pytest` and standard linters to confirm no regressions and that `in` lookups maintain type checking correctness.

---
*PR created automatically by Jules for task [1707897319206324053](https://jules.google.com/task/1707897319206324053) started by @n24q02m*