### PR TITLE
feat: MCP_RELAY_PASSWORD edge auth env

### DIFF
--- a/docker-compose.http.yml
+++ b/docker-compose.http.yml
@@ -5,6 +5,7 @@ services:
     environment:
       - TRANSPORT_MODE=http
       - CREDENTIAL_SECRET=${CREDENTIAL_SECRET}
+      - MCP_RELAY_PASSWORD=${MCP_RELAY_PASSWORD}
     ports:
       - "8081:8080"
     volumes:


### PR DESCRIPTION
Per mcp-core spec 2026-05-01 §4.2.1 — pass new env var to HTTP container for /login gate.