### PR TITLE
feat(auth): migrate to in-memory session store (TC-NearZK)

### DIFF
--- a/src/better_telegram_mcp/auth/in_memory_session_store.py
+++ b/src/better_telegram_mcp/auth/in_memory_session_store.py
@@ -1,0 +1,55 @@
+"""In-memory per-user session store (TC-NearZK).
+
+Replaces deprecated per_user_session_store.py (disk-encrypted AES-GCM +
+PBKDF2) for HTTP multi-user mode. Aligns with Notion's in-memory
+pattern: server has access during request lifetime; restart clears all
+sessions, users re-auth via OTP/2FA flow.
+
+Trust model: server admin (n24q02m operator) can dump live memory via
+debugger but no persistent file = no FS-dump compromise.
+
+See ~/projects/.superpower/mcp-core/specs/2026-04-30-trust-model-alignment.md
+§ 4.D3 + § 5.A8.
+"""
+
+from __future__ import annotations
+
+import copy
+
+from .per_user_session_store import SessionInfo
+
+
+class InMemorySessionStore:
+    """Per-user MTProto session store with no disk persistence.
+
+    Drop-in replacement for PerUserSessionStore (same public API).
+    Constructor takes no arguments — no data_dir or secret needed.
+    """
+
+    def __init__(self) -> None:
+        self._store: dict[str, dict] = {}
+
+    def store(self, bearer: str, info: SessionInfo) -> None:
+        """Store a session for the given bearer token. Overwrites existing."""
+        self._store[bearer] = info.to_dict()
+
+    def load(self, bearer: str) -> SessionInfo | None:
+        """Load session info for a bearer token. Returns None if not found."""
+        data = self._store.get(bearer)
+        if data is None:
+            return None
+        return SessionInfo.from_dict(copy.deepcopy(data))
+
+    def load_all(self) -> dict[str, SessionInfo]:
+        """Load all stored sessions."""
+        return {
+            bearer: SessionInfo.from_dict(copy.deepcopy(data))
+            for bearer, data in self._store.items()
+        }
+
+    def delete(self, bearer: str) -> bool:
+        """Delete a session. Returns True if it existed."""
+        if bearer not in self._store:
+            return False
+        del self._store[bearer]
+        return True

