### PR TITLE
⚡ Bolt: optimize rate limit pruning with bisect

### DIFF
--- a/src/better_telegram_mcp/auth_server.py
+++ b/src/better_telegram_mcp/auth_server.py
@@ -8,6 +8,7 @@ status page when authenticated.
 from __future__ import annotations
 
 import asyncio
+import bisect
 import html
 import re
 import secrets
@@ -252,10 +253,15 @@ class AuthServer:
         now = time.time()
         window_start = now - self._RATE_LIMIT_WINDOW
         timestamps = self._rate_limits[key]
-        self._rate_limits[key] = [t for t in timestamps if t > window_start]
-        if len(self._rate_limits[key]) >= self._RATE_LIMIT_MAX:
+
+        # ⚡ Bolt: Use O(log N) bisect and O(k) in-place deletion instead of O(N) list comprehension
+        idx = bisect.bisect_right(timestamps, window_start)
+        if idx > 0:
+            del timestamps[:idx]
+
+        if len(timestamps) >= self._RATE_LIMIT_MAX:
             return False
-        self._rate_limits[key].append(now)
+        timestamps.append(now)
         return True
 
     def _make_app(self) -> Starlette:

--- a/src/better_telegram_mcp/transports/http_multi_user.py
+++ b/src/better_telegram_mcp/transports/http_multi_user.py
@@ -13,6 +13,7 @@ Provides:
 
 from __future__ import annotations
 
+import bisect
 import functools
 import time
 from collections import defaultdict
@@ -44,13 +45,15 @@ def _check_rate_limit(ip: str, limit: int) -> bool:
     window_start = now - _RATE_LIMIT_WINDOW
     timestamps = _rate_limits[ip]
 
-    # Prune old entries
-    _rate_limits[ip] = [t for t in timestamps if t > window_start]
+    # ⚡ Bolt: Use O(log N) bisect and O(k) in-place deletion instead of O(N) list comprehension
+    idx = bisect.bisect_right(timestamps, window_start)
+    if idx > 0:
+        del timestamps[:idx]
 
-    if len(_rate_limits[ip]) >= limit:
+    if len(timestamps) >= limit:
         return False
 
-    _rate_limits[ip].append(now)
+    timestamps.append(now)
     return True
 
 


### PR DESCRIPTION
💡 What: Updated the rate limiting logic in `auth_server.py` and `http_multi_user.py` to use `bisect.bisect_right` for finding stale timestamps and slicing for in-place deletion, rather than rebuilding the list with a list comprehension.
🎯 Why: In a high-traffic environment, repeatedly pruning rate limits using O(N) list comprehensions creates unnecessary CPU overhead and memory allocations. Because the timestamp lists are strictly chronologically ordered, binary search is the optimal approach.
📊 Impact: Upgrades pruning scan from O(N) to O(log N) and avoids O(N) memory allocations per rate limit check, reducing GC pressure.
🔬 Measurement: Verify tests run properly. No behavior changes, only a pure algorithmic improvement.

---
*PR created automatically by Jules for task [4443970453844257643](https://jules.google.com/task/4443970453844257643) started by @n24q02m*