### PR TITLE
feat: declare userConfig schema and document install prompt

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,6 +2,15 @@
   "name": "better-telegram-mcp",
   "description": "Telegram dual-mode (Bot API + MTProto) — messages, chats, media, contacts",
   "version": "4.9.0",
+  "userConfig": {
+    "TELEGRAM_BOT_TOKEN": {
+      "type": "string",
+      "title": "Bot token (bot mode)",
+      "description": "From @BotFather. Required for stdio bot mode. Leave empty for user mode (HTTP only).",
+      "sensitive": true,
+      "required": false
+    }
+  },
   "author": {
     "name": "n24q02m",
     "url": "https://github.com/n24q02m"
@@ -10,8 +19,15 @@
   "mcpServers": {
     "better-telegram-mcp": {
       "command": "uvx",
-      "args": ["--python", "3.13", "better-telegram-mcp@latest"],
-      "env": { "MCP_TRANSPORT": "stdio" }
+      "args": [
+        "--python",
+        "3.13",
+        "better-telegram-mcp@latest"
+      ],
+      "env": {
+        "MCP_TRANSPORT": "stdio",
+        "TELEGRAM_BOT_TOKEN": "${user_config.TELEGRAM_BOT_TOKEN}"
+      }
     }
   }
 }

--- a/docs/setup-manual.md
+++ b/docs/setup-manual.md
@@ -27,25 +27,34 @@ All MCP servers across this stack share this priority hierarchy. Note: 2 plugins
 
 For Claude Code users, the plugin approach is the simplest. **Bot mode only** -- user mode requires HTTP (see Method 3).
 
+### Step 0: Credential prompt
+
+When you run `/plugin install better-telegram-mcp@n24q02m-plugins`, Claude Code prompts for the field declared in `plugin.json` `userConfig`:
+
+| Field | Required | Sensitive | Notes |
+|:------|:---------|:----------|:------|
+| `TELEGRAM_BOT_TOKEN` | No (leave empty for user mode via Method 3) | Yes | From [@BotFather](https://t.me/BotFather). Format: `123456789:ABCdefGHI-...` |
+
+Sensitive values are stored in the system keychain (or `~/.claude/.credentials.json` fallback) and persist across `/plugin update`. Claude Code substitutes the value into `mcpServers.better-telegram-mcp.env.TELEGRAM_BOT_TOKEN` via `${user_config.TELEGRAM_BOT_TOKEN}` -- you do not edit `env` manually.
+
+> Leaving the field empty disables stdio bot mode; you must use Method 3 HTTP for user mode (phone+OTP) anyway. The `TELEGRAM_PHONE` value used in user mode is collected in the HTTP `/authorize` form, not via `userConfig`.
+
+### Steps
+
 1. Get a bot token from [@BotFather](https://t.me/BotFather):
    - Open Telegram, send `/newbot` to @BotFather
    - Follow prompts to name your bot
    - Copy the token (format: `123456789:ABCdefGHI-JKLmnoPQRstUVwxyz`)
 
-2. Open Claude Code and install the plugin:
+2. Open Claude Code and install the plugin (Claude Code prompts for `TELEGRAM_BOT_TOKEN`):
    ```bash
    /plugin marketplace add n24q02m/claude-plugins
    /plugin install better-telegram-mcp@n24q02m-plugins
    ```
 
-3. Configure `TELEGRAM_BOT_TOKEN` in the plugin settings (Claude Code prompts on first use), or set the env var system-wide:
-   ```bash
-   export TELEGRAM_BOT_TOKEN="123456789:ABCdef..."
-   ```
+3. Restart Claude Code -- the server starts in stdio bot mode with the token injected.
 
-4. Restart Claude Code -- the server starts in stdio bot mode.
-
-> **Need user mode (read messages, browse chats, manage groups)?** Bot tokens cannot do this. Skip to Method 3 (HTTP) -- user mode runs over HTTP only.
+> **Need user mode (read messages, browse chats, manage groups)?** Bot tokens cannot do this. Skip to Method 3 (HTTP) -- user mode runs over HTTP only and does not use the `userConfig` prompt.
 
 ## Method 2: Docker stdio (fallback)
 

--- a/docs/setup-with-agent.md
+++ b/docs/setup-with-agent.md
@@ -20,13 +20,25 @@ All MCP servers across this stack share this priority hierarchy. Note: 2 plugins
 
 ## Option 1: Claude Code Plugin (Recommended, stdio Bot Mode Only)
 
+### Step 0: Credential prompt
+
+When the install command runs, Claude Code prompts for the field declared in `plugin.json` `userConfig`:
+
+| Field | Required | Sensitive | Source |
+|:------|:---------|:----------|:-------|
+| `TELEGRAM_BOT_TOKEN` | No (skip for user mode via Option 3) | Yes | [@BotFather](https://t.me/BotFather) |
+
+The plugin manifest substitutes the value into `mcpServers.better-telegram-mcp.env.TELEGRAM_BOT_TOKEN` via `${user_config.TELEGRAM_BOT_TOKEN}`. Sensitive values stay in the system keychain and persist across `/plugin update` -- you do not edit `env` manually.
+
+### Steps
+
 ```bash
 # Install from marketplace (includes skills: /setup-bot, /channel-post)
 /plugin marketplace add n24q02m/claude-plugins
 /plugin install better-telegram-mcp@n24q02m-plugins
 ```
 
-Set `TELEGRAM_BOT_TOKEN` from [@BotFather](https://t.me/BotFather) in plugin settings or as a system env var. **Bot mode only** -- user mode (read messages, browse chats) requires HTTP (Option 3).
+Paste your bot token when prompted. **Bot mode only** -- user mode (read messages, browse chats) requires HTTP (Option 3) and uses a separate auth flow (phone+OTP via web form, not `userConfig`).
 
 ## Option 2: Docker stdio (fallback)
 


### PR DESCRIPTION
## Summary

- Add `userConfig.TELEGRAM_BOT_TOKEN` (sensitive, optional) so `/plugin install` prompts for the bot token at install time. Optional because user-mode flows run over HTTP only and collect `TELEGRAM_PHONE` through the `/authorize` web form, not the install prompt.
- Substitute via `${user_config.TELEGRAM_BOT_TOKEN}` into `mcpServers.better-telegram-mcp.env`.
- Update `setup-manual.md` and `setup-with-agent.md` Method 1 with Step 0 prompt section.

## Test plan
- [ ] CI green
- [ ] Bot mode works after `/plugin install` with token prompt
- [ ] User mode (Method 3 HTTP) unaffected by userConfig

Generated with [Claude Code](https://claude.com/claude-code)