### PR TITLE
⚡ Bolt: [PERF] Suboptimal data structure choice: List/Tuple instead of Set for membership test

### DIFF
--- a/src/better_telegram_mcp/tools/help_tool.py
+++ b/src/better_telegram_mcp/tools/help_tool.py
@@ -12,7 +12,7 @@ _DOC_CACHE: dict[str, str] = {}
 
 
 async def handle_help(topic: str | None = None) -> str:
-    if topic is None or topic in ("all", "telegram"):
+    if topic is None or topic in {"all", "telegram"}:
         # Bolt: Load all documentation files concurrently to reduce I/O wait time
         tasks = [_load_doc(t) for t in sorted(_VALID_TOPICS)]
         results = await asyncio.gather(*tasks)


### PR DESCRIPTION
This PR optimizes membership tests in the codebase to use O(1) sets instead of O(N) tuples/lists.

Specifically:
- In `src/better_telegram_mcp/tools/help_tool.py`, the membership test for `topic` was changed from a tuple `("all", "telegram")` to a set `{"all", "telegram"}`.
- Verified that `src/better_telegram_mcp/backends/security.py` already uses set literals for its membership checks.

Rationale: For small membership checks (n>=2), switching from literal tuples to literal sets in Python improves lookup performance (O(1) vs O(N)) as the AST optimizer compiles them to `frozenset` constants at compile time.

---
*PR created automatically by Jules for task [1430451834496926431](https://jules.google.com/task/1430451834496926431) started by @n24q02m*