### PR TITLE
[TEST] Missing test file for resources.py

### DIFF
--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,58 +1,75 @@
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 
-from better_telegram_mcp.server import mcp
+from better_telegram_mcp.resources import register_resources
 
 
-def test_resources_registered():
-    resources = mcp._resource_manager._resources
-    expected_uris = {
+@pytest.fixture
+def mock_mcp():
+    mcp = MagicMock()
+    # Mock the decorator behavior: @mcp.resource(uri) returns a decorator that returns the function
+    mcp.resource.side_effect = lambda uri: lambda fn: fn
+    return mcp
+
+
+def test_register_resources_calls_decorator(mock_mcp):
+    """Test that register_resources registers all expected URIs."""
+    register_resources(mock_mcp)
+
+    expected_uris = [
         "telegram://docs/messages",
         "telegram://docs/chats",
         "telegram://docs/media",
         "telegram://docs/contacts",
         "telegram://stats",
-    }
-    assert {str(uri) for uri in resources.keys()} == expected_uris
+    ]
+
+    # Get all URIs passed to mcp.resource
+    registered_uris = [call.args[0] for call in mock_mcp.resource.call_args_list]
+
+    for uri in expected_uris:
+        assert uri in registered_uris
 
 
 @pytest.mark.asyncio
-async def test_docs_messages_resource():
-    resources = mcp._resource_manager._resources
-    fn = resources["telegram://docs/messages"]
-    result = await fn.fn()
-    assert "Telegram Messages" in result
+async def test_resource_functions_call_help_tool(mock_mcp):
+    """Test that each registered resource function calls handle_help with the right topic."""
+    # We need to capture the functions being registered
+    registrations = {}
 
+    def mock_resource(uri):
+        def decorator(fn):
+            registrations[uri] = fn
+            return fn
 
-@pytest.mark.asyncio
-async def test_docs_chats_resource():
-    resources = mcp._resource_manager._resources
-    fn = resources["telegram://docs/chats"]
-    result = await fn.fn()
-    assert "Telegram Chats" in result
+        return decorator
 
+    mock_mcp.resource.side_effect = mock_resource
 
-@pytest.mark.asyncio
-async def test_docs_media_resource():
-    resources = mcp._resource_manager._resources
-    fn = resources["telegram://docs/media"]
-    result = await fn.fn()
-    assert "Telegram Media" in result
+    register_resources(mock_mcp)
 
+    # Patch handle_help where it's defined because it's imported locally inside the functions
+    with patch(
+        "better_telegram_mcp.tools.help_tool.handle_help", new_callable=AsyncMock
+    ) as mock_handle:
+        mock_handle.return_value = "Mocked Help Content"
 
-@pytest.mark.asyncio
-async def test_docs_contacts_resource():
-    resources = mcp._resource_manager._resources
-    fn = resources["telegram://docs/contacts"]
-    result = await fn.fn()
-    assert "Telegram Contacts" in result
+        # Test each registration
+        test_cases = [
+            ("telegram://docs/messages", "messages"),
+            ("telegram://docs/chats", "chats"),
+            ("telegram://docs/media", "media"),
+            ("telegram://docs/contacts", "contacts"),
+            ("telegram://stats", "all"),
+        ]
 
+        for uri, expected_topic in test_cases:
+            mock_handle.reset_mock()
+            fn = registrations[uri]
+            result = await fn()
 
-@pytest.mark.asyncio
-async def test_stats_resource():
-    resources = mcp._resource_manager._resources
-    fn = resources["telegram://stats"]
-    result = await fn.fn()
-    assert "Telegram Messages" in result
-    assert "Telegram Chats" in result
+            assert result == "Mocked Help Content"
+            mock_handle.assert_called_once_with(expected_topic)


### PR DESCRIPTION
Rewrote `tests/test_resources.py` as a pure unit test. It now mocks `FastMCP` and tests `register_resources` in isolation, verifying that all resource URIs are correctly registered and that the resource functions call `handle_help` with the appropriate topics. This improves test reliability by removing dependencies on the global `mcp` instance and the `mcp-core` library which might not be available in all environments.

---
*PR created automatically by Jules for task [9137921496797035459](https://jules.google.com/task/9137921496797035459) started by @n24q02m*