### PR TITLE
🎨 Palette: Improve form validation focus and logical flow

### DIFF
--- a/src/better_telegram_mcp/auth_server.py
+++ b/src/better_telegram_mcp/auth_server.py
@@ -136,8 +136,8 @@ function clearInvalid(id){$(id).removeAttribute('aria-invalid')}
 async function checkStatus(){
   try{const r=await fetch('/status',{headers:{'X-Auth-Token':_t}});const d=await r.json();
     if(d.authenticated){$('auth-name').textContent=d.name||'User';show('step2')}
-    else{show('step0');$('otp').focus()}
-  }catch(e){show('step0')}
+    else{show('step0');$('btn-send').focus()}
+  }catch(e){show('step0');$('btn-send').focus()}
 }
 
 async function sendCode(){
@@ -153,7 +153,7 @@ async function verify(){
   const btn=$('btn-verify'),s=$('s1'),fs=$('fs1');
   clearInvalid('otp');clearInvalid('pwd');
   const code=$('otp').value.trim();
-  if(!code){st(s,'error','Please enter the OTP code first.');setInvalid('otp');return}
+  if(!code){st(s,'error','Please enter the OTP code first.');setInvalid('otp');$('otp').focus();return}
   btnLoading(fs,btn,'Verifying...');
   try{const body={code};const pwd=$('pwd').value.trim();if(pwd)body.password=pwd;
     const r=await fetch('/verify',{method:'POST',headers:{'Content-Type':'application/json','X-Auth-Token':_t},body:JSON.stringify(body)});
@@ -161,10 +161,10 @@ async function verify(){
     if(d.ok){$('auth-name').textContent=d.name||'User';show('step2')}
     else{
       btnReset(fs,btn,'Verify Code');
-      if(d.needs_password){showPwd();st(s,'error','2FA password is required. Please enter it above.');setInvalid('pwd')}
-      else{st(s,'error',d.error||'Verification failed');setInvalid('otp');if($('pwd-section').style.display==='block')setInvalid('pwd')}
+      if(d.needs_password){showPwd();st(s,'error','2FA password is required. Please enter it above.');setInvalid('pwd');$('pwd').focus()}
+      else{st(s,'error',d.error||'Verification failed');setInvalid('otp');if($('pwd-section').style.display==='block')setInvalid('pwd');$('otp').focus()}
     }
-  }catch(e){st(s,'error','Network error. Check your connection.');setInvalid('otp');if($('pwd-section').style.display==='block')setInvalid('pwd');btnReset(fs,btn,'Verify Code')}
+  }catch(e){st(s,'error','Network error. Check your connection.');setInvalid('otp');if($('pwd-section').style.display==='block')setInvalid('pwd');btnReset(fs,btn,'Verify Code');$('otp').focus()}
 }
 checkStatus();
 </script>

--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -585,6 +585,7 @@ def render_telegram_credential_form(
                     errorEl.textContent = "Please enter a value.";
                     errorEl.style.display = "block";
                     inputEl.setAttribute("aria-invalid", "true");
+                    inputEl.focus();
                     return;
                 }}
                 errorEl.style.display = "none";
@@ -659,11 +660,13 @@ def render_telegram_credential_form(
                 var inputs = activePanel ? activePanel.querySelectorAll('.field-input') : [];
                 var payload = {{}};
                 var valid = true;
+                var firstInvalid = null;
 
                 inputs.forEach(function (input) {{
                     if (input.value.trim() === "") {{
                         valid = false;
                         input.setAttribute("aria-invalid", "true");
+                        if (!firstInvalid) firstInvalid = input;
                     }} else {{
                         input.removeAttribute("aria-invalid");
                         payload[input.name] = input.value;
@@ -672,6 +675,7 @@ def render_telegram_credential_form(
 
                 if (!valid) {{
                     showStatus("error", "Please fill in the required field.");
+                    if (firstInvalid) firstInvalid.focus();
                     return;
                 }}
 


### PR DESCRIPTION
## What
- Adds auto-focusing behavior to the first invalid input element when form validation fails in both `credential_form.py` and `auth_server.py`.
- Updates the initial focus state in the `auth_server.py` form from the "OTP Code" input to the "Send OTP Code" button, making the flow more logical.

## Why
When forms fail validation, keyboard and screen reader users can lose their place on the page. By automatically shifting focus to the field requiring correction, we reduce friction and make the interface more accessible. Additionally, focusing the "Send OTP Code" button first ensures the user naturally begins at Step 1 rather than jumping ahead to an empty input field.

## Accessibility
- **Focus Management:** Users are immediately guided to errors, reducing the need for manual navigation.
- **Logical Flow:** The initial focus respects the linear progression of the authentication steps.

---
*PR created automatically by Jules for task [17657287797041998177](https://jules.google.com/task/17657287797041998177) started by @n24q02m*