### PR TITLE
feat: route stdio mode to FastMCP/MCP SDK direct + multi-target Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,14 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev
 
 # ========================
-# Stage 2: Runtime
+# Stage 2: Runtime base (shared by stdio + http targets)
 # ========================
-FROM python:3.13-slim-bookworm@sha256:bb73517d48bd32016e15eade0c009b2724ec3a025a9975b5cd9b251d0dcadb33
+# Multi-target Dockerfile per spec
+# `~/projects/.superpower/mcp-core/specs/2026-04-30-multi-mode-stdio-http-architecture.md`
+# section D6. Build stdio: `docker buildx build --target stdio -t <repo>:stdio .`
+# Build http:  `docker buildx build --target http  -t <repo>:http .`
+# Build latest (= http): `docker buildx build --target http -t <repo>:latest .`
+FROM python:3.13-slim-bookworm@sha256:bb73517d48bd32016e15eade0c009b2724ec3a025a9975b5cd9b251d0dcadb33 AS runtime
 
 LABEL org.opencontainers.image.source="https://github.com/n24q02m/better-telegram-mcp"
 LABEL io.modelcontextprotocol.server.name="io.github.n24q02m/better-telegram-mcp"
@@ -43,10 +48,7 @@ ENV PATH="/app/.venv/bin:$PATH" \
     PYTHONPATH=/app/src \
     PYTHONUNBUFFERED=1 \
     TELEGRAM_DATA_DIR=/data \
-    TRANSPORT_MODE=stdio \
     HOST=0.0.0.0
-
-EXPOSE 8080
 
 # Create non-root user and set permissions
 RUN groupadd -r appuser && useradd -r -g appuser -d /home/appuser -m appuser \
@@ -56,5 +58,18 @@ RUN groupadd -r appuser && useradd -r -g appuser -d /home/appuser -m appuser \
 VOLUME /data
 USER appuser
 
-# Stdio transport by default
-CMD ["python", "-m", "better_telegram_mcp"]
+# ========================
+# Stage 3a: stdio target (default for plugin marketplace & uvx-style usage)
+# ========================
+FROM runtime AS stdio
+ENV MCP_TRANSPORT=stdio
+ENTRYPOINT ["python", "-m", "better_telegram_mcp"]
+
+# ========================
+# Stage 3b: http target (multi-user remote daemon)
+# ========================
+FROM runtime AS http
+ENV MCP_TRANSPORT=http \
+    MCP_PORT=8080
+EXPOSE 8080
+ENTRYPOINT ["python", "-m", "better_telegram_mcp"]

--- a/src/better_telegram_mcp/server.py
+++ b/src/better_telegram_mcp/server.py
@@ -591,10 +591,11 @@ def main() -> None:
         or os.environ.get("MCP_TRANSPORT") == "stdio"
         or os.environ.get("TRANSPORT_MODE") == "stdio"
     ):
-        from mcp_core.transport import run_smart_stdio_proxy
-
-        daemon_cmd = [sys.executable, "-m", "better_telegram_mcp"]
-        sys.exit(run_smart_stdio_proxy("better-telegram-mcp", daemon_cmd))
+        # Stdio mode: run FastMCP stdio server directly. No bridge layer.
+        # Universal MCP client compatibility (Claude Code, Cursor, VS Code Copilot, etc.).
+        # See: ~/projects/.superpower/mcp-core/specs/2026-04-30-multi-mode-stdio-http-architecture.md
+        mcp.run(transport="stdio")
+        return
 
     # HTTP mode: dispatch through transports/http.py so the multi-user
     # OAuth 2.1 branch, the refuse-guard for broken single-user-on-public

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -357,13 +357,15 @@ async def test_help_works_during_pending_auth():
 
 
 def test_main_calls_run():
+    """main() in stdio mode runs FastMCP stdio server directly (no bridge)."""
+    import better_telegram_mcp.server as srv
+
     with (
-        patch("mcp_core.transport.run_smart_stdio_proxy", return_value=0) as mock_proxy,
+        patch.object(srv.mcp, "run") as mock_run,
         patch.dict(os.environ, {"MCP_TRANSPORT": "stdio"}),
-        pytest.raises(SystemExit, match="0"),
     ):
         main()
-        mock_proxy.assert_called_once()
+    mock_run.assert_called_once_with(transport="stdio")
 
 
 # --- unconfigured state tests (no credentials) ---

