### PR TITLE
🎨 Palette: [UX improvement] Add visual disabled states and form locking during submission

### DIFF
--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -254,6 +254,12 @@ def render_telegram_credential_form(
             color: #555;
         }}
 
+        .field-input:disabled {{
+            opacity: 0.5;
+            cursor: not-allowed;
+            background-color: #0a0a0a;
+        }}
+
         .help-text {{
             font-size: 0.8125rem;
             color: #666;
@@ -687,6 +693,8 @@ def render_telegram_credential_form(
                 submitBtn.setAttribute("aria-busy", "true");
                 submitBtn.textContent = "Connecting...";
                 statusBox.style.display = "none";
+                form.querySelectorAll(".field-input").forEach(function (i) {{ i.disabled = true; }});
+                tabs.forEach(function (t) {{ t.disabled = true; }});
 
                 fetch(submitUrl, {{
                     method: "POST",
@@ -736,6 +744,8 @@ def render_telegram_credential_form(
                                 submitBtn.disabled = false;
                                 submitBtn.removeAttribute("aria-busy");
                                 submitBtn.textContent = "Connect";
+                                form.querySelectorAll(".field-input").forEach(function (i) {{ i.disabled = false; }});
+                                tabs.forEach(function (t) {{ t.disabled = false; }});
                             }}
                         }});
                     }})
@@ -744,6 +754,8 @@ def render_telegram_credential_form(
                         submitBtn.disabled = false;
                         submitBtn.removeAttribute("aria-busy");
                         submitBtn.textContent = "Connect";
+                        form.querySelectorAll(".field-input").forEach(function (i) {{ i.disabled = false; }});
+                        tabs.forEach(function (t) {{ t.disabled = false; }});
                     }});
             }});
         }})();


### PR DESCRIPTION
💡 What: The UX enhancement disables the form's interactive elements (inputs and tabs) when the connect action is in-flight. It also adds a new CSS rule to lower the opacity of disabled inputs and display a not-allowed cursor.

🎯 Why: To prevent users from modifying their inputs or double-submitting the form while waiting for the network response, providing clear feedback that the system is processing their request.

📸 Before/After: Captured during frontend verification.

♿ Accessibility: Prevents conflicting state changes and visually communicates that fields are temporarily read-only during async events.

---
*PR created automatically by Jules for task [7072990153340148830](https://jules.google.com/task/7072990153340148830) started by @n24q02m*