### PR TITLE
🎨 Palette: Improve error state visualization with aria-invalid

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-24 - Improve error state visualization with aria-invalid
+**Learning:** Directly manipulating inline styles for validation (like `style.borderColor = "#f87171"`) creates a confusing visual state when native browser focus rings (e.g. blue outline) overlap with the manual style. It also fails to communicate the error state to assistive technologies.
+**Action:** Always use semantic HTML attributes like `aria-invalid="true"` combined with CSS attribute selectors (`[aria-invalid="true"]:focus`) for form validation feedback. This ensures accessibility for screen readers, allows precise control over focus states in CSS, and maintains a clean separation of concerns between JavaScript state and visual styling.

--- a/src/better_telegram_mcp/auth_server.py
+++ b/src/better_telegram_mcp/auth_server.py
@@ -48,6 +48,8 @@ input{width:100%;padding:.75rem 1rem;background:#111;border:1px solid #444;
 input[type="password"]{letter-spacing:normal;text-align:left}
 input:focus{border-color:#3b82f6}
 input:focus-visible,button:focus-visible{outline:2px solid #3b82f6;outline-offset:2px}
+input[aria-invalid="true"]{border-color:#ef4444}
+input[aria-invalid="true"]:focus,input[aria-invalid="true"]:focus-visible{border-color:#ef4444;outline:2px solid #ef4444}
 button{width:100%;padding:.75rem;background:#3b82f6;color:#fff;border:none;
   border-radius:8px;font-size:1rem;cursor:pointer;font-weight:500}
 button:hover{background:#2563eb}
@@ -127,6 +129,8 @@ function clearSt(el){el.className='st';el.textContent='';el.style.display='none'
 function btnLoading(fs,btn,text){fs.disabled=true;btn.textContent=text;btn.setAttribute('aria-busy','true')}
 function btnReset(fs,btn,text){fs.disabled=false;btn.textContent=text;btn.removeAttribute('aria-busy')}
 function showPwd(){$('pwd-section').style.display='block';$('pwd').required=true;$('pwd').focus()}
+function setInvalid(id){$(id).setAttribute('aria-invalid','true')}
+function clearInvalid(id){$(id).removeAttribute('aria-invalid')}
 
 async function checkStatus(){
   try{const r=await fetch('/status',{headers:{'X-Auth-Token':_t}});const d=await r.json();
@@ -146,8 +150,9 @@ async function sendCode(){
 
 async function verify(){
   const btn=$('btn-verify'),s=$('s1'),fs=$('fs1');
+  clearInvalid('otp');clearInvalid('pwd');
   const code=$('otp').value.trim();
-  if(!code){st(s,'error','Please enter the OTP code first.');return}
+  if(!code){st(s,'error','Please enter the OTP code first.');setInvalid('otp');return}
   btnLoading(fs,btn,'Verifying...');
   try{const body={code};const pwd=$('pwd').value.trim();if(pwd)body.password=pwd;
     const r=await fetch('/verify',{method:'POST',headers:{'Content-Type':'application/json','X-Auth-Token':_t},body:JSON.stringify(body)});
@@ -155,10 +160,10 @@ async function verify(){
     if(d.ok){$('auth-name').textContent=d.name||'User';show('step2')}
     else{
       btnReset(fs,btn,'Verify Code');
-      if(d.needs_password){showPwd();st(s,'error','2FA password is required. Please enter it above.')}
-      else{st(s,'error',d.error||'Verification failed')}
+      if(d.needs_password){showPwd();st(s,'error','2FA password is required. Please enter it above.');setInvalid('pwd')}
+      else{st(s,'error',d.error||'Verification failed');setInvalid('otp');if($('pwd-section').style.display==='block')setInvalid('pwd')}
     }
-  }catch(e){st(s,'error','Network error. Check your connection.');btnReset(fs,btn,'Verify Code')}
+  }catch(e){st(s,'error','Network error. Check your connection.');setInvalid('otp');if($('pwd-section').style.display==='block')setInvalid('pwd');btnReset(fs,btn,'Verify Code')}
 }
 checkStatus();
 </script>

--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -210,6 +210,15 @@ def render_telegram_credential_form(
             box-shadow: 0 0 0 3px rgba(74, 111, 165, 0.2);
         }}
 
+        .field-input[aria-invalid="true"] {{
+            border-color: #f87171;
+        }}
+
+        .field-input[aria-invalid="true"]:focus {{
+            border-color: #f87171;
+            box-shadow: 0 0 0 3px rgba(248, 113, 113, 0.2);
+        }}
+
         .field-input::placeholder {{
             color: #555;
         }}
@@ -421,7 +430,6 @@ def render_telegram_credential_form(
                     statusBox.style.display = "none";
                     statusBox.textContent = "";
                     form.querySelectorAll(".field-input").forEach(function (i) {{
-                        i.style.borderColor = "";
                         i.removeAttribute("aria-invalid");
                         i.removeAttribute("required");
                     }});
@@ -545,10 +553,12 @@ def render_telegram_credential_form(
                 if (value.trim() === "") {{
                     errorEl.textContent = "Please enter a value.";
                     errorEl.style.display = "block";
+                    inputEl.setAttribute("aria-invalid", "true");
                     return;
                 }}
                 errorEl.style.display = "none";
                 errorEl.textContent = "";
+                inputEl.removeAttribute("aria-invalid");
                 buttonEl.disabled = true;
                 buttonEl.setAttribute("aria-busy", "true");
                 buttonEl.textContent = "Verifying...";
@@ -588,6 +598,7 @@ def render_telegram_credential_form(
                                 errorEl.textContent = data.error || data.error_description || "Verification failed.";
                                 errorEl.style.display = "block";
                                 inputEl.disabled = false;
+                                inputEl.setAttribute("aria-invalid", "true");
                                 buttonEl.disabled = false;
                                 buttonEl.removeAttribute("aria-busy");
                                 buttonEl.textContent = "Verify";
@@ -599,6 +610,7 @@ def render_telegram_credential_form(
                         errorEl.textContent = "Network error: " + err.message;
                         errorEl.style.display = "block";
                         inputEl.disabled = false;
+                        inputEl.setAttribute("aria-invalid", "true");
                         buttonEl.disabled = false;
                         buttonEl.removeAttribute("aria-busy");
                         buttonEl.textContent = "Verify";
@@ -620,10 +632,8 @@ def render_telegram_credential_form(
                 inputs.forEach(function (input) {{
                     if (input.value.trim() === "") {{
                         valid = false;
-                        input.style.borderColor = "#f87171";
                         input.setAttribute("aria-invalid", "true");
                     }} else {{
-                        input.style.borderColor = "";
                         input.removeAttribute("aria-invalid");
                         payload[input.name] = input.value;
                     }}


### PR DESCRIPTION
* 💡 What: Replaced inline JS `style.borderColor` manipulation with semantic `aria-invalid="true"` attributes for form validation across `credential_form.py` and `auth_server.py`. Added corresponding CSS attribute selectors to handle the visual error states and focus rings.
* 🎯 Why: Previously, manual border styling caused native browser focus rings to overlap awkwardly with error borders. It also failed to communicate the error state programmatically to screen readers.
* 📸 Before/After: Visuals verified via temporary Playwright scripts showing proper red borders and focus outlines when validation fails.
* ♿ Accessibility: Screen readers will now announce the invalid state of the inputs thanks to the `aria-invalid` attribute.

---
*PR created automatically by Jules for task [5106228200491593997](https://jules.google.com/task/5106228200491593997) started by @n24q02m*