### PR TITLE
feat: wire /login relay-password gate into multi-user oauth_server

### DIFF
--- a/src/better_telegram_mcp/transports/oauth_server.py
+++ b/src/better_telegram_mcp/transports/oauth_server.py
@@ -16,6 +16,12 @@ from pathlib import Path
 from typing import cast
 
 from loguru import logger
+from mcp_core.auth.relay_login import (
+    configure_relay_login,
+    login_get_handler,
+    login_post_handler,
+    require_relay_session,
+)
 from mcp_core.oauth import (
     JWTIssuer,
     OAuthProvider,
@@ -56,6 +62,15 @@ def create_app(
     master_secret: str,
 ) -> Starlette:
     """Create the multi-user Starlette ASGI application with OAuth 2.1."""
+
+    # Edge auth password gate (per spec 2026-05-01-stdio-pure-http-multiuser
+    # §5.1.2.1 + D21). When ``MCP_RELAY_PASSWORD`` is set, /authorize is
+    # fronted by a thin cookie-session check; unauthenticated requests are
+    # redirected to /login. Empty/unset password disables the gate (single-
+    # user dev mode). This custom multi-user OAuth server bypasses mcp-core's
+    # local_oauth_app, so we wire the same primitive here for parity.
+    _relay_password = os.environ.get("MCP_RELAY_PASSWORD", "")
+    configure_relay_login(_relay_password)
 
     issuer = JWTIssuer(server_name="better-telegram-mcp", keys_dir=data_dir / "keys")
     user_store = SqliteUserStore(
@@ -105,7 +120,21 @@ def create_app(
         await auth_provider.shutdown()
 
     async def authorize(request: Request) -> JSONResponse | RedirectResponse:
-        """GET /authorize"""
+        """GET /authorize.
+
+        When ``MCP_RELAY_PASSWORD`` is set, requests without a valid
+        ``mcp_relay_session`` cookie are redirected to ``/login`` (handled
+        inside ``require_relay_session``). Mirrors mcp-core's
+        ``local_oauth_app.py`` wrapper pattern.
+        """
+        if _relay_password:
+            gated = await require_relay_session(
+                dict(request.cookies),
+                str(request.url.path)
+                + (f"?{request.url.query}" if request.url.query else ""),
+            )
+            if gated is not None:
+                return gated
         params = request.query_params
         client_id = params.get("client_id")
         redirect_uri = params.get("redirect_uri")
@@ -309,7 +338,20 @@ def create_app(
     async def health(_request: Request) -> JSONResponse:
         return JSONResponse({"status": "ok", "server": "better-telegram-mcp"})
 
+    async def login_get(request: Request):
+        """GET /login -- render the relay-password form."""
+        next_param = request.query_params.get("next", "/authorize")
+        return await login_get_handler(next_param)
+
+    async def login_post(request: Request):
+        """POST /login -- verify relay password and issue session cookie."""
+        form = await request.form()
+        ip = request.client.host if request.client else "unknown"
+        return await login_post_handler(dict(form), ip=ip)
+
     routes = [
+        Route("/login", login_get, methods=["GET"]),
+        Route("/login", login_post, methods=["POST"]),
         Route("/authorize", authorize, methods=["GET"]),
         Route("/register", register, methods=["POST"]),
         Route("/token", token, methods=["POST"]),

--- a/tests/test_oauth_server_relay_gate.py
+++ b/tests/test_oauth_server_relay_gate.py
@@ -1,0 +1,219 @@
+"""Tests for the relay-password gate wired into the multi-user OAuth server.
+
+Per spec ``2026-05-01-stdio-pure-http-multiuser §5.1.2.1`` + D21, the custom
+multi-user ``oauth_server.create_app`` must mount ``/login`` GET + POST and
+gate ``/authorize`` behind the ``MCP_RELAY_PASSWORD`` cookie session — same
+primitive mcp-core's ``local_oauth_app.py`` uses, so single-user and
+multi-user deployments share an identical edge auth surface.
+"""
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from mcp_core.auth.relay_login import _fails, _sessions, configure_relay_login
+from starlette.testclient import TestClient
+
+from better_telegram_mcp.transports.oauth_server import create_app
+
+
+@pytest.fixture(autouse=True)
+def _reset_relay_login() -> None:
+    """Clear module-scoped session + brute-force counters between cases.
+
+    ``relay_login`` keeps these in module-global dicts; without a reset
+    a sticky ``mcp_relay_session`` from one test can satisfy the gate in
+    another, masking real failures.
+    """
+    _sessions.clear()
+    _fails.clear()
+    configure_relay_login("")
+    yield
+    _sessions.clear()
+    _fails.clear()
+    configure_relay_login("")
+
+
+@pytest.fixture
+def data_dir(tmp_path):
+    d = tmp_path / "data"
+    d.mkdir()
+    (d / "keys").mkdir()
+    return d
+
+
+@pytest.fixture
+def mock_inner_app():
+    async def app(scope, receive, send):
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"application/json")],
+            }
+        )
+        await send({"type": "http.response.body", "body": b"{}"})
+
+    return app
+
+
+def _build_app(data_dir, mock_inner_app, *, relay_password: str | None):
+    """Build the multi-user OAuth app with optional ``MCP_RELAY_PASSWORD`` set.
+
+    The env var must be set BEFORE ``create_app`` is called — the wiring
+    snapshots ``os.environ.get("MCP_RELAY_PASSWORD", "")`` at construction
+    time and feeds it into ``configure_relay_login``.
+    """
+    issuer = MagicMock()
+    issuer.get_jwks.return_value = {"keys": []}
+    issuer.verify_access_token.return_value = {"sub": "user123"}
+
+    oauth = MagicMock()
+    oauth.create_authorize_redirect = AsyncMock(return_value="https://relay/auth")
+    oauth.exchange_code = AsyncMock(
+        return_value=("access_token_123", {"TELEGRAM_BOT_TOKEN": "123:abc"})
+    )
+
+    user_store = MagicMock()
+    user_store.get_credentials.return_value = {"TELEGRAM_BOT_TOKEN": "123:abc"}
+
+    auth_provider = MagicMock()
+    auth_provider.restore_sessions = AsyncMock()
+    auth_provider.shutdown = AsyncMock()
+    auth_provider.register_bot = AsyncMock()
+    auth_provider.resolve_backend.return_value = MagicMock()
+
+    env_patch = (
+        patch.dict("os.environ", {"MCP_RELAY_PASSWORD": relay_password}, clear=False)
+        if relay_password is not None
+        else patch.dict("os.environ", {}, clear=False)
+    )
+
+    with (
+        env_patch,
+        patch(
+            "better_telegram_mcp.transports.oauth_server.JWTIssuer",
+            return_value=issuer,
+        ),
+        patch(
+            "better_telegram_mcp.transports.oauth_server.OAuthProvider",
+            return_value=oauth,
+        ),
+        patch(
+            "better_telegram_mcp.transports.oauth_server.SqliteUserStore",
+            return_value=user_store,
+        ),
+        patch(
+            "better_telegram_mcp.auth.telegram_auth_provider.TelegramAuthProvider",
+            return_value=auth_provider,
+        ),
+        patch(
+            "better_telegram_mcp.server.create_http_mcp_server"
+        ) as mock_create_server,
+    ):
+        mock_mcp = MagicMock()
+        mock_mcp._mcp_server = MagicMock()
+        mock_create_server.return_value = mock_mcp
+
+        with (
+            patch(
+                "mcp.server.streamable_http_manager.StreamableHTTPSessionManager"
+            ) as mock_manager_cls,
+            patch(
+                "mcp.server.fastmcp.server.StreamableHTTPASGIApp",
+                return_value=mock_inner_app,
+            ),
+        ):
+            mock_manager = MagicMock()
+
+            @asynccontextmanager
+            async def mock_run():
+                yield
+
+            mock_manager.run.return_value = mock_run()
+            mock_manager_cls.return_value = mock_manager
+
+            return create_app(
+                data_dir=data_dir,
+                public_url="https://mcp.example.com",
+                master_secret="topsecret",
+            )
+
+
+def test_authorize_no_password_gate_disabled(data_dir, mock_inner_app, monkeypatch):
+    """Empty MCP_RELAY_PASSWORD -> /authorize proceeds without cookie."""
+    monkeypatch.delenv("MCP_RELAY_PASSWORD", raising=False)
+    app = _build_app(data_dir, mock_inner_app, relay_password=None)
+    with TestClient(app) as client:
+        resp = client.get(
+            "/authorize",
+            params={
+                "client_id": "cli",
+                "redirect_uri": "https://cli/cb",
+                "state": "st",
+                "code_challenge": "cc",
+            },
+            follow_redirects=False,
+        )
+    # Gate disabled -> falls through to OAuth provider redirect (302/307 to relay).
+    assert resp.status_code in (302, 307)
+    assert resp.headers["location"] == "https://relay/auth"
+
+
+def test_authorize_with_password_no_cookie_redirects_to_login(data_dir, mock_inner_app):
+    """MCP_RELAY_PASSWORD set + no cookie -> 302 redirect to /login?next=..."""
+    app = _build_app(data_dir, mock_inner_app, relay_password="s3cret")
+    with TestClient(app) as client:
+        resp = client.get(
+            "/authorize",
+            params={
+                "client_id": "cli",
+                "redirect_uri": "https://cli/cb",
+                "state": "st",
+                "code_challenge": "cc",
+            },
+            follow_redirects=False,
+        )
+    assert resp.status_code == 302
+    location = resp.headers["location"]
+    assert location.startswith("/login?next=")
+    # The next param must encode the original /authorize URL with query string.
+    assert "%2Fauthorize" in location
+
+
+def test_login_get_returns_html_form(data_dir, mock_inner_app):
+    """GET /login -> 200 with the relay-password form."""
+    app = _build_app(data_dir, mock_inner_app, relay_password="s3cret")
+    with TestClient(app) as client:
+        resp = client.get("/login")
+    assert resp.status_code == 200
+    assert "Relay login" in resp.text
+    assert 'name="password"' in resp.text
+
+
+def test_login_post_wrong_password_401(data_dir, mock_inner_app):
+    """POST /login with wrong password -> 401."""
+    app = _build_app(data_dir, mock_inner_app, relay_password="s3cret")
+    with TestClient(app) as client:
+        resp = client.post(
+            "/login",
+            data={"password": "wrong", "next": "/authorize"},
+        )
+    assert resp.status_code == 401
+
+
+def test_login_post_correct_password_sets_cookie_and_redirects(
+    data_dir, mock_inner_app
+):
+    """POST /login with correct password -> 302 + Set-Cookie mcp_relay_session."""
+    app = _build_app(data_dir, mock_inner_app, relay_password="s3cret")
+    with TestClient(app) as client:
+        resp = client.post(
+            "/login",
+            data={"password": "s3cret", "next": "/authorize"},
+            follow_redirects=False,
+        )
+    assert resp.status_code == 302
+    set_cookie = resp.headers.get("set-cookie", "")
+    assert "mcp_relay_session=" in set_cookie
+    assert resp.headers["location"] == "/authorize"


### PR DESCRIPTION
## Summary

Per mcp-core spec `2026-05-01-stdio-pure-http-multiuser.md` §5.1.2.1 + D21. The custom multi-user OAuth server (`transports/oauth_server.py`) bypassed mcp-core's `local_oauth_app` `/login` wiring → `/login` = 404 on multi-user deploy when `DCR_SERVER_SECRET` + `PUBLIC_URL` + api_id/api_hash all set. This wires the identical `relay_login` primitive from mcp-core into the custom server so single-user (mcp-core `local_oauth_app`) and multi-user (telegram custom `oauth_server`) deployments share an identical edge auth surface.

## Changes

- Import `configure_relay_login` + `login_get_handler` + `login_post_handler` + `require_relay_session` from `mcp_core.auth.relay_login`.
- Snapshot `MCP_RELAY_PASSWORD` at `create_app` construction; empty disables the gate (single-user dev mode).
- Wrap `/authorize` handler with `require_relay_session` check at the top (mirrors `local_oauth_app.authorize` wrapper).
- Add `/login` GET (renders password form) + `/login` POST (verifies, sets `mcp_relay_session` cookie). `/register`, `/token`, `/.well-known/*` remain unprotected per spec.

## Test plan

- [x] New `tests/test_oauth_server_relay_gate.py`: 5 scenarios — empty password gate disabled, set password redirects to /login, GET /login renders form, POST /login 401 wrong, POST /login 302 + Set-Cookie correct.
- [x] Full suite: `uv run pytest tests/` → 614 passed, 12 skipped.
- [x] Pre-commit hooks: ruff, ty, pytest, gitleaks all green.
- [ ] Post-merge: BETA cut, deploy oci-better-telegram-mcp, `curl https://better-telegram-mcp.n24q02m.com/login` → 200.