### PR TITLE
🎨 Palette: Auto-focus first invalid input on form validation failure

### DIFF
--- a/src/better_telegram_mcp/auth_server.py
+++ b/src/better_telegram_mcp/auth_server.py
@@ -153,7 +153,7 @@ async function verify(){
   const btn=$('btn-verify'),s=$('s1'),fs=$('fs1');
   clearInvalid('otp');clearInvalid('pwd');
   const code=$('otp').value.trim();
-  if(!code){st(s,'error','Please enter the OTP code first.');setInvalid('otp');return}
+  if(!code){st(s,'error','Please enter the OTP code first.');setInvalid('otp');$('otp').focus();return}
   btnLoading(fs,btn,'Verifying...');
   try{const body={code};const pwd=$('pwd').value.trim();if(pwd)body.password=pwd;
     const r=await fetch('/verify',{method:'POST',headers:{'Content-Type':'application/json','X-Auth-Token':_t},body:JSON.stringify(body)});

--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -585,6 +585,7 @@ def render_telegram_credential_form(
                     errorEl.textContent = "Please enter a value.";
                     errorEl.style.display = "block";
                     inputEl.setAttribute("aria-invalid", "true");
+                    inputEl.focus();
                     return;
                 }}
                 errorEl.style.display = "none";
@@ -659,11 +660,13 @@ def render_telegram_credential_form(
                 var inputs = activePanel ? activePanel.querySelectorAll('.field-input') : [];
                 var payload = {{}};
                 var valid = true;
+                var firstInvalid = null;
 
                 inputs.forEach(function (input) {{
                     if (input.value.trim() === "") {{
                         valid = false;
                         input.setAttribute("aria-invalid", "true");
+                        if (!firstInvalid) firstInvalid = input;
                     }} else {{
                         input.removeAttribute("aria-invalid");
                         payload[input.name] = input.value;
@@ -672,6 +675,7 @@ def render_telegram_credential_form(
 
                 if (!valid) {{
                     showStatus("error", "Please fill in the required field.");
+                    if (firstInvalid) firstInvalid.focus();
                     return;
                 }}
 


### PR DESCRIPTION
💡 **What:** Added `.focus()` calls to the client-side JavaScript validation logic in `credential_form.py` and `auth_server.py`. When a form submission fails validation (due to empty required fields), the focus is immediately shifted to the first invalid input.
🎯 **Why:** To improve keyboard navigation and reduce friction. Previously, users had to manually click or tab back to the empty field after seeing an error message.
📸 **Before/After:** Before, the focus remained on the submit button. Now, the focus ring appears around the missing input field immediately. (Screenshot verified via Playwright).
♿ **Accessibility:** This is a crucial accessibility improvement for screen reader and keyboard-only users, guiding them directly to the source of the error.

---
*PR created automatically by Jules for task [15493757926078907894](https://jules.google.com/task/15493757926078907894) started by @n24q02m*