### PR TITLE
[FIX] Too Many Parameters in `contact`

### DIFF
--- a/src/better_telegram_mcp/server.py
+++ b/src/better_telegram_mcp/server.py
@@ -13,7 +13,7 @@ from .backends.base import TelegramBackend
 from .config import Settings
 from .tools.chats import ChatOptions, handle_chats
 from .tools.config_tool import handle_config
-from .tools.contacts import ContactsOptions, handle_contacts
+from .tools.contacts import ContactRequest, handle_contacts
 from .tools.help_tool import handle_help
 from .tools.media import MediaOptions, handle_media
 from .tools.messages import MessagesArgs, handle_messages
@@ -368,15 +368,7 @@ async def media(
         openWorldHint=True,
     )
 )
-async def contact(
-    action: str,
-    query: str | None = None,
-    phone: str | None = None,
-    first_name: str | None = None,
-    last_name: str | None = None,
-    user_id: int | None = None,
-    unblock: bool = False,
-) -> str:
+async def contact(args: ContactRequest) -> str:
     """Manage contacts: list, search, add, and block/unblock users (user mode only).
 
     Actions:
@@ -388,15 +380,7 @@ async def contact(
     if _unconfigured or _pending_auth:
         return _not_ready_response()
 
-    opts = ContactsOptions(
-        query=query,
-        phone=phone,
-        first_name=first_name,
-        last_name=last_name,
-        user_id=user_id,
-        unblock=unblock,
-    )
-    return await handle_contacts(get_backend(), action, options=opts)
+    return await handle_contacts(get_backend(), args)
 
 
 @mcp.tool(

--- a/src/better_telegram_mcp/tools/contacts.py
+++ b/src/better_telegram_mcp/tools/contacts.py
@@ -45,9 +45,7 @@ async def handle_contacts(
             case "block":
                 if args.user_id is None:
                     return err("'block' requires user_id")
-                result = await backend.block_user(
-                    args.user_id, unblock=args.unblock
-                )
+                result = await backend.block_user(args.user_id, unblock=args.unblock)
                 action_word = "unblocked" if args.unblock else "blocked"
                 return ok({action_word: result})
 

--- a/src/better_telegram_mcp/tools/contacts.py
+++ b/src/better_telegram_mcp/tools/contacts.py
@@ -6,7 +6,8 @@ from ..backends.base import ModeError, TelegramBackend
 from ..utils.formatting import err, ok, safe_error
 
 
-class ContactsOptions(BaseModel):
+class ContactRequest(BaseModel):
+    action: str = Field(description="Action to perform: list, search, add, block")
     query: str | None = Field(default=None, description="Query to search for")
     phone: str | None = Field(default=None, description="Phone number to add")
     first_name: str | None = Field(
@@ -19,48 +20,45 @@ class ContactsOptions(BaseModel):
 
 async def handle_contacts(
     backend: TelegramBackend,
-    action: str,
-    options: ContactsOptions | None = None,
+    args: ContactRequest,
 ) -> str:
-    if options is None:
-        options = ContactsOptions()
     try:
-        match action:
+        match args.action:
             case "list":
                 results = await backend.list_contacts()
                 return ok({"contacts": results, "count": len(results)})
 
             case "search":
-                if not options.query:
+                if not args.query:
                     return err("'search' requires query")
-                results = await backend.search_contacts(options.query)
+                results = await backend.search_contacts(args.query)
                 return ok({"contacts": results, "count": len(results)})
 
             case "add":
-                if not options.phone or not options.first_name:
+                if not args.phone or not args.first_name:
                     return err("'add' requires phone and first_name")
                 result = await backend.add_contact(
-                    options.phone, options.first_name, last_name=options.last_name
+                    args.phone, args.first_name, last_name=args.last_name
                 )
                 return ok({"added": result})
 
             case "block":
-                if options.user_id is None:
+                if args.user_id is None:
                     return err("'block' requires user_id")
                 result = await backend.block_user(
-                    options.user_id, unblock=options.unblock
+                    args.user_id, unblock=args.unblock
                 )
-                action_word = "unblocked" if options.unblock else "blocked"
+                action_word = "unblocked" if args.unblock else "blocked"
                 return ok({action_word: result})
 
             case _:
                 import difflib
 
                 valid = ["add", "block", "list", "search"]
-                closest = difflib.get_close_matches(action, valid, n=1)
+                closest = difflib.get_close_matches(args.action, valid, n=1)
                 suggestion = f" Did you mean '{closest[0]}'?" if closest else ""
                 return err(
-                    f"Unknown action '{action}'.{suggestion} Valid: {'|'.join(valid)}"
+                    f"Unknown action '{args.action}'.{suggestion} Valid: {'|'.join(valid)}"
                 )
     except ModeError as e:
         return err(str(e))

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -122,7 +122,8 @@ async def test_contact_list(mock_backend):
     try:
         srv._backend = mock_backend
         srv._pending_auth = False
-        result = await contact(action="list")
+        from better_telegram_mcp.tools.contacts import ContactRequest
+        result = await contact(ContactRequest(action="list"))
         assert "contacts" in result
     finally:
         srv._backend = old_backend
@@ -320,7 +321,8 @@ async def test_contact_blocked_during_pending_auth(mock_backend):
     try:
         srv._backend = mock_backend
         srv._pending_auth = True
-        result = json.loads(await contact(action="list"))
+        from better_telegram_mcp.tools.contacts import ContactRequest
+        result = json.loads(await contact(ContactRequest(action="list")))
         assert "error" in result
         assert "not authenticated" in result["error"].lower()
     finally:
@@ -522,7 +524,8 @@ async def test_contact_returns_setup_hint_when_unconfigured():
     old = srv._unconfigured
     try:
         srv._unconfigured = True
-        result = json.loads(await contact(action="list"))
+        from better_telegram_mcp.tools.contacts import ContactRequest
+        result = json.loads(await contact(ContactRequest(action="list")))
         assert result["error"] == "Not configured"
         assert "setup" in result
     finally:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -123,6 +123,7 @@ async def test_contact_list(mock_backend):
         srv._backend = mock_backend
         srv._pending_auth = False
         from better_telegram_mcp.tools.contacts import ContactRequest
+
         result = await contact(ContactRequest(action="list"))
         assert "contacts" in result
     finally:
@@ -322,6 +323,7 @@ async def test_contact_blocked_during_pending_auth(mock_backend):
         srv._backend = mock_backend
         srv._pending_auth = True
         from better_telegram_mcp.tools.contacts import ContactRequest
+
         result = json.loads(await contact(ContactRequest(action="list")))
         assert "error" in result
         assert "not authenticated" in result["error"].lower()
@@ -525,6 +527,7 @@ async def test_contact_returns_setup_hint_when_unconfigured():
     try:
         srv._unconfigured = True
         from better_telegram_mcp.tools.contacts import ContactRequest
+
         result = json.loads(await contact(ContactRequest(action="list")))
         assert result["error"] == "Not configured"
         assert "setup" in result

--- a/tests/test_tools/test_contacts.py
+++ b/tests/test_tools/test_contacts.py
@@ -5,12 +5,14 @@ import json
 import pytest
 
 from better_telegram_mcp.backends.base import ModeError
-from better_telegram_mcp.tools.contacts import ContactsOptions, handle_contacts
+from better_telegram_mcp.tools.contacts import ContactRequest, handle_contacts
 
 
 @pytest.mark.asyncio
 async def test_list(mock_backend):
-    result = json.loads(await handle_contacts(mock_backend, "list"))
+    result = json.loads(
+        await handle_contacts(mock_backend, ContactRequest(action="list"))
+    )
     assert result["contacts"] == []
     assert result["count"] == 0
 
@@ -18,7 +20,9 @@ async def test_list(mock_backend):
 @pytest.mark.asyncio
 async def test_search(mock_backend):
     result = json.loads(
-        await handle_contacts(mock_backend, "search", ContactsOptions(query="John"))
+        await handle_contacts(
+            mock_backend, ContactRequest(action="search", query="John")
+        )
     )
     assert result["contacts"] == []
     assert result["count"] == 0
@@ -26,7 +30,7 @@ async def test_search(mock_backend):
 
 @pytest.mark.asyncio
 async def test_search_missing_params(mock_backend):
-    result = json.loads(await handle_contacts(mock_backend, "search"))
+    result = json.loads(await handle_contacts(mock_backend, ContactRequest(action="search")))
     assert "error" in result
 
 
@@ -35,8 +39,8 @@ async def test_add(mock_backend):
     result = json.loads(
         await handle_contacts(
             mock_backend,
-            "add",
-            ContactsOptions(
+            ContactRequest(
+                action="add",
                 phone="+1234567890",
                 first_name="John",
                 last_name="Doe",
@@ -52,12 +56,16 @@ async def test_add(mock_backend):
 @pytest.mark.asyncio
 async def test_add_missing_params(mock_backend):
     result = json.loads(
-        await handle_contacts(mock_backend, "add", ContactsOptions(phone="+123"))
+        await handle_contacts(
+            mock_backend, ContactRequest(action="add", phone="+123")
+        )
     )
     assert "error" in result
 
     result = json.loads(
-        await handle_contacts(mock_backend, "add", ContactsOptions(first_name="John"))
+        await handle_contacts(
+            mock_backend, ContactRequest(action="add", first_name="John")
+        )
     )
     assert "error" in result
 
@@ -65,7 +73,9 @@ async def test_add_missing_params(mock_backend):
 @pytest.mark.asyncio
 async def test_block(mock_backend):
     result = json.loads(
-        await handle_contacts(mock_backend, "block", ContactsOptions(user_id=123))
+        await handle_contacts(
+            mock_backend, ContactRequest(action="block", user_id=123)
+        )
     )
     assert result["blocked"] is True
 
@@ -74,7 +84,8 @@ async def test_block(mock_backend):
 async def test_unblock(mock_backend):
     result = json.loads(
         await handle_contacts(
-            mock_backend, "block", ContactsOptions(user_id=123, unblock=True)
+            mock_backend,
+            ContactRequest(action="block", user_id=123, unblock=True),
         )
     )
     assert result["unblocked"] is True
@@ -82,13 +93,17 @@ async def test_unblock(mock_backend):
 
 @pytest.mark.asyncio
 async def test_block_missing_params(mock_backend):
-    result = json.loads(await handle_contacts(mock_backend, "block"))
+    result = json.loads(
+        await handle_contacts(mock_backend, ContactRequest(action="block"))
+    )
     assert "error" in result
 
 
 @pytest.mark.asyncio
 async def test_unknown_action(mock_backend):
-    result = json.loads(await handle_contacts(mock_backend, "unknown"))
+    result = json.loads(
+        await handle_contacts(mock_backend, ContactRequest(action="unknown"))
+    )
     assert "error" in result
     assert "Unknown action" in result["error"]
 
@@ -96,7 +111,9 @@ async def test_unknown_action(mock_backend):
 @pytest.mark.asyncio
 async def test_mode_error(mock_backend):
     mock_backend.list_contacts.side_effect = ModeError("user")
-    result = json.loads(await handle_contacts(mock_backend, "list"))
+    result = json.loads(
+        await handle_contacts(mock_backend, ContactRequest(action="list"))
+    )
     assert "error" in result
     assert "user mode" in result["error"]
 
@@ -106,7 +123,8 @@ async def test_general_exception(mock_backend):
     mock_backend.add_contact.side_effect = RuntimeError("network error")
     result = json.loads(
         await handle_contacts(
-            mock_backend, "add", ContactsOptions(phone="+1", first_name="X")
+            mock_backend,
+            ContactRequest(action="add", phone="+1", first_name="X"),
         )
     )
     assert "error" in result

--- a/tests/test_tools/test_contacts.py
+++ b/tests/test_tools/test_contacts.py
@@ -30,7 +30,9 @@ async def test_search(mock_backend):
 
 @pytest.mark.asyncio
 async def test_search_missing_params(mock_backend):
-    result = json.loads(await handle_contacts(mock_backend, ContactRequest(action="search")))
+    result = json.loads(
+        await handle_contacts(mock_backend, ContactRequest(action="search"))
+    )
     assert "error" in result
 
 
@@ -56,9 +58,7 @@ async def test_add(mock_backend):
 @pytest.mark.asyncio
 async def test_add_missing_params(mock_backend):
     result = json.loads(
-        await handle_contacts(
-            mock_backend, ContactRequest(action="add", phone="+123")
-        )
+        await handle_contacts(mock_backend, ContactRequest(action="add", phone="+123"))
     )
     assert "error" in result
 
@@ -73,9 +73,7 @@ async def test_add_missing_params(mock_backend):
 @pytest.mark.asyncio
 async def test_block(mock_backend):
     result = json.loads(
-        await handle_contacts(
-            mock_backend, ContactRequest(action="block", user_id=123)
-        )
+        await handle_contacts(mock_backend, ContactRequest(action="block", user_id=123))
     )
     assert result["blocked"] is True
 


### PR DESCRIPTION
The `contact` tool in `server.py` had too many parameters, which was flagged as a code improvement task. I have refactored this by:

1. Renaming `ContactsOptions` to `ContactRequest` in `src/better_telegram_mcp/tools/contacts.py` and adding the `action` field to it.
2. Updating `handle_contacts` to accept this new `ContactRequest` model.
3. Modifying the `contact` tool in `src/better_telegram_mcp/server.py` to use `ContactRequest` in its signature.
4. Updating all relevant tests in `tests/test_tools/test_contacts.py` and `tests/test_server.py` to match the new implementation.

This change adheres to the "mega-tool" pattern used elsewhere in the project and makes the tool registration cleaner. All changes have been verified with linting and syntax checks.

---
*PR created automatically by Jules for task [2788726179788388616](https://jules.google.com/task/2788726179788388616) started by @n24q02m*