### PR TITLE
[TEST] Missing test file for help_tool.py

### DIFF
--- a/tests/test_tools/test_help_tool.py
+++ b/tests/test_tools/test_help_tool.py
@@ -110,3 +110,17 @@ async def test_help_all_no_docs(monkeypatch):
     result = await handle_help("all")
     parsed = json.loads(result)
     assert "error" in parsed
+
+
+@pytest.mark.asyncio
+async def test_help_cache_hit():
+    """Verify that _load_doc returns content from _DOC_CACHE if available."""
+    import better_telegram_mcp.tools.help_tool
+
+    # Manually populate cache with a sentinel value
+    topic = "messages"
+    sentinel = "CACHED_CONTENT_SENTINEL"
+    better_telegram_mcp.tools.help_tool._DOC_CACHE[topic] = sentinel
+
+    result = await handle_help(topic)
+    assert result == sentinel


### PR DESCRIPTION
Added a new test case `test_help_cache_hit` to `tests/test_tools/test_help_tool.py` to achieve 100% test coverage for `src/better_telegram_mcp/tools/help_tool.py`. The new test verifies that the documentation loader correctly returns cached content when available.

Verification steps:
1. Created a temporary mock environment for `mcp-core` and `relay` dependencies.
2. Ran `pytest --cov=better_telegram_mcp.tools.help_tool tests/test_tools/`.
3. Confirmed 100% coverage for `help_tool.py` and that all 90 tests in the directory pass.
4. Cleaned up temporary mock artifacts.
5. Ran `ruff` for linting and formatting checks.

---
*PR created automatically by Jules for task [8164118553013712651](https://jules.google.com/task/8164118553013712651) started by @n24q02m*