### PR TITLE
fix: remove TELEGRAM_PHONE from userConfig (stdio = bot mode only)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -9,13 +9,6 @@
       "description": "From @BotFather. Required for stdio bot mode. Leave empty for user mode (HTTP only).",
       "sensitive": true,
       "required": false
-    },
-    "TELEGRAM_PHONE": {
-      "type": "string",
-      "title": "Phone number (user mode, HTTP only)",
-      "description": "International format (e.g. +84xxxxxxxxx). Used by user mode HTTP flow only - not stdio bot mode.",
-      "sensitive": true,
-      "required": false
     }
   },
   "author": {
@@ -33,8 +26,7 @@
       ],
       "env": {
         "MCP_TRANSPORT": "stdio",
-        "TELEGRAM_BOT_TOKEN": "${user_config.TELEGRAM_BOT_TOKEN}",
-        "TELEGRAM_PHONE": "${user_config.TELEGRAM_PHONE}"
+        "TELEGRAM_BOT_TOKEN": "${user_config.TELEGRAM_BOT_TOKEN}"
       }
     }
   }


### PR DESCRIPTION
## Summary
- Removes `TELEGRAM_PHONE` from `userConfig` in `.claude-plugin/plugin.json`.
- Removes the `TELEGRAM_PHONE` env substitution from `mcpServers.better-telegram-mcp.env`.
- Spec V9 requires stdio = bot mode only. `userConfig` feeds the plugin's stdio `mcpServers.env`, so including `TELEGRAM_PHONE` was wrong scope -- phone is only used by the HTTP user-mode relay form at `/authorize`, never by stdio.

## Test plan
- [x] `plugin.json` JSON valid
- [x] pre-commit passes (gitleaks, JSON checks, diacritics)
- [ ] CI green
- [ ] After merge: `claude-plugins` sync regenerates downstream `plugins/better-telegram-mcp/.claude-plugin/plugin.json` with same change

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>