### PR TITLE
⚡ Bolt: O(log N) rate limit pruning using bisect

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Rate Limit Pruning Performance
+**Learning:** For rate-limiting or sliding-window timestamp pruning where a list is strictly chronologically ordered (e.g. from `time.time()` appends in a single thread), rebuilding the list with a list comprehension (`[t for t in list if t > start]`) is an unnecessary O(N) operation and memory allocation.
+**Action:** Use `bisect.bisect_right(list, start)` to find the cutoff index in O(log N) time, then perform an in-place C-level slice deletion (`del list[:idx]`). This prevents redundant memory allocation and speeds up pruning significantly.

--- a/src/better_telegram_mcp/auth_server.py
+++ b/src/better_telegram_mcp/auth_server.py
@@ -8,6 +8,7 @@ status page when authenticated.
 from __future__ import annotations
 
 import asyncio
+import bisect
 import html
 import re
 import secrets
@@ -252,10 +253,13 @@ class AuthServer:
         now = time.time()
         window_start = now - self._RATE_LIMIT_WINDOW
         timestamps = self._rate_limits[key]
-        self._rate_limits[key] = [t for t in timestamps if t > window_start]
-        if len(self._rate_limits[key]) >= self._RATE_LIMIT_MAX:
+        # ⚡ Bolt: Fast in-place pruning of strictly ordered chronological list
+        idx = bisect.bisect_right(timestamps, window_start)
+        if idx > 0:
+            del timestamps[:idx]
+        if len(timestamps) >= self._RATE_LIMIT_MAX:
             return False
-        self._rate_limits[key].append(now)
+        timestamps.append(now)
         return True
 
     def _make_app(self) -> Starlette:

--- a/src/better_telegram_mcp/transports/http_multi_user.py
+++ b/src/better_telegram_mcp/transports/http_multi_user.py
@@ -13,6 +13,7 @@ Provides:
 
 from __future__ import annotations
 
+import bisect
 import functools
 import time
 from collections import defaultdict
@@ -44,10 +45,13 @@ def _check_rate_limit(ip: str, limit: int) -> bool:
     window_start = now - _RATE_LIMIT_WINDOW
     timestamps = _rate_limits[ip]
 
-    # Prune old entries
-    _rate_limits[ip] = [t for t in timestamps if t > window_start]
+    # Prune old entries using O(log N) bisect instead of O(N) list comprehension
+    # ⚡ Bolt: Fast in-place pruning of strictly ordered chronological list
+    idx = bisect.bisect_right(timestamps, window_start)
+    if idx > 0:
+        del timestamps[:idx]
 
-    if len(_rate_limits[ip]) >= limit:
+    if len(timestamps) >= limit:
         return False
 
     _rate_limits[ip].append(now)


### PR DESCRIPTION
💡 What: Optimized rate limit pruning in `_check_rate_limit` by replacing O(N) list comprehensions with O(log N) `bisect.bisect_right` and in-place `del`.
🎯 Why: Rebuilding the entire list of timestamps on every rate-limited request creates unnecessary memory allocation and garbage collection pressure, especially during high traffic.
📊 Impact: Reduces memory allocations for the rate limit array to zero and speeds up array pruning from O(N) to O(log N).
🔬 Measurement: Verified functionality by running the full test suite (`uv run --no-sync pytest`). Performance can be verified by benchmarking the `/health` or `/auth` endpoints under load.

---
*PR created automatically by Jules for task [17206816328176661987](https://jules.google.com/task/17206816328176661987) started by @n24q02m*