### PR TITLE
[PERF] Suboptimal data structure choice: List/Tuple instead of Set for membership test

### DIFF
--- a/src/better_telegram_mcp/backends/security.py
+++ b/src/better_telegram_mcp/backends/security.py
@@ -13,7 +13,7 @@ class SecurityError(Exception):
 
 
 # Private/internal IP ranges that should not be accessed via SSRF
-_BLOCKED_NETWORKS = [
+_BLOCKED_NETWORKS = (
     ipaddress.ip_network("0.0.0.0/8"),
     ipaddress.ip_network("127.0.0.0/8"),
     ipaddress.ip_network("10.0.0.0/8"),
@@ -24,7 +24,7 @@ _BLOCKED_NETWORKS = [
     ipaddress.ip_network("::ffff:0:0/96"),
     ipaddress.ip_network("fc00::/7"),
     ipaddress.ip_network("fe80::/10"),
-]
+)
 
 
 def validate_url(url: str) -> None:

--- a/src/better_telegram_mcp/tools/help_tool.py
+++ b/src/better_telegram_mcp/tools/help_tool.py
@@ -12,7 +12,7 @@ _DOC_CACHE: dict[str, str] = {}
 
 
 async def handle_help(topic: str | None = None) -> str:
-    if topic is None or topic in ("all", "telegram"):
+    if topic is None or topic in {"all", "telegram"}:
         # Bolt: Load all documentation files concurrently to reduce I/O wait time
         tasks = [_load_doc(t) for t in sorted(_VALID_TOPICS)]
         results = await asyncio.gather(*tasks)


### PR DESCRIPTION
Changed the membership check in `src/better_telegram_mcp/tools/help_tool.py` from a tuple to a set literal for O(1) performance. Additionally, converted `_BLOCKED_NETWORKS` in `src/better_telegram_mcp/backends/security.py` from a list to a tuple for better immutability and memory efficiency for a global constant. verified with `ruff` and targeted functional tests.

---
*PR created automatically by Jules for task [2397422234185978850](https://jules.google.com/task/2397422234185978850) started by @n24q02m*