### PR TITLE
fix: regenerate uv.lock UV_NO_SOURCES=1 (Docker build trap)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.9.0b4"
+version = "4.9.0b5"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },
@@ -112,7 +112,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.27.0" },
-    { name = "n24q02m-mcp-core", directory = "../mcp-core/packages/core-py" },
+    { name = "n24q02m-mcp-core", specifier = ">=1.13.0b4" },
     { name = "pydantic", specifier = ">=2.9,<2.13" },
     { name = "pydantic-settings", specifier = ">=2.14.0" },
     { name = "starlette", specifier = ">=1.0.0" },
@@ -727,8 +727,8 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.13.0b3"
-source = { directory = "../mcp-core/packages/core-py" }
+version = "1.13.0b4"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
     { name = "cryptography" },
@@ -741,29 +741,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "authlib", specifier = ">=1.7.0" },
-    { name = "cryptography", specifier = ">=47.0.0" },
-    { name = "fastmcp", specifier = ">=3.2.4" },
-    { name = "filelock", specifier = ">=3.16.1" },
-    { name = "httpx", specifier = ">=0.28.1" },
-    { name = "loguru", specifier = ">=0.7.3" },
-    { name = "platformdirs", specifier = ">=4.9.6" },
-    { name = "pydantic", specifier = ">=2.12.5,<2.13" },
-    { name = "starlette", specifier = ">=1.0.0" },
-    { name = "tomli-w", specifier = ">=1.2.0" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pytest", specifier = ">=9.0.3" },
-    { name = "pytest-asyncio", specifier = ">=1.3.0" },
-    { name = "pytest-cov", specifier = ">=7.1.0" },
-    { name = "pytest-timeout", specifier = ">=2.4.0" },
-    { name = "ruff", specifier = ">=0.15.12" },
-    { name = "ty", specifier = ">=0.0.33" },
+sdist = { url = "https://files.pythonhosted.org/packages/0a/65/916107fa1ff9636fd0b2ef37a7d8e7c6bd94f1f51ed9e616903ffd13771c/n24q02m_mcp_core-1.13.0b4.tar.gz", hash = "sha256:5ccd0a909bb434cd0b5d4bdacb19a962cca986c095b5a47869cf54ab27f81727", size = 185547, upload-time = "2026-05-02T06:02:37.875Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/d4/e25b5e3c994b4b8618e57570dfdf3f787be54f38d10c5644ab623f0cfc8c/n24q02m_mcp_core-1.13.0b4-py3-none-any.whl", hash = "sha256:e73be2e0d6649bff1d73dfaea9147501ad821709118c962a35b35aa64a7ce940", size = 118637, upload-time = "2026-05-02T06:02:36.536Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Beta CD failed because uv.lock had path source. Per feedback_uv_lock_docker_trap.md.