### PR TITLE
fix: return 401 + WWW-Authenticate for bearer auth failures

### DIFF
--- a/src/better_telegram_mcp/transports/http_multi_user.py
+++ b/src/better_telegram_mcp/transports/http_multi_user.py
@@ -94,13 +94,18 @@ def _error_response(status: int, error: str, description: str) -> JSONResponse:
 
 
 def _jsonrpc_error(code: int, message: str) -> JSONResponse:
+    # RFC 6750 §3: missing/invalid bearer token MUST return 401 +
+    # WWW-Authenticate: Bearer. MCP SDK uses the header to discover the
+    # authorization server and trigger OAuth. Returning 403 leaves the
+    # client stuck with no way to recover.
     return JSONResponse(
         {
             "jsonrpc": "2.0",
             "error": {"code": code, "message": message},
             "id": None,
         },
-        status_code=403,
+        status_code=401,
+        headers={"WWW-Authenticate": "Bearer"},
     )
 
 

--- a/src/better_telegram_mcp/transports/oauth_server.py
+++ b/src/better_telegram_mcp/transports/oauth_server.py
@@ -32,13 +32,19 @@ from .http import _current_backend
 
 
 def _jsonrpc_error(code: int, message: str) -> JSONResponse:
+    # RFC 6750 §3: missing/invalid bearer token MUST return 401 with
+    # WWW-Authenticate: Bearer. MCP Python SDK relies on this header to
+    # discover the authorization server and initiate the OAuth flow; if
+    # we return 403 the client treats it as a terminal authorization
+    # failure and never attempts to authenticate.
     return JSONResponse(
         {
             "jsonrpc": "2.0",
             "error": {"code": code, "message": message},
             "id": None,
         },
-        status_code=403,  # Authentication errors map to JSON-RPC HTTP 403 or 401
+        status_code=401,
+        headers={"WWW-Authenticate": "Bearer"},
     )
 
 

--- a/tests/test_http_multi_user.py
+++ b/tests/test_http_multi_user.py
@@ -90,7 +90,7 @@ def test_error_responses():
     assert b"err" in resp.body
 
     resp = _jsonrpc_error(-32000, "msg")
-    assert resp.status_code == 403
+    assert resp.status_code == 401
     assert b"msg" in resp.body
 
 
@@ -235,14 +235,14 @@ def test_auth_user_verify_no_bearer(client):
 
 def test_mcp_middleware_no_auth(client):
     response = client.post("/mcp", json={})
-    assert response.status_code == 403
+    assert response.status_code == 401
     assert "Bearer authentication required" in response.json()["error"]["message"]
 
 
 def test_mcp_middleware_invalid_bearer(client, mock_deps):
     mock_deps["auth"].resolve_backend.return_value = None
     response = client.post("/mcp", json={}, headers={"authorization": "Bearer invalid"})
-    assert response.status_code == 403
+    assert response.status_code == 401
     assert "Invalid or expired bearer token" in response.json()["error"]["message"]
 
 
@@ -353,7 +353,7 @@ def test_auth_user_verify_missing_code(client):
 
 def test_mcp_middleware_wrong_header_format(client, mock_deps):
     response = client.post("/mcp", headers={"authorization": "NotBearer token"})
-    assert response.status_code == 403
+    assert response.status_code == 401
 
 
 def test_auth_user_verify_fail(client, mock_deps):

--- a/tests/test_oauth_server.py
+++ b/tests/test_oauth_server.py
@@ -245,7 +245,7 @@ def test_metadata(client):
 
 def test_mcp_no_auth(client):
     resp = client.post("/mcp", json={"jsonrpc": "2.0", "method": "list_tools", "id": 1})
-    assert resp.status_code == 403
+    assert resp.status_code == 401
     assert "Bearer authentication required" in resp.json()["error"]["message"]
 
 
@@ -256,7 +256,7 @@ def test_mcp_invalid_token(client, mock_issuer):
         json={"jsonrpc": "2.0", "method": "list_tools", "id": 1},
         headers={"Authorization": "Bearer badtoken"},
     )
-    assert resp.status_code == 403
+    assert resp.status_code == 401
     assert "Invalid or expired access token" in resp.json()["error"]["message"]
 
 
@@ -294,7 +294,7 @@ def test_mcp_user_not_found(client, mock_issuer, mock_auth_provider, mock_user_s
         headers={"Authorization": "BeArEr goodtoken"},
     )
 
-    assert resp.status_code == 403
+    assert resp.status_code == 401
     assert "User credentials not found" in resp.json()["error"]["message"]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.6.9"
+version = "4.6.10"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
Both telegram transports returned 403 for missing/invalid bearer tokens. RFC 6750 requires 401 + WWW-Authenticate: Bearer. Python MCP SDK follows the RFC: 401 triggers OAuth, 403 is terminal. With 403 clients hang at connect.

Fix 403→401 + add WWW-Authenticate header in both `oauth_server.py` and `http_multi_user.py` `_jsonrpc_error` helpers. Update test assertions.

Found via E2E Phase 3 Config #7 2026-04-22.