### PR TITLE
[FIX] N+1 Query Issue in list_chats

### DIFF
--- a/src/better_telegram_mcp/backends/user_backend.py
+++ b/src/better_telegram_mcp/backends/user_backend.py
@@ -263,11 +263,11 @@ class UserBackend(TelegramBackend):
     # --- Chats ---
     async def list_chats(self, *, limit: int = 50) -> list[dict[str, Any]]:
         client = self._ensure_client()
-        # Bolt: using iter_dialogs in an async comprehension is faster and uses less
-        # memory than get_dialogs(), which creates an intermediate TotalList.
-        return [
-            self._serialize_dialog(d) async for d in client.iter_dialogs(limit=limit)
-        ]
+        # Bolt: Using get_dialogs() is more efficient for simple listings as it
+        # fetches all results in a single request, avoiding N+1 sequential I/O
+        # overhead from async iteration over the stream.
+        dialogs = await client.get_dialogs(limit=limit)
+        return [self._serialize_dialog(d) for d in dialogs]
 
     async def get_chat_info(self, chat_id: str | int) -> dict[str, Any]:
         client = self._ensure_client()

--- a/tests/test_backends/test_user_backend.py
+++ b/tests/test_backends/test_user_backend.py
@@ -400,11 +400,7 @@ class TestListChats:
 
         dialogs = [_mock_dialog(i, f"Chat {i}") for i in range(3)]
 
-        async def mock_iter_dialogs(*args, **kwargs):
-            for d in dialogs:
-                yield d
-
-        mock_client.iter_dialogs = MagicMock(side_effect=mock_iter_dialogs)
+        mock_client.get_dialogs = AsyncMock(return_value=dialogs)
 
         settings = _make_settings(tmp_path)
         backend = UserBackend(settings)
@@ -414,7 +410,7 @@ class TestListChats:
 
         assert len(result) == 3
         assert result[1]["title"] == "Chat 1"
-        mock_client.iter_dialogs.assert_called_once_with(limit=10)
+        mock_client.get_dialogs.assert_awaited_once_with(limit=10)
 
 
 class TestGetChatInfo:


### PR DESCRIPTION
Optimized list_chats by replacing the async list comprehension over iter_dialogs with client.get_dialogs(limit=limit). This allows fetching dialogs in bulk, avoiding sequential I/O overhead.

Key changes:
- Replaced async list comprehension with `await client.get_dialogs(limit=limit)`.
- Updated "Bolt" performance comment to reflect the shift to bulk fetching.
- Updated `tests/test_backends/test_user_backend.py` to test `get_dialogs` instead of `iter_dialogs`.

---
*PR created automatically by Jules for task [13989887650241594031](https://jules.google.com/task/13989887650241594031) started by @n24q02m*