### PR TITLE
[TEST] Missing test file for credential_state.py

### DIFF
--- a/src/better_telegram_mcp/credential_state.py
+++ b/src/better_telegram_mcp/credential_state.py
@@ -89,11 +89,11 @@ def get_state() -> CredentialState:
 def get_setup_url() -> str | None:
     return _setup_url
 
+
 def set_setup_url(url: str | None) -> None:
     """For testing and setup tool actions."""
     global _setup_url
     _setup_url = url
-
 
 
 def resolve_credential_state() -> CredentialState:

--- a/src/better_telegram_mcp/credential_state.py
+++ b/src/better_telegram_mcp/credential_state.py
@@ -89,6 +89,12 @@ def get_state() -> CredentialState:
 def get_setup_url() -> str | None:
     return _setup_url
 
+def set_setup_url(url: str | None) -> None:
+    """For testing and setup tool actions."""
+    global _setup_url
+    _setup_url = url
+
+
 
 def resolve_credential_state() -> CredentialState:
     """Fast, synchronous credential check. Called during lifespan startup.

--- a/tests/test_credential_state.py
+++ b/tests/test_credential_state.py
@@ -13,6 +13,7 @@ from better_telegram_mcp.credential_state import (
     get_state,
     reset_state,
     resolve_credential_state,
+    set_setup_url,
     set_state,
 )
 
@@ -73,6 +74,28 @@ def test_set_state():
 def test_set_state_setup_in_progress():
     set_state(CredentialState.SETUP_IN_PROGRESS)
     assert get_state() == CredentialState.SETUP_IN_PROGRESS
+
+
+def test_set_setup_url():
+    set_setup_url("http://localhost/setup")
+    assert get_setup_url() == "http://localhost/setup"
+
+
+def test_current_sub_contextvar():
+    """Verify _current_sub contextvar isolation."""
+    import asyncio
+    from better_telegram_mcp.credential_state import _current_sub
+
+    async def check_sub(val):
+        _current_sub.set(val)
+        await asyncio.sleep(0.01)
+        return _current_sub.get()
+
+    async def run_test():
+        results = await asyncio.gather(check_sub("sub1"), check_sub("sub2"))
+        assert results == ["sub1", "sub2"]
+
+    asyncio.run(run_test())
 
 
 def test_reset_state():

--- a/tests/test_credential_state.py
+++ b/tests/test_credential_state.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -9,6 +10,7 @@ import pytest
 
 from better_telegram_mcp.credential_state import (
     CredentialState,
+    _current_sub,
     get_setup_url,
     get_state,
     reset_state,
@@ -83,8 +85,6 @@ def test_set_setup_url():
 
 def test_current_sub_contextvar():
     """Verify _current_sub contextvar isolation."""
-    import asyncio
-    from better_telegram_mcp.credential_state import _current_sub
 
     async def check_sub(val):
         _current_sub.set(val)


### PR DESCRIPTION
Improved test coverage for `src/better_telegram_mcp/credential_state.py`.

- Added `set_setup_url` helper to allow setting the internal `_setup_url` state (previously only resettable via `reset_state`).
- Added `test_set_setup_url` to verify the new setter.
- Added `test_current_sub_contextvar` to verify the isolation of the `_current_sub` `ContextVar`, which was previously untested.

Although the task mentioned a missing test file, `tests/test_credential_state.py` already existed but lacked coverage for these specific components.

---
*PR created automatically by Jules for task [18110343929172577398](https://jules.google.com/task/18110343929172577398) started by @n24q02m*