### PR TITLE
⚡ Bolt: Optimize trusted proxy list lookup to O(1)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-19 - Frozenset over List for Immutable O(1) Lookups in Settings
+**Learning:** Returning `list` from `@functools.cached_property` properties that are used primarily for containment checks (`in`) creates a performance bottleneck (O(N) lookup) in hot paths (like per-request IP validation).
+**Action:** Always memoize these structures as `frozenset` instead of `list` to upgrade lookups to O(1) while maintaining immutability.

--- a/src/better_telegram_mcp/config.py
+++ b/src/better_telegram_mcp/config.py
@@ -42,10 +42,13 @@ class Settings(BaseSettings):
     mode: Literal["bot", "user"] = "bot"
 
     @functools.cached_property
-    def trusted_proxy_list(self) -> list[str]:
+    def trusted_proxy_list(self) -> frozenset[str]:
+        """⚡ Bolt: Memoize proxy parsing and convert to frozenset for O(1) lookups."""
         if not self.trusted_proxies:
-            return []
-        return [p.strip() for p in self.trusted_proxies.split(",") if p.strip()]
+            return frozenset()
+        return frozenset(
+            p.strip() for p in self.trusted_proxies.split(",") if p.strip()
+        )
 
     @model_validator(mode="after")
     def _detect_mode(self) -> Settings:


### PR DESCRIPTION
💡 What: Changed the return type of `Settings.trusted_proxy_list` from a List to a Frozenset.
🎯 Why: The property is used primarily for a containment (`in`) check on every request to authorize rate limits and client IP. A list lookup is O(N), which can slow things down if the allowlist grows, whereas a frozenset is O(1).
📊 Impact: Upgrades containment check in a hot path from O(N) to O(1) time complexity.
🔬 Measurement: Verify using `uv run pytest tests/test_config.py`. All tests should pass and `in` operations will transparently use the more efficient set-hash check.

---
*PR created automatically by Jules for task [8826965068663319027](https://jules.google.com/task/8826965068663319027) started by @n24q02m*