### PR TITLE
🎨 Palette: Auto-focus invalid fields on validation failure

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-06-25 - Improve ARIA associations in credential forms
 **Learning:** For dynamic/conditionally-visible elements like status boxes or inline errors (e.g. `status-box`, `step-error`), it is completely safe and highly recommended to associate them proactively via `aria-describedby` directly on the `<input>` fields, even if the error blocks are initially empty or styled as `display: none`. Furthermore, strictly decorative strings like "Required" visual badges adjacent to natively `<input required>` fields should have `aria-hidden="true"` applied to avoid screen readers announcing "Required required" redundantly.
 **Action:** Always verify if a native `required` attribute exists on inputs before adding visual "Required" text. If it does, ensure the visual text is masked with `aria-hidden="true"`. Pre-wire inputs to their respective alert/status `div` elements with `aria-describedby` during HTML templating.
+## 2024-05-05 - Focus First Invalid Input on Form Validation Failure
+**Learning:** Bringing focus to the first invalid input when client-side form validation fails is a low-effort, high-impact a11y/UX pattern that works natively without relying solely on screen reader ARIA live regions to announce errors.
+**Action:** Always add `.focus()` calls when interrupting form submissions with JS validation logic.

--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -585,6 +585,7 @@ def render_telegram_credential_form(
                     errorEl.textContent = "Please enter a value.";
                     errorEl.style.display = "block";
                     inputEl.setAttribute("aria-invalid", "true");
+                    inputEl.focus();
                     return;
                 }}
                 errorEl.style.display = "none";
@@ -659,11 +660,15 @@ def render_telegram_credential_form(
                 var inputs = activePanel ? activePanel.querySelectorAll('.field-input') : [];
                 var payload = {{}};
                 var valid = true;
+                var firstInvalidInput = null;
 
                 inputs.forEach(function (input) {{
                     if (input.value.trim() === "") {{
                         valid = false;
                         input.setAttribute("aria-invalid", "true");
+                        if (!firstInvalidInput) {{
+                            firstInvalidInput = input;
+                        }}
                     }} else {{
                         input.removeAttribute("aria-invalid");
                         payload[input.name] = input.value;
@@ -672,6 +677,9 @@ def render_telegram_credential_form(
 
                 if (!valid) {{
                     showStatus("error", "Please fill in the required field.");
+                    if (firstInvalidInput) {{
+                        firstInvalidInput.focus();
+                    }}
                     return;
                 }}
 


### PR DESCRIPTION
💡 What: Automatically sets `.focus()` on the first invalid form input when client-side validation prevents submission. This logic applies to both the main credential form tabs and the multi-step (OTP) verification input.

🎯 Why: To reduce friction for keyboard and screen reader users. When a form submission fails due to an empty required field, bringing focus directly to the invalid field saves the user from having to manually find and navigate to the error.

♿ Accessibility: Enhances a11y by ensuring the keyboard navigation sequence is logically managed during error states.

---
*PR created automatically by Jules for task [6711402413515685346](https://jules.google.com/task/6711402413515685346) started by @n24q02m*