### PR TITLE
feat(docs): add trust model section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ uv sync
 uv run better-telegram-mcp
 ```
 
+## Trust Model
+
+This plugin implements **TC-NearZK** (in-memory, ephemeral). See [mcp-core/docs/TRUST-MODEL.md](https://github.com/n24q02m/mcp-core/blob/main/docs/TRUST-MODEL.md) for full classification.
+
+| Mode | Storage | Encryption | Who can read your data? |
+|---|---|---|---|
+| HTTP n24q02m-hosted (default) | In-memory `dict[sub] = MTProtoSession` | In-process only | Server process (cleared on restart) |
+| HTTP self-host | Same as hosted | Same | Only you (admin = user) |
+| stdio proxy | `~/.better-telegram-mcp/config.json` | AES-GCM, machine-bound key | Only your OS user (file perm 0600) |
+
 ## License
 
 MIT -- See [LICENSE](LICENSE).

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.8.5"
+version = "4.9.0b2"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },
@@ -112,7 +112,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.27.0" },
-    { name = "n24q02m-mcp-core", directory = "../mcp-core/packages/core-py" },
+    { name = "n24q02m-mcp-core", specifier = ">=1.11.3" },
     { name = "pydantic", specifier = ">=2.9,<2.13" },
     { name = "pydantic-settings", specifier = ">=2.14.0" },
     { name = "starlette", specifier = ">=1.0.0" },
@@ -728,7 +728,7 @@ wheels = [
 [[package]]
 name = "n24q02m-mcp-core"
 version = "1.11.5"
-source = { directory = "../mcp-core/packages/core-py" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
     { name = "cryptography" },
@@ -741,29 +741,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "authlib", specifier = ">=1.7.0" },
-    { name = "cryptography", specifier = ">=47.0.0" },
-    { name = "fastmcp", specifier = ">=3.2.4" },
-    { name = "filelock", specifier = ">=3.16.1" },
-    { name = "httpx", specifier = ">=0.28.1" },
-    { name = "loguru", specifier = ">=0.7.3" },
-    { name = "platformdirs", specifier = ">=4.9.6" },
-    { name = "pydantic", specifier = ">=2.12.5,<2.13" },
-    { name = "starlette", specifier = ">=1.0.0" },
-    { name = "tomli-w", specifier = ">=1.2.0" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pytest", specifier = ">=9.0.3" },
-    { name = "pytest-asyncio", specifier = ">=1.3.0" },
-    { name = "pytest-cov", specifier = ">=7.1.0" },
-    { name = "pytest-timeout", specifier = ">=2.4.0" },
-    { name = "ruff", specifier = ">=0.15.12" },
-    { name = "ty", specifier = ">=0.0.33" },
+sdist = { url = "https://files.pythonhosted.org/packages/0b/6c/e0a40d83d6f205d9d7b82a328c36e4f67fdaf023f24afa24619c9a1d20fd/n24q02m_mcp_core-1.11.5.tar.gz", hash = "sha256:da0bfc839387d4b530218fdd9935cdcaeed5ca32672c8411026fe2aa922ef8c7", size = 200476, upload-time = "2026-04-29T13:39:14.741Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/43/02d41151dbcc4d195a40f5f8a20f361efe3cc5f7f115ead1d01c4b75cc44/n24q02m_mcp_core-1.11.5-py3-none-any.whl", hash = "sha256:5d6495720ab4d97d701f98a26304857444bd1342fe0ed99104cb2829ea920e07", size = 123128, upload-time = "2026-04-29T13:39:13.335Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add Trust Model section to README documenting the TC-NearZK trust class for HTTP hosted mode.

Links to canonical `mcp-core/docs/TRUST-MODEL.md` for full classification. Includes per-mode table showing in-memory credential storage (`dict[sub] = MTProtoSession`), no disk persistence.

Part of Task 8 of the trust-model-alignment plan.