--- a/src/better_telegram_mcp/auth/per_user_session_store.py
+++ b/src/better_telegram_mcp/auth/per_user_session_store.py
@@ -1,5 +1,9 @@
 """Encrypted per-user session storage for multi-user HTTP mode.
 
+DEPRECATED v1.0.0 — disk-encrypted AES-GCM + PBKDF2 storage replaced by
+InMemorySessionStore (TC-NearZK trust class). Module retained for one minor
+release as migration shim. Removed in v2.0.0.
+
 Stores bearer_token -> session_info mappings in a single encrypted file.
 Uses AES-256-GCM, key derived from CREDENTIAL_SECRET env var or auto-generated.
 Reuses the key derivation pattern from transports/credential_store.py.

--- a/src/better_telegram_mcp/auth/telegram_auth_provider.py
+++ b/src/better_telegram_mcp/auth/telegram_auth_provider.py
@@ -19,7 +19,8 @@ from ..backends.base import TelegramBackend
 from ..backends.bot_backend import BotBackend
 from ..backends.user_backend import UserBackend
 from ..config import Settings
-from .per_user_session_store import PerUserSessionStore, SessionInfo
+from .in_memory_session_store import InMemorySessionStore
+from .per_user_session_store import SessionInfo
 
 # Session expiry: 30 days
 _SESSION_TTL = 30 * 24 * 60 * 60
@@ -39,7 +40,7 @@ class TelegramAuthProvider:
         self._data_dir = data_dir
         self._api_id = api_id
         self._api_hash = api_hash
-        self._store = PerUserSessionStore(data_dir)
+        self._store = InMemorySessionStore()
 
         # bearer -> active TelegramBackend
         self.active_clients: dict[str, TelegramBackend] = {}

--- a/tests/auth/test_in_memory_session_store.py
+++ b/tests/auth/test_in_memory_session_store.py
@@ -1,0 +1,126 @@
+"""Tests for InMemorySessionStore (TC-NearZK trust class)."""
+
+from __future__ import annotations
+
+from better_telegram_mcp.auth.in_memory_session_store import InMemorySessionStore
+from better_telegram_mcp.auth.per_user_session_store import SessionInfo
+
+
+def _bot_info(token: str = "123:ABC") -> SessionInfo:
+    return SessionInfo(session_name="test", mode="bot", bot_token=token)
+
+
+def _user_info(phone: str = "+1111") -> SessionInfo:
+    return SessionInfo(
+        session_name="user-sess",
+        mode="user",
+        api_id=12345,
+        api_hash="abcdef",
+        phone=phone,
+    )
+
+
+class TestInMemorySessionStoreRoundTrip:
+    def test_store_and_load(self) -> None:
+        store = InMemorySessionStore()
+        info = _bot_info()
+        store.store("bearer-a", info)
+        loaded = store.load("bearer-a")
+        assert loaded is not None
+        assert loaded.session_name == "test"
+        assert loaded.bot_token == "123:ABC"
+
+    def test_load_returns_none_for_unknown(self) -> None:
+        store = InMemorySessionStore()
+        assert store.load("nonexistent") is None
+
+    def test_load_returns_none_when_empty(self) -> None:
+        store = InMemorySessionStore()
+        assert store.load("any-bearer") is None
+
+    def test_overwrite_existing(self) -> None:
+        store = InMemorySessionStore()
+        store.store("b1", _bot_info("old"))
+        store.store("b1", _bot_info("new"))
+        loaded = store.load("b1")
+        assert loaded is not None
+        assert loaded.bot_token == "new"
+
+    def test_returns_copy_not_reference(self) -> None:
+        """Mutations to loaded SessionInfo must not affect stored data."""
+        store = InMemorySessionStore()
+        store.store("b1", _bot_info("original"))
+        loaded = store.load("b1")
+        assert loaded is not None
+        loaded.bot_token = "mutated"
+        loaded2 = store.load("b1")
+        assert loaded2 is not None
+        assert loaded2.bot_token == "original"
+
+
+class TestInMemorySessionStoreIsolation:
+    def test_per_bearer_isolation(self) -> None:
+        store = InMemorySessionStore()
+        store.store("bearer-a", _bot_info("token-a"))
+        store.store("bearer-b", _bot_info("token-b"))
+        a = store.load("bearer-a")
+        b = store.load("bearer-b")
+        assert a is not None and a.bot_token == "token-a"
+        assert b is not None and b.bot_token == "token-b"
+
+    def test_sessions_lost_on_new_instance(self) -> None:
+        """Simulate restart: new InMemorySessionStore has no prior data."""
+        store1 = InMemorySessionStore()
+        store1.store("bearer-a", _bot_info())
+        assert store1.load("bearer-a") is not None
+
+        store2 = InMemorySessionStore()
+        assert store2.load("bearer-a") is None
+
+
+class TestInMemorySessionStoreDelete:
+    def test_delete_existing_returns_true(self) -> None:
+        store = InMemorySessionStore()
+        store.store("b1", _bot_info())
+        assert store.delete("b1") is True
+        assert store.load("b1") is None
+
+    def test_delete_nonexistent_returns_false(self) -> None:
+        store = InMemorySessionStore()
+        assert store.delete("nonexistent") is False
+
+    def test_delete_preserves_others(self) -> None:
+        store = InMemorySessionStore()
+        store.store("b1", _bot_info("t1"))
+        store.store("b2", _bot_info("t2"))
+        store.delete("b1")
+        assert store.load("b1") is None
+        loaded = store.load("b2")
+        assert loaded is not None and loaded.bot_token == "t2"
+
+
+class TestInMemorySessionStoreLoadAll:
+    def test_load_all_empty(self) -> None:
+        store = InMemorySessionStore()
+        assert store.load_all() == {}
+
+    def test_load_all_returns_all(self) -> None:
+        store = InMemorySessionStore()
+        store.store("b1", _bot_info("t1"))
+        store.store("b2", _bot_info("t2"))
+        all_sessions = store.load_all()
+        assert len(all_sessions) == 2
+        assert "b1" in all_sessions
+        assert "b2" in all_sessions
+        assert all_sessions["b1"].bot_token == "t1"
+        assert all_sessions["b2"].bot_token == "t2"
+
+    def test_load_all_returns_copy(self) -> None:
+        """Mutations to load_all() result must not affect stored data."""
+        store = InMemorySessionStore()
+        store.store("b1", _bot_info("original"))
+        all_sessions = store.load_all()
+        all_sessions["b1"].bot_token = "mutated"
+        loaded = store.load("b1")
+        assert loaded is not None
+        assert loaded.bot_token == "original"


### PR DESCRIPTION
Per spec § 4.D3 + § 5.A8 of `~/projects/.superpower/mcp-core/specs/2026-04-30-trust-model-alignment.md`.

## Changes

- **New**: `src/better_telegram_mcp/auth/in_memory_session_store.py` — `InMemorySessionStore` (TC-NearZK trust class). Drop-in replacement for `PerUserSessionStore` with identical public API (`store/load/load_all/delete`). No constructor args — no `data_dir` or secret needed.
- **Modified**: `src/better_telegram_mcp/auth/telegram_auth_provider.py` — swap instantiation to `InMemorySessionStore()`; remove `PerUserSessionStore` import.
- **Modified**: `src/better_telegram_mcp/auth/per_user_session_store.py` — deprecation notice added; module retained as migration shim for one minor release.
- **New**: `tests/auth/test_in_memory_session_store.py` — 13 tests covering round-trip, isolation, restart clears data, delete, load_all, and copy semantics.

## Trust model

Drops disk persistence. Aligns with Notion in-memory pattern: server has access during request lifetime; restart clears all sessions, users re-auth via OTP+2FA. Eliminates persistent FS-dump compromise (TC-NearZK).