### PR TITLE
🎨 Palette: Improve accessibility by focusing invalid inputs on validation failure

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-06-25 - Improve ARIA associations in credential forms
 **Learning:** For dynamic/conditionally-visible elements like status boxes or inline errors (e.g. `status-box`, `step-error`), it is completely safe and highly recommended to associate them proactively via `aria-describedby` directly on the `<input>` fields, even if the error blocks are initially empty or styled as `display: none`. Furthermore, strictly decorative strings like "Required" visual badges adjacent to natively `<input required>` fields should have `aria-hidden="true"` applied to avoid screen readers announcing "Required required" redundantly.
 **Action:** Always verify if a native `required` attribute exists on inputs before adding visual "Required" text. If it does, ensure the visual text is masked with `aria-hidden="true"`. Pre-wire inputs to their respective alert/status `div` elements with `aria-describedby` during HTML templating.
+## 2024-05-30 - Focus First Invalid Input on Form Submit
+**Learning:** Automatically focusing the first invalid input on form submission or step verification significantly improves keyboard navigation, saving screen reader and keyboard users from manually tabbing back through the form to find the error.
+**Action:** When adding client-side form validation, always track the first field that fails validation and call `.focus()` on it before returning.

--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -585,6 +585,7 @@ def render_telegram_credential_form(
                     errorEl.textContent = "Please enter a value.";
                     errorEl.style.display = "block";
                     inputEl.setAttribute("aria-invalid", "true");
+                    inputEl.focus();
                     return;
                 }}
                 errorEl.style.display = "none";
@@ -659,11 +660,15 @@ def render_telegram_credential_form(
                 var inputs = activePanel ? activePanel.querySelectorAll('.field-input') : [];
                 var payload = {{}};
                 var valid = true;
+                var firstInvalidInput = null;
 
                 inputs.forEach(function (input) {{
                     if (input.value.trim() === "") {{
                         valid = false;
                         input.setAttribute("aria-invalid", "true");
+                        if (!firstInvalidInput) {{
+                            firstInvalidInput = input;
+                        }}
                     }} else {{
                         input.removeAttribute("aria-invalid");
                         payload[input.name] = input.value;
@@ -672,6 +677,9 @@ def render_telegram_credential_form(
 
                 if (!valid) {{
                     showStatus("error", "Please fill in the required field.");
+                    if (firstInvalidInput) {{
+                        firstInvalidInput.focus();
+                    }}
                     return;
                 }}
 


### PR DESCRIPTION
💡 **What:** Added logic to the client-side JavaScript in `credential_form.py` to automatically focus the `inputEl` or the `firstInvalidInput` when a required field is missing upon form submission or step verification.
🎯 **Why:** To prevent keyboard and screen reader users from losing context or having to manually navigate back up the form to find the empty required field after an error occurs. 
📸 **Before/After:** Automatically shifts focus instead of just showing a red error message. (Verified via Playwright script).
♿ **Accessibility:** Reduces cognitive load and unnecessary tab navigation for keyboard-only users and provides immediate context to screen readers about which field requires attention.

---
*PR created automatically by Jules for task [11433331641599510366](https://jules.google.com/task/11433331641599510366) started by @n24q02m*