### PR TITLE
[TEST] Missing test cases for config_tool.py

### DIFF
--- a/tests/test_tools/test_config_tool.py
+++ b/tests/test_tools/test_config_tool.py
@@ -118,3 +118,19 @@ async def test_general_exception(mock_backend):
 # Auth/send_code actions removed — auth handled by mcp-core's local OAuth
 # AS in HTTP mode (browser paste form + OTP /otp endpoint), not by the
 # config tool.
+
+
+@pytest.mark.asyncio
+async def test_unknown_action_suggestion(mock_backend):
+    result = json.loads(await handle_config(mock_backend, "statu"))
+    assert "error" in result
+    assert "Did you mean 'status'?" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_set_invalid_int(mock_backend):
+    result = json.loads(
+        await handle_config(mock_backend, "set", message_limit="invalid")
+    )
+    assert "error" in result
+    assert "ValueError" in result["error"]


### PR DESCRIPTION
The task was to analyze and fix missing test coverage for `config_tool.py`. Upon inspection, a test file `tests/test_tools/test_config_tool.py` already existed but it was missing coverage for some specific branches, such as the `difflib` suggestion for unknown actions and `ValueError` handling for invalid integer inputs in the `set` action.

I have:
1.  Analyzed the existing test file and `config_tool.py` logic.
2.  Added `test_unknown_action_suggestion` and `test_set_invalid_int` to the test file.
3.  Verified the logic using a standalone script that mocks the missing environment dependencies (like `mcp-core`).
4.  Ensured the code follows the project's formatting and linting standards.

---
*PR created automatically by Jules for task [15396773299373948948](https://jules.google.com/task/15396773299373948948) started by @n24q02m*