### PR TITLE
fix: migrate plugin.json to HTTP remote + telegram /health route

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -9,12 +9,8 @@
   "homepage": "https://github.com/n24q02m/better-telegram-mcp",
   "mcpServers": {
     "better-telegram-mcp": {
-      "command": "uvx",
-      "args": [
-        "--python",
-        "3.13",
-        "better-telegram-mcp"
-      ]
+      "type": "http",
+      "url": "https://better-telegram-mcp.n24q02m.com/mcp"
     }
   }
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
     hooks:
       - id: ty
         name: ty type check
-        entry: mise exec -- uv run ty check
+        entry: mise exec -- uv run --no-sync ty check
         language: system
         types: [python]
         pass_filenames: false
@@ -49,7 +49,7 @@ repos:
     hooks:
       - id: pytest
         name: pytest (Python)
-        entry: mise exec -- uv run pytest --tb=short -q --timeout=30
+        entry: mise exec -- uv run --no-sync pytest --tb=short -q --timeout=30
         language: system
         types: [python]
         pass_filenames: false

--- a/src/better_telegram_mcp/transports/oauth_server.py
+++ b/src/better_telegram_mcp/transports/oauth_server.py
@@ -306,12 +306,16 @@ def create_app(
 
     mcp_app = BearerAuthMCPApp(mcp_asgi_handler)
 
+    async def health(_request: Request) -> JSONResponse:
+        return JSONResponse({"status": "ok", "server": "better-telegram-mcp"})
+
     routes = [
         Route("/authorize", authorize, methods=["GET"]),
         Route("/register", register, methods=["POST"]),
         Route("/token", token, methods=["POST"]),
         Route("/.well-known/jwks.json", jwks, methods=["GET"]),
         Route("/.well-known/oauth-authorization-server", metadata, methods=["GET"]),
+        Route("/health", health, methods=["GET"]),
         Route("/mcp", endpoint=mcp_app),
     ]
 

--- a/tests/test_oauth_server.py
+++ b/tests/test_oauth_server.py
@@ -243,6 +243,12 @@ def test_metadata(client):
     assert resp.json()["authorization_endpoint"] == "https://mcp.example.com/authorize"
 
 
+def test_health(client):
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok", "server": "better-telegram-mcp"}
+
+
 def test_mcp_no_auth(client):
     resp = client.post("/mcp", json={"jsonrpc": "2.0", "method": "list_tools", "id": 1})
     assert resp.status_code == 401


### PR DESCRIPTION
## Summary

- Plugin manifest now points to deployed `https://better-telegram-mcp.n24q02m.com/mcp` (parity with notion remote-oauth pattern). Local stdio spawn was a pre-deploy artifact that produced a HTTP-mode server which never spoke JSON-RPC stdio to Claude Code.
- Multi-user OAuth Starlette app (`transports/oauth_server.py`) was missing a `/health` route — better-telegram-mcp.n24q02m.com/health returned 404 while notion + email return 200. Added route + regression test for liveness probe parity.
- Pre-commit hooks updated to use `uv run --no-sync` to prevent uv.lock drift on repos with `[tool.uv.sources]` paths (per memory `feedback_uv_lock_docker_trap.md`).

## Test plan

- [x] Pre-commit hooks all pass (gitleaks, ruff, ty, pytest, etc.)
- [x] `test_oauth_server.py::test_health` covers new route
- [ ] CI green
- [ ] Manual verify after release: `curl https://better-telegram-mcp.n24q02m.com/health` returns `{"status":"ok","server":"better-telegram-mcp"}`
- [ ] Claude Code `/mcp` shows `plugin:better-telegram-mcp:better-telegram-mcp` connected via HTTP

🤖 Generated with [Claude Code](https://claude.com/claude-code)