### PR TITLE
fix: wire create_http_mcp_server() + auth_scope diagnostic log

### DIFF
--- a/src/better_telegram_mcp/transports/http.py
+++ b/src/better_telegram_mcp/transports/http.py
@@ -194,8 +194,28 @@ async def _per_request_sub_scope(
         provider = get_global_provider()
         if provider is not None:
             backend = provider.resolve_backend(sub)
+            keys_preview = list(provider.active_clients.keys())
+            keys_short = [
+                k[:12] + "..." if len(k) > 12 else k for k in keys_preview[:5]
+            ]
+            logger.info(
+                "auth_scope: sub={} found_backend={} active_keys_count={} keys={}",
+                (sub or "")[:12] + "...",
+                type(backend).__name__ if backend else "None",
+                len(provider.active_clients),
+                keys_short,
+            )
             if backend is not None:
                 backend_token = _current_backend.set(backend)
+        else:
+            logger.warning(
+                "auth_scope: get_global_provider() returned None (sub={})",
+                (sub or "")[:12],
+            )
+    else:
+        logger.warning(
+            "auth_scope: claims has no 'sub' field, claims_keys={}", list(claims.keys())
+        )
 
     try:
         await next_()
@@ -226,7 +246,12 @@ def _start_multi_user_http(settings: Settings) -> None:
     from ..auth.telegram_auth_provider import TelegramAuthProvider, set_global_provider
     from ..credential_form import render_telegram_credential_form
     from ..credential_state import on_step_submitted, save_credentials
-    from ..server import mcp
+    from ..server import create_http_mcp_server
+
+    # Set _multi_user_mode = True in server module so get_backend() reads
+    # the per-request contextvar set by _per_request_sub_scope below
+    # instead of falling back to the global single-user backend.
+    mcp = create_http_mcp_server()
 
     # Build the global TelegramAuthProvider so ``save_credentials``,
     # ``on_step_submitted``, and the auth_scope middleware all share the

--- a/tests/test_relay_setup.py
+++ b/tests/test_relay_setup.py
@@ -164,17 +164,26 @@ async def test_lifespan_falls_back_to_unconfigured_when_no_credentials():
     def mock_resolve():
         return CredentialState.AWAITING_SETUP
 
-    with (
-        patch.object(srv, "Settings", return_value=MagicMock(is_configured=False)),
-        patch(
-            "better_telegram_mcp.credential_state.resolve_credential_state",
-            side_effect=mock_resolve,
-        ),
-    ):
-        async with _lifespan(mcp):
-            assert srv._unconfigured is True
+    # Reset _multi_user_mode flag — earlier tests may have called
+    # create_http_mcp_server() which flips it globally. Unconfigured
+    # fallback is single-user-mode behavior; multi-user has its own
+    # branch that yields immediately without setting _unconfigured.
+    original_multi_user = srv._multi_user_mode
+    srv._multi_user_mode = False
+    try:
+        with (
+            patch.object(srv, "Settings", return_value=MagicMock(is_configured=False)),
+            patch(
+                "better_telegram_mcp.credential_state.resolve_credential_state",
+                side_effect=mock_resolve,
+            ),
+        ):
+            async with _lifespan(mcp):
+                assert srv._unconfigured is True
 
-        assert srv._unconfigured is False
+            assert srv._unconfigured is False
+    finally:
+        srv._multi_user_mode = original_multi_user
 
 
 # --- relay_schema ---

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -568,20 +568,27 @@ async def test_lifespan_unconfigured_mode():
     from better_telegram_mcp.credential_state import CredentialState
     from better_telegram_mcp.server import _lifespan
 
-    with (
-        patch.object(srv, "Settings") as mock_settings_cls,
-        patch(
-            "better_telegram_mcp.credential_state.resolve_credential_state",
-            return_value=CredentialState.AWAITING_SETUP,
-        ),
-    ):
-        mock_settings = mock_settings_cls.return_value
-        mock_settings.is_configured = False
+    # Reset _multi_user_mode flag — earlier tests may have called
+    # create_http_mcp_server() which flips it globally.
+    original_multi_user = srv._multi_user_mode
+    srv._multi_user_mode = False
+    try:
+        with (
+            patch.object(srv, "Settings") as mock_settings_cls,
+            patch(
+                "better_telegram_mcp.credential_state.resolve_credential_state",
+                return_value=CredentialState.AWAITING_SETUP,
+            ),
+        ):
+            mock_settings = mock_settings_cls.return_value
+            mock_settings.is_configured = False
 
-        async with _lifespan(mcp):
-            assert srv._unconfigured is True
+            async with _lifespan(mcp):
+                assert srv._unconfigured is True
 
-        assert srv._unconfigured is False
+            assert srv._unconfigured is False
+    finally:
+        srv._multi_user_mode = original_multi_user
 
 
 # --- setup_* config actions (credential state integration) ---

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.9.0b9"
+version = "4.9.0b10"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },
@@ -112,7 +112,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.27.0" },
-    { name = "n24q02m-mcp-core", directory = "../mcp-core/packages/core-py" },
+    { name = "n24q02m-mcp-core", specifier = ">=1.13.0b9" },
     { name = "pydantic", specifier = ">=2.9,<2.13" },
     { name = "pydantic-settings", specifier = ">=2.14.0" },
     { name = "starlette", specifier = ">=1.0.0" },
