### PR TITLE
[FIX] Glama display name

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,7 +148,3 @@ Conventional Commits: `type(scope): message`. Automated semantic release.
 - **Mega-tool pattern**: 6 tools x N actions = full API coverage with minimal tool registration overhead
 - **Session persistence**: `~/.better-telegram-mcp/<name>.session` for Telethon (MTProto)
 - **Auth flow**: OTP sent to Telegram app -> terminal input or `config(action='auth', code='...')` for headless
-
-## TODO / Backlog
-
-- [ ] **Glama display name**: Cannot set programmatically. Update manually via Glama admin page.

--- a/server.json
+++ b/server.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.n24q02m/better-telegram-mcp",
+  "title": "Better Telegram MCP",
   "description": "Telegram MCP server — dual-mode Bot API + MTProto, 6 composite tools.",
   "repository": {
     "url": "https://github.com/n24q02m/better-telegram-mcp.git",


### PR DESCRIPTION
Following the MCP 2025-12-11 specification, I added the `title` field to `server.json` to allow platforms like Glama to discover the display name programmatically. This removes the need for manual intervention on the Glama admin page, so the corresponding TODO in `AGENTS.md` has been removed.

---
*PR created automatically by Jules for task [464928640721667292](https://jules.google.com/task/464928640721667292) started by @n24q02m*