### PR TITLE
🎨 Palette: Add focus-visible styles for keyboard accessibility

### DIFF
--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -144,6 +144,12 @@ def render_telegram_credential_form(
             color: #ccc;
         }}
 
+        .tab:focus-visible {{
+            outline: 2px solid #4a6fa5;
+            outline-offset: -2px;
+            border-radius: 4px;
+        }}
+
         .tab.active {{
             color: #fff;
             border-bottom-color: #4a6fa5;
@@ -223,6 +229,12 @@ def render_telegram_credential_form(
             text-decoration: underline;
         }}
 
+        .help-text a:focus-visible {{
+            outline: 2px solid #4a6fa5;
+            outline-offset: 2px;
+            border-radius: 2px;
+        }}
+
         .submit-btn {{
             width: 100%;
             background-color: #4a6fa5;
@@ -240,6 +252,11 @@ def render_telegram_credential_form(
 
         .submit-btn:hover {{
             background-color: #5a7fb5;
+        }}
+
+        .submit-btn:focus-visible {{
+            outline: 2px solid #4a6fa5;
+            outline-offset: 2px;
         }}
 
         .submit-btn:disabled {{


### PR DESCRIPTION
## 💡 What
Added `:focus-visible` CSS rules to the main interactive elements within the credential form UI:
- Custom `.tab` buttons
- Links in `.help-text` descriptions
- The primary `.submit-btn`

## 🎯 Why
When custom UI components or resets clear default browser focus styles, it makes the interface completely unusable for keyboard-only or screen-reader users who rely on visual indicators to know which element has focus. This change restores that feedback.

## 📸 Before/After
*(See Playwright verification screenshots attached to the session)*
Before: Tabbing through the interface showed no visual change on tabs or buttons.
After: Tabbing adds a clear `#4a6fa5` 2px solid outline around the focused element.

## ♿ Accessibility
This directly improves WCAG 2.4.7 Focus Visible compliance. By specifically using `:focus-visible` rather than `:focus`, we maintain a clean aesthetic for mouse/pointer users while ensuring keyboard users get the essential guidance they need.

---
*PR created automatically by Jules for task [3631760325211975345](https://jules.google.com/task/3631760325211975345) started by @n24q02m*