### PR TITLE
[TEST] Missing test file for credential_form.py

### DIFF
--- a/tests/test_credential_form.py
+++ b/tests/test_credential_form.py
@@ -189,3 +189,23 @@ def test_phone_prefill_marks_phone_required_only() -> None:
     bot_input = html.split('name="TELEGRAM_BOT_TOKEN"')[1].split("/>")[0]
     assert "required" in phone_input
     assert "required" not in bot_input
+
+
+def test_bot_mode_marks_bot_token_required_only() -> None:
+    """Bot mode (default): only bot token input has ``required`` attr."""
+    html = render_telegram_credential_form(SCHEMA, "/auth")
+    phone_input = html.split('name="TELEGRAM_PHONE"')[1].split("/>")[0]
+    bot_input = html.split('name="TELEGRAM_BOT_TOKEN"')[1].split("/>")[0]
+    assert "required" in bot_input
+    assert "required" not in phone_input
+
+
+def test_bot_token_only_prefill_marks_bot_token_required_only() -> None:
+    """Bot mode with prefill: only bot token input has ``required`` attr."""
+    html = render_telegram_credential_form(
+        SCHEMA, "/auth", prefill={"TELEGRAM_BOT_TOKEN": "abc"}
+    )
+    phone_input = html.split('name="TELEGRAM_PHONE"')[1].split("/>")[0]
+    bot_input = html.split('name="TELEGRAM_BOT_TOKEN"')[1].split("/>")[0]
+    assert "required" in bot_input
+    assert "required" not in phone_input


### PR DESCRIPTION
The task was to address a missing test file for credential_form.py. Upon investigation, I found that tests/test_credential_form.py already existed with 21 tests. I verified these tests, performed visual and behavioral verification of the HTML/JS using Playwright, and enhanced the test suite with 2 additional tests for the 'required' attribute state in Bot mode. The final test suite contains 23 tests, all passing.

---
*PR created automatically by Jules for task [800422528688856760](https://jules.google.com/task/800422528688856760) started by @n24q02m*