### PR TITLE
[TEST] Missing test file for messages.py

### DIFF
--- a/tests/test_tools/test_messages.py
+++ b/tests/test_tools/test_messages.py
@@ -5,8 +5,7 @@ import json
 import pytest
 
 from better_telegram_mcp.backends.base import ModeError
-from better_telegram_mcp.server import MessagesArgs
-from better_telegram_mcp.tools.messages import handle_messages
+from better_telegram_mcp.tools.messages import MessagesArgs, handle_messages
 
 
 @pytest.mark.asyncio
@@ -237,3 +236,15 @@ async def test_general_exception(mock_backend):
     )
     assert "error" in result
     assert "RuntimeError" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_unknown_action_suggestion(mock_backend):
+    # 'sendd' should suggest 'send'
+    result = json.loads(
+        await handle_messages(mock_backend, MessagesArgs(action="sendd"))
+    )
+    assert "error" in result
+    assert "Unknown action 'sendd'." in result["error"]
+    assert "Did you mean 'send'?" in result["error"]
+    assert "Valid: delete|edit|forward|history|pin|react|search|send" in result["error"]


### PR DESCRIPTION
This PR fixes the test collection issue for `messages.py` by removing a transitive dependency on `mcp-core` (via `server.py`). It also adds a new test case to exercise the `difflib` suggestion logic when an unknown action is provided.

Summary of changes:
- Updated `tests/test_tools/test_messages.py` to import `MessagesArgs` directly from `better_telegram_mcp.tools.messages`.
- Added `test_unknown_action_suggestion` to verify that helpful suggestions are provided for near-miss action names (e.g., "sendd" -> "send").
- Verified 100% line coverage for `src/better_telegram_mcp/tools/messages.py`.

---
*PR created automatically by Jules for task [15627548232259508678](https://jules.google.com/task/15627548232259508678) started by @n24q02m*