### PR TITLE
[FIX] N+1 Query Issue in `get_members`

### DIFF
--- a/src/better_telegram_mcp/backends/user_backend.py
+++ b/src/better_telegram_mcp/backends/user_backend.py
@@ -335,10 +335,8 @@ class UserBackend(TelegramBackend):
         self, chat_id: str | int, *, limit: int = 50
     ) -> list[dict[str, Any]]:
         client = self._ensure_client()
-        return [
-            self._serialize_user(user)
-            async for user in client.iter_participants(chat_id, limit=limit)
-        ]
+        users = await client.get_participants(chat_id, limit=limit)
+        return [self._serialize_user(user) for user in users]
 
     async def promote_admin(
         self, chat_id: str | int, user_id: int, *, demote: bool = False

--- a/tests/test_backends/test_user_backend.py
+++ b/tests/test_backends/test_user_backend.py
@@ -643,11 +643,7 @@ class TestGetMembers:
 
         users = [_mock_user(user_id=i) for i in range(3)]
 
-        async def mock_iter(*args, **kwargs):
-            for u in users:
-                yield u
-
-        mock_client.iter_participants = mock_iter
+        mock_client.get_participants = AsyncMock(return_value=users)
 
         settings = _make_settings(tmp_path)
         backend = UserBackend(settings)
@@ -655,6 +651,7 @@ class TestGetMembers:
 
         result = await backend.get_members(123, limit=10)
 
+        mock_client.get_participants.assert_awaited_once_with(123, limit=10)
         assert len(result) == 3
         assert result[0]["first_name"] == "Test"
 


### PR DESCRIPTION
This PR addresses the N+1 query issue in the `get_members` method of `UserBackend`.
The implementation was changed from using `client.iter_participants` (which can lead to sequential network requests when processed via async comprehension) to `client.get_participants`, which fetches members in bulk.
This reduces network latency and improves performance when retrieving chat members.
Tests were updated to verify the new bulk fetching implementation.

---
*PR created automatically by Jules for task [9848680140975631391](https://jules.google.com/task/9848680140975631391) started by @n24q02m*