### PR TITLE
[FIX] Too Many Parameters in `message`

### DIFF
--- a/src/better_telegram_mcp/server.py
+++ b/src/better_telegram_mcp/server.py
@@ -219,20 +219,7 @@ register_open_relay_tool(mcp, "better-telegram-mcp", _PUBLIC_URL)
         openWorldHint=True,
     )
 )
-async def message(
-    action: str,
-    chat_id: str | int | None = None,
-    text: str | None = None,
-    message_id: int | None = None,
-    reply_to: int | None = None,
-    parse_mode: str | None = None,
-    from_chat: str | int | None = None,
-    to_chat: str | int | None = None,
-    emoji: str | None = None,
-    query: str | None = None,
-    limit: int = 20,
-    offset_id: int | None = None,
-) -> str:
+async def message(args: MessagesArgs) -> str:
     """Send, edit, delete, forward, pin, react, search, and get message history.
 
     Actions (chat_id: "@username" | int):
@@ -248,20 +235,6 @@ async def message(
     if _unconfigured or _pending_auth:
         return _not_ready_response()
 
-    args = MessagesArgs(
-        action=action,
-        chat_id=chat_id,
-        text=text,
-        message_id=message_id,
-        reply_to=reply_to,
-        parse_mode=parse_mode,
-        from_chat=from_chat,
-        to_chat=to_chat,
-        emoji=emoji,
-        query=query,
-        limit=limit,
-        offset_id=offset_id,
-    )
     return await handle_messages(get_backend(), args)
 
 

--- a/src/better_telegram_mcp/tools/messages.py
+++ b/src/better_telegram_mcp/tools/messages.py
@@ -3,25 +3,39 @@ from __future__ import annotations
 from collections.abc import Callable, Coroutine
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from ..backends.base import ModeError, TelegramBackend
 from ..utils.formatting import err, ok, safe_error
 
 
 class MessagesArgs(BaseModel):
-    action: str
-    chat_id: str | int | None = None
-    text: str | None = None
-    message_id: int | None = None
-    reply_to: int | None = None
-    parse_mode: str | None = None
-    from_chat: str | int | None = None
-    to_chat: str | int | None = None
-    emoji: str | None = None
-    query: str | None = None
-    limit: int = 20
-    offset_id: int | None = None
+    action: str = Field(
+        description="Action to perform: send, edit, delete, forward, pin, react, search, or history"
+    )
+    chat_id: str | int | None = Field(
+        default=None, description="Target chat ID (@username or int)"
+    )
+    text: str | None = Field(default=None, description="Message text for send/edit")
+    message_id: int | None = Field(
+        default=None, description="Message ID for edit/delete/forward/pin/react"
+    )
+    reply_to: int | None = Field(default=None, description="Message ID to reply to")
+    parse_mode: str | None = Field(
+        default=None, description="Parse mode (HTML, MarkdownV2, or Markdown)"
+    )
+    from_chat: str | int | None = Field(
+        default=None, description="Source chat ID for forward"
+    )
+    to_chat: str | int | None = Field(
+        default=None, description="Destination chat ID for forward"
+    )
+    emoji: str | None = Field(default=None, description="Emoji for reaction")
+    query: str | None = Field(default=None, description="Search query")
+    limit: int = Field(default=20, description="Max results for search/history")
+    offset_id: int | None = Field(
+        default=None, description="Offset message ID for history"
+    )
 
 
 async def _handle_send(backend: TelegramBackend, args: MessagesArgs) -> str:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -60,14 +60,14 @@ def test_get_settings_not_initialized():
 @pytest.mark.asyncio
 async def test_message_send(mock_backend):
     import better_telegram_mcp.server as srv
-    from better_telegram_mcp.server import message
+    from better_telegram_mcp.server import MessagesArgs, message
 
     old_backend = srv._backend
     old_pending = srv._pending_auth
     try:
         srv._backend = mock_backend
         srv._pending_auth = False
-        result = await message(action="send", chat_id=123, text="hi")
+        result = await message(MessagesArgs(action="send", chat_id=123, text="hi"))
         assert "message_id" in result
     finally:
         srv._backend = old_backend
@@ -132,14 +132,14 @@ async def test_contact_list(mock_backend):
 @pytest.mark.asyncio
 async def test_message_unknown_action(mock_backend):
     import better_telegram_mcp.server as srv
-    from better_telegram_mcp.server import message
+    from better_telegram_mcp.server import MessagesArgs, message
 
     old_backend = srv._backend
     old_pending = srv._pending_auth
     try:
         srv._backend = mock_backend
         srv._pending_auth = False
-        result = json.loads(await message(action="nonexistent"))
+        result = json.loads(await message(MessagesArgs(action="nonexistent")))
         assert "error" in result
         assert "Unknown action" in result["error"]
     finally:
@@ -253,14 +253,14 @@ async def test_lifespan_user_mode():
 @pytest.mark.asyncio
 async def test_message_blocked_during_pending_auth(mock_backend):
     import better_telegram_mcp.server as srv
-    from better_telegram_mcp.server import message
+    from better_telegram_mcp.server import MessagesArgs, message
 
     old_backend = srv._backend
     old_pending = srv._pending_auth
     try:
         srv._backend = mock_backend
         srv._pending_auth = True
-        result = json.loads(await message(action="send", chat_id=123, text="hi"))
+        result = json.loads(await message(MessagesArgs(action="send", chat_id=123, text="hi")))
         assert "error" in result
         assert "not authenticated" in result["error"].lower()
     finally:
@@ -422,14 +422,14 @@ async def test_help_works_without_credentials():
 async def test_message_returns_setup_hint_when_unconfigured():
     """message tool returns actionable setup instructions when unconfigured."""
     import better_telegram_mcp.server as srv
-    from better_telegram_mcp.server import message
+    from better_telegram_mcp.server import MessagesArgs, message
 
     old_unconfigured = srv._unconfigured
     old_pending = srv._pending_auth
     try:
         srv._unconfigured = True
         srv._pending_auth = False
-        result = json.loads(await message(action="send", chat_id=123, text="hi"))
+        result = json.loads(await message(MessagesArgs(action="send", chat_id=123, text="hi")))
         assert "error" in result
         assert result["error"] == "Not configured"
         assert "setup" in result

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -260,7 +260,9 @@ async def test_message_blocked_during_pending_auth(mock_backend):
     try:
         srv._backend = mock_backend
         srv._pending_auth = True
-        result = json.loads(await message(MessagesArgs(action="send", chat_id=123, text="hi")))
+        result = json.loads(
+            await message(MessagesArgs(action="send", chat_id=123, text="hi"))
+        )
         assert "error" in result
         assert "not authenticated" in result["error"].lower()
     finally:
@@ -429,7 +431,9 @@ async def test_message_returns_setup_hint_when_unconfigured():
     try:
         srv._unconfigured = True
         srv._pending_auth = False
-        result = json.loads(await message(MessagesArgs(action="send", chat_id=123, text="hi")))
+        result = json.loads(
+            await message(MessagesArgs(action="send", chat_id=123, text="hi"))
+        )
         assert "error" in result
         assert result["error"] == "Not configured"
         assert "setup" in result


### PR DESCRIPTION
The `message` tool in `src/better_telegram_mcp/server.py` had too many parameters (12). This change encapsulates those parameters into a single `MessagesArgs` Pydantic model in `src/better_telegram_mcp/tools/messages.py`. 

Benefits:
- Cleaner function signature in `server.py`.
- Improved maintainability.
- Consistent with other tools like `chat`, `media`, and `contact`.
- Better tool metadata for LLMs through Pydantic `Field` descriptions.

Changes:
- Modified `src/better_telegram_mcp/tools/messages.py` to add `Field` and `description` to `MessagesArgs`.
- Refactored `src/better_telegram_mcp/server.py` to use the new `MessagesArgs` parameter.
- Updated `tests/test_server.py` to reflect the signature change.

---
*PR created automatically by Jules for task [4881362294601214110](https://jules.google.com/task/4881362294601214110) started by @n24q02m*