### PR TITLE
[FIX] N+1 Query Issue in search_messages

### DIFF
--- a/src/better_telegram_mcp/backends/user_backend.py
+++ b/src/better_telegram_mcp/backends/user_backend.py
@@ -237,10 +237,8 @@ class UserBackend(TelegramBackend):
     ) -> list[dict[str, Any]]:
         client = self._ensure_client()
         entity = chat_id if chat_id is not None else None
-        return [
-            self._serialize_message(msg)
-            async for msg in client.iter_messages(entity, search=query, limit=limit)
-        ]
+        messages = await client.get_messages(entity, search=query, limit=limit)
+        return [self._serialize_message(msg) for msg in messages]
 
     async def get_history(
         self,

--- a/tests/test_backends/test_user_backend.py
+++ b/tests/test_backends/test_user_backend.py
@@ -322,6 +322,7 @@ class TestSearchMessages:
                 yield m
 
         mock_client.iter_messages = mock_iter
+        mock_client.get_messages = AsyncMock(return_value=msgs)
 
         settings = _make_settings(tmp_path)
         backend = UserBackend(settings)
@@ -342,6 +343,7 @@ class TestSearchMessages:
                 yield m
 
         mock_client.iter_messages = mock_iter
+        mock_client.get_messages = AsyncMock(return_value=msgs)
 
         settings = _make_settings(tmp_path)
         backend = UserBackend(settings)


### PR DESCRIPTION
Replaces client.iter_messages with client.get_messages in search_messages to perform native bulk fetching. This improves throughput by avoiding sequential blocking on each iteration of the async generator for small result sets. Backend unit tests have been updated to mock get_messages for search-related test cases.

---
*PR created automatically by Jules for task [4122803277254840011](https://jules.google.com/task/4122803277254840011) started by @n24q02m*