### PR TITLE
[PERF] Suboptimal data structure choice: List/Tuple instead of Set for membership test

### DIFF
--- a/src/better_telegram_mcp/tools/help_tool.py
+++ b/src/better_telegram_mcp/tools/help_tool.py
@@ -12,7 +12,7 @@ _DOC_CACHE: dict[str, str] = {}
 
 
 async def handle_help(topic: str | None = None) -> str:
-    if topic is None or topic in ("all", "telegram"):
+    if topic is None or topic in {"all", "telegram"}:
         # Bolt: Load all documentation files concurrently to reduce I/O wait time
         tasks = [_load_doc(t) for t in sorted(_VALID_TOPICS)]
         results = await asyncio.gather(*tasks)


### PR DESCRIPTION
Changing list/tuple to set for membership checking is a low-risk, one-character fix that guarantees O(1) performance instead of O(N).

What: Changed `topic in ("all", "telegram")` to `topic in {"all", "telegram"}` in `handle_help`.
Why: Set membership tests are faster (O(1)) than tuple/list (O(N)).
Impact: Improved performance of help tool topic validation.
Measurement: Constant time lookup for the 'all' and 'telegram' topics.

---
*PR created automatically by Jules for task [17214094622615953281](https://jules.google.com/task/17214094622615953281) started by @n24q02m*