### PR TITLE
⚡ Bolt: Optimize `request.headers` lookup in Starlette apps

### DIFF
--- a/src/better_telegram_mcp/auth_server.py
+++ b/src/better_telegram_mcp/auth_server.py
@@ -247,10 +247,10 @@ class AuthServer:
         # 🛡️ Sentinel: Never trust x-forwarded-for or cf-connecting-ip headers for rate
         # limiting unless explicitly behind a configured trusted proxy, as they can be easily spoofed.
         if client_ip in self._settings.trusted_proxy_list:
-            if "cf-connecting-ip" in request.headers:
-                return request.headers["cf-connecting-ip"]
-            if "x-forwarded-for" in request.headers:
-                return request.headers["x-forwarded-for"].split(",")[0].strip()
+            if cf_ip := request.headers.get("cf-connecting-ip"):
+                return cf_ip
+            if xff := request.headers.get("x-forwarded-for"):
+                return xff.split(",")[0].strip()
         return client_ip
 
     def _check_rate_limit(self, key: str) -> bool:

--- a/src/better_telegram_mcp/transports/http_multi_user.py
+++ b/src/better_telegram_mcp/transports/http_multi_user.py
@@ -76,10 +76,10 @@ def _get_client_ip(request: Request) -> str:
     trusted_proxies = _parse_trusted_proxies(trusted_proxies_env)
 
     if client_ip in trusted_proxies:
-        if "cf-connecting-ip" in request.headers:
-            return request.headers["cf-connecting-ip"]
-        if "x-forwarded-for" in request.headers:
-            return request.headers["x-forwarded-for"].split(",")[0].strip()
+        if cf_ip := request.headers.get("cf-connecting-ip"):
+            return cf_ip
+        if xff := request.headers.get("x-forwarded-for"):
+            return xff.split(",")[0].strip()
     return client_ip
 
 


### PR DESCRIPTION
💡 **What:** Replaced the two-step `if "header" in request.headers` check followed by a retrieval with a single `.get()` lookup using the walrus operator (`if val := request.headers.get("header"):`).
🎯 **Why:** To prevent redundant underlying dictionary lookups on Starlette's `Headers` object in the hot path of request validation and IP extraction.
📊 **Impact:** Reduces lookup overhead slightly for proxy headers extraction (`cf-connecting-ip` and `x-forwarded-for`).
🔬 **Measurement:** This optimization can be observed via localized micro-benchmarks targeting header parsing logic during high-throughput proxy requests. Verified full correctness via pytest.

---
*PR created automatically by Jules for task [3228180003497910227](https://jules.google.com/task/3228180003497910227) started by @n24q02m*