--- a/tests/test_stdio_direct.py
+++ b/tests/test_stdio_direct.py
@@ -1,0 +1,146 @@
+"""Verify better-telegram-mcp runs in stdio direct mode (no smart_stdio bridge).
+
+Spawns ``python -m better_telegram_mcp`` with ``MCP_TRANSPORT=stdio`` and
+exercises the JSON-RPC handshake plus ``tools/list`` to prove the FastMCP
+stdio server is wired directly (no daemon-spawn bridge layer in front of
+it).
+
+Marked ``live`` because it spawns a real subprocess and speaks the MCP
+protocol; excluded from the default ``pytest`` invocation but runs under
+``uv run pytest -m live``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+pytestmark = [pytest.mark.live, pytest.mark.timeout(60)]
+
+
+def _spawn_stdio_server() -> subprocess.Popen[str]:
+    """Start ``python -m better_telegram_mcp`` with stdio transport.
+
+    Returns the running subprocess. Caller is responsible for terminating it.
+    """
+    env = {**os.environ, "MCP_TRANSPORT": "stdio"}
+    return subprocess.Popen(
+        [sys.executable, "-m", "better_telegram_mcp"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+        text=True,
+        bufsize=1,
+    )
+
+
+def _read_response(proc: subprocess.Popen[str]) -> dict:
+    """Read one JSON-RPC line from stdout, parsed as dict."""
+    assert proc.stdout is not None and proc.stderr is not None
+    line = proc.stdout.readline()
+    if not line:
+        stderr = proc.stderr.read()
+        raise RuntimeError(
+            f"server closed stdout without sending a response. stderr=\n{stderr}"
+        )
+    return json.loads(line)
+
+
+def test_stdio_direct_init_responds():
+    """Spawn the server with MCP_TRANSPORT=stdio; verify init response shape."""
+    proc = _spawn_stdio_server()
+    assert proc.stdin is not None
+    init_request = (
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {},
+                    "clientInfo": {"name": "test", "version": "1.0"},
+                },
+            }
+        )
+        + "\n"
+    )
+    try:
+        proc.stdin.write(init_request)
+        proc.stdin.flush()
+        response = _read_response(proc)
+        assert response["id"] == 1
+        assert "result" in response, f"unexpected response: {response}"
+        # FastMCP negotiates protocol version; just assert it returned one.
+        assert "protocolVersion" in response["result"]
+        assert response["result"]["serverInfo"]["name"] == "better-telegram-mcp"
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+def test_stdio_direct_tools_list_returns_expected_tools():
+    """Verify tools/list returns the expected telegram tool set over stdio."""
+    proc = _spawn_stdio_server()
+    assert (
+        proc.stdin is not None and proc.stdout is not None and proc.stderr is not None
+    )
+    requests = [
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {},
+                    "clientInfo": {"name": "test", "version": "1.0"},
+                },
+            }
+        ),
+        json.dumps({"jsonrpc": "2.0", "method": "notifications/initialized"}),
+        json.dumps({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}}),
+    ]
+    try:
+        for r in requests:
+            proc.stdin.write(r + "\n")
+            proc.stdin.flush()
+        responses: dict[int, dict] = {}
+        while len(responses) < 2:
+            line = proc.stdout.readline()
+            if not line:
+                stderr = proc.stderr.read()
+                raise RuntimeError(
+                    f"server closed stdout before tools/list response. "
+                    f"stderr=\n{stderr}"
+                )
+            data = json.loads(line)
+            if "id" in data:
+                responses[data["id"]] = data
+        assert 2 in responses, f"missing tools/list response: {responses}"
+        tools = responses[2]["result"]["tools"]
+        tool_names = {t["name"] for t in tools}
+        # Core telegram tools that must be exposed in stdio mode. The full
+        # 7-tool set is chat, message, media, contact, config, help,
+        # config__open_relay; we assert the 6 always-on ones (config__open_relay
+        # registration may depend on relay-setup state, so we don't require it
+        # here) and accept any tool count >= 5.
+        expected = {"chat", "message", "media", "contact", "config", "help"}
+        assert expected.issubset(tool_names), (
+            f"missing tools: {expected - tool_names}; got: {tool_names}"
+        )
+        assert len(tools) >= 5
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.8.4"
+version = "4.8.5"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },
@@ -112,7 +112,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.27.0" },
-    { name = "n24q02m-mcp-core", specifier = ">=1.11.3" },
+    { name = "n24q02m-mcp-core", directory = "../mcp-core/packages/core-py" },
     { name = "pydantic", specifier = ">=2.9,<2.13" },
     { name = "pydantic-settings", specifier = ">=2.14.0" },
     { name = "starlette", specifier = ">=1.0.0" },
@@ -727,8 +727,8 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.11.3"
-source = { registry = "https://pypi.org/simple" }
+version = "1.11.5"
+source = { directory = "../mcp-core/packages/core-py" }
 dependencies = [
     { name = "authlib" },
     { name = "cryptography" },
@@ -741,9 +741,29 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/ce/2a174b08ea2d6e8bb6913756295e58a35460ca63e89201c58f4e80042fb5/n24q02m_mcp_core-1.11.3.tar.gz", hash = "sha256:55873571bf310d915917ff7ffc742948729215e807c514241b284a720eefa0b3", size = 200469, upload-time = "2026-04-29T10:59:50.138Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/a8/15d750245bc44bc21cdddb267ec026cf45f3c8c2c400c564e8808ed1f001/n24q02m_mcp_core-1.11.3-py3-none-any.whl", hash = "sha256:fe15f0b0da7152400da7fa6a0663ab1d0141b7d6c1d585d3d32ae40c6e0243fd", size = 123129, upload-time = "2026-04-29T10:59:48.631Z" },
+
+[package.metadata]
+requires-dist = [
+    { name = "authlib", specifier = ">=1.7.0" },
+    { name = "cryptography", specifier = ">=47.0.0" },
+    { name = "fastmcp", specifier = ">=3.2.4" },
+    { name = "filelock", specifier = ">=3.16.1" },
+    { name = "httpx", specifier = ">=0.28.1" },
+    { name = "loguru", specifier = ">=0.7.3" },
+    { name = "platformdirs", specifier = ">=4.9.6" },
+    { name = "pydantic", specifier = ">=2.12.5,<2.13" },
+    { name = "starlette", specifier = ">=1.0.0" },
+    { name = "tomli-w", specifier = ">=1.2.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "pytest-timeout", specifier = ">=2.4.0" },
+    { name = "ruff", specifier = ">=0.15.12" },
+    { name = "ty", specifier = ">=0.0.33" },
 ]
 
 [[package]]


### PR DESCRIPTION
Migrate stdio path from smart_stdio bridge to direct FastMCP/MCP SDK stdio. Universal MCP client compat. Multi-target Dockerfile (:stdio + :http). Spec: ~/projects/.superpower/mcp-core/specs/2026-04-30-multi-mode-stdio-http-architecture.md