### PR TITLE
feat: align userConfig with relay_schema fields

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -9,6 +9,13 @@
       "description": "From @BotFather. Required for stdio bot mode. Leave empty for user mode (HTTP only).",
       "sensitive": true,
       "required": false
+    },
+    "TELEGRAM_PHONE": {
+      "type": "string",
+      "title": "Phone number (user mode, HTTP only)",
+      "description": "International format (e.g. +84xxxxxxxxx). Used by user mode HTTP flow only - not stdio bot mode.",
+      "sensitive": true,
+      "required": false
     }
   },
   "author": {
@@ -26,7 +33,8 @@
       ],
       "env": {
         "MCP_TRANSPORT": "stdio",
-        "TELEGRAM_BOT_TOKEN": "${user_config.TELEGRAM_BOT_TOKEN}"
+        "TELEGRAM_BOT_TOKEN": "${user_config.TELEGRAM_BOT_TOKEN}",
+        "TELEGRAM_PHONE": "${user_config.TELEGRAM_PHONE}"
       }
     }
   }


### PR DESCRIPTION
## Summary
- Add TELEGRAM_PHONE to .claude-plugin/plugin.json userConfig + mcpServers env.
- relay_schema declares both TELEGRAM_BOT_TOKEN + TELEGRAM_PHONE; plugin.json had only the bot token. Now 1:1 parity.

## Test plan
- [x] pre-commit hooks pass
- [ ] CI green