### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix overly broad Exception handling during JSON parsing

### DIFF
--- a/src/better_telegram_mcp/transports/http_multi_user.py
+++ b/src/better_telegram_mcp/transports/http_multi_user.py
@@ -150,7 +150,7 @@ def create_app(
 
         try:
             body = await request.json()
-        except Exception:
+        except ValueError:
             return _error_response(400, "invalid_request", "Invalid JSON body")
 
         redirect_uris = body.get("redirect_uris", [])
@@ -186,7 +186,7 @@ def create_app(
 
         try:
             body = await request.json()
-        except Exception:
+        except ValueError:
             return _error_response(400, "invalid_request", "Invalid JSON body")
 
         bot_token = body.get("bot_token")
@@ -214,7 +214,7 @@ def create_app(
 
         try:
             body = await request.json()
-        except Exception:
+        except ValueError:
             return _error_response(400, "invalid_request", "Invalid JSON body")
 
         phone = body.get("phone")
@@ -250,7 +250,7 @@ def create_app(
 
         try:
             body = await request.json()
-        except Exception:
+        except ValueError:
             return _error_response(400, "invalid_request", "Invalid JSON body")
 
         code = body.get("code")

--- a/src/better_telegram_mcp/transports/oauth_server.py
+++ b/src/better_telegram_mcp/transports/oauth_server.py
@@ -135,7 +135,7 @@ def create_app(
         """POST /register — RFC 7591 Dynamic Client Registration."""
         try:
             body = await request.json()
-        except Exception:
+        except ValueError:
             return JSONResponse({"error": "invalid_request"}, status_code=400)
 
         client_name = body.get("client_name", "unknown")


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Broad `except Exception:` blocks around JSON parsing can silently swallow unexpected application bugs (like `KeyError`, `AttributeError`, or `MemoryError`) and framework-level exceptions (like `ClientDisconnect`), improperly categorizing them as 400 Bad Request 'Invalid JSON body'.
🎯 Impact: This makes debugging internal errors difficult and can mask unexpected side effects or application crashes.
🔧 Fix: Replaced `except Exception:` with `except ValueError:` in `src/better_telegram_mcp/transports/http_multi_user.py` and `src/better_telegram_mcp/transports/oauth_server.py`.
✅ Verification: Ran `uv run --no-sync ruff check .` and `uv run --no-sync ruff format .` (both passed). Pytest is failing globally due to environment setup issues related to missing `mcp-core` dependency from parent directory, but changes were manually reviewed and approved by Code Review tool.

---
*PR created automatically by Jules for task [11611803040705954717](https://jules.google.com/task/11611803040705954717) started by @n24q02m*