### PR TITLE
[TEST] Missing test file for media.py

### DIFF
--- a/tests/test_tools/test_media.py
+++ b/tests/test_tools/test_media.py
@@ -87,6 +87,7 @@ async def test_send_photo_missing_params(mock_backend):
         await handle_media(mock_backend, "send_photo", MediaOptions(chat_id=123))
     )
     assert "error" in result
+    assert "requires chat_id and file_path_or_url" in result["error"]
 
     result = json.loads(
         await handle_media(
@@ -98,6 +99,7 @@ async def test_send_photo_missing_params(mock_backend):
         )
     )
     assert "error" in result
+    assert "requires chat_id and file_path_or_url" in result["error"]
 
 
 @pytest.mark.asyncio
@@ -122,18 +124,20 @@ async def test_download_missing_params(mock_backend):
         await handle_media(mock_backend, "download", MediaOptions(chat_id=123))
     )
     assert "error" in result
+    assert "requires chat_id and message_id" in result["error"]
 
     result = json.loads(
         await handle_media(mock_backend, "download", MediaOptions(message_id=10))
     )
     assert "error" in result
+    assert "requires chat_id and message_id" in result["error"]
 
 
 @pytest.mark.asyncio
 async def test_unknown_action(mock_backend):
     result = json.loads(await handle_media(mock_backend, "unknown", MediaOptions()))
     assert "error" in result
-    assert "Unknown action" in result["error"]
+    assert "Unknown action 'unknown'" in result["error"]
 
 
 @pytest.mark.asyncio
@@ -163,3 +167,50 @@ async def test_general_exception(mock_backend):
     )
     assert "error" in result
     assert "RuntimeError" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_unknown_action_suggestion(mock_backend):
+    result = json.loads(await handle_media(mock_backend, "send_phot", MediaOptions()))
+    assert "error" in result
+    assert "Did you mean 'send_photo'?" in result["error"]
+
+    result = json.loads(await handle_media(mock_backend, "downlo", MediaOptions()))
+    assert "error" in result
+    assert "Did you mean 'download'?" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_download_no_output_dir(mock_backend):
+    result = json.loads(
+        await handle_media(
+            mock_backend,
+            "download",
+            MediaOptions(
+                chat_id=123,
+                message_id=10,
+            ),
+        )
+    )
+    assert result["path"] == "/tmp/file.jpg"
+    mock_backend.download_media.assert_awaited_once_with(
+        123, 10, output_dir=None
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_photo_string_chat_id(mock_backend):
+    result = json.loads(
+        await handle_media(
+            mock_backend,
+            "send_photo",
+            MediaOptions(
+                chat_id="@username",
+                file_path_or_url="https://example.com/photo.jpg",
+            ),
+        )
+    )
+    assert result["message_id"] == 3
+    mock_backend.send_media.assert_awaited_once_with(
+        "@username", "photo", "https://example.com/photo.jpg", caption=None
+    )

--- a/tests/test_tools/test_media.py
+++ b/tests/test_tools/test_media.py
@@ -193,9 +193,7 @@ async def test_download_no_output_dir(mock_backend):
         )
     )
     assert result["path"] == "/tmp/file.jpg"
-    mock_backend.download_media.assert_awaited_once_with(
-        123, 10, output_dir=None
-    )
+    mock_backend.download_media.assert_awaited_once_with(123, 10, output_dir=None)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR enhances the test suite for the media tool to ensure complete and robust coverage.

Changes:
- Added `test_unknown_action_suggestion`: Verifies that `difflib` correctly suggests the intended action when a typo occurs (e.g., 'send_phot' -> 'send_photo').
- Added `test_download_no_output_dir`: Ensures the `download` action handles cases where the `output_dir` is not explicitly provided.
- Added `test_send_photo_string_chat_id`: Validates that `chat_id` can be passed as a string (e.g., a Telegram username).
- Enhanced `test_send_photo_missing_params` and `test_download_missing_params`: Replaced generic error presence checks with specific message assertions to prevent regression of error feedback.

These improvements ensure that `handle_media` is thoroughly validated across all primary and edge-case paths.

---
*PR created automatically by Jules for task [4120840161635122404](https://jules.google.com/task/4120840161635122404) started by @n24q02m*