@@ -727,8 +727,8 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.13.0b8"
-source = { directory = "../mcp-core/packages/core-py" }
+version = "1.13.0b9"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
     { name = "cryptography" },
@@ -741,29 +741,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "authlib", specifier = ">=1.7.0" },
-    { name = "cryptography", specifier = ">=47.0.0" },
-    { name = "fastmcp", specifier = ">=3.2.4" },
-    { name = "filelock", specifier = ">=3.16.1" },
-    { name = "httpx", specifier = ">=0.28.1" },
-    { name = "loguru", specifier = ">=0.7.3" },
-    { name = "platformdirs", specifier = ">=4.9.6" },
-    { name = "pydantic", specifier = ">=2.12.5,<2.13" },
-    { name = "starlette", specifier = ">=1.0.0" },
-    { name = "tomli-w", specifier = ">=1.2.0" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pytest", specifier = ">=9.0.3" },
-    { name = "pytest-asyncio", specifier = ">=1.3.0" },
-    { name = "pytest-cov", specifier = ">=7.1.0" },
-    { name = "pytest-timeout", specifier = ">=2.4.0" },
-    { name = "ruff", specifier = ">=0.15.12" },
-    { name = "ty", specifier = ">=0.0.33" },
+sdist = { url = "https://files.pythonhosted.org/packages/b2/83/62231d50dc150328f58c78fac135962e5a7641a00035d1e2b332d7b340a2/n24q02m_mcp_core-1.13.0b9.tar.gz", hash = "sha256:45ca969044f84a06db37d54705f03928dfaf53fd23ab3d13b4e59b86a70e4f3f", size = 192382, upload-time = "2026-05-03T14:27:54.192Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/89/7fac8548690857aa6932af2987a9ff19bce595cc975b890c8d83eff27381/n24q02m_mcp_core-1.13.0b9-py3-none-any.whl", hash = "sha256:32ebc4b96b12b8c033bf0f50a938c891020e393a67e5bebde6944f6d4a555eae", size = 123359, upload-time = "2026-05-03T14:27:55.796Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
PR #450 lost the http.py changes during squash merge (only uv.lock landed). This PR reapplies them properly:

- Replace `from ..server import mcp` with `mcp = create_http_mcp_server()` so `_multi_user_mode` flag is set to True (without it, get_backend() falls through to global single-user backend).
- Add diagnostic logging to `_per_request_sub_scope` middleware (logs sub, found_backend, active_keys count) to verify per-request contextvar wiring.
- Test fixtures: reset `_multi_user_mode = False` in test_lifespan_unconfigured_mode + test_lifespan_falls_back_to_unconfigured (test isolation — earlier tests may have flipped the global flag).

After merge, retest user-mode tool call expectation: middleware fires → log shows backend resolved by sub → tool returns Telegram-domain response (not bot-mode 'requires user mode' fallback).