### PR TITLE
[FIX] Too Many Parameters in `media`

### DIFF
--- a/src/better_telegram_mcp/server.py
+++ b/src/better_telegram_mcp/server.py
@@ -331,11 +331,7 @@ async def chat(
 )
 async def media(
     action: str,
-    chat_id: str | int | None = None,
-    file_path_or_url: str | None = None,
-    message_id: int | None = None,
-    caption: str | None = None,
-    output_dir: str | None = None,
+    options: MediaOptions | None = None,
 ) -> str:
     """Send photos, files, voice, video, and download media from messages.
 
@@ -349,14 +345,9 @@ async def media(
     if _unconfigured or _pending_auth:
         return _not_ready_response()
 
-    opts = MediaOptions(
-        chat_id=chat_id,
-        file_path_or_url=file_path_or_url,
-        message_id=message_id,
-        caption=caption,
-        output_dir=output_dir,
-    )
-    return await handle_media(get_backend(), action, opts)
+    if options is None:
+        options = MediaOptions()
+    return await handle_media(get_backend(), action, options)
 
 
 @mcp.tool(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -95,6 +95,7 @@ async def test_chat_list(mock_backend):
 async def test_media_send_photo(mock_backend):
     import better_telegram_mcp.server as srv
     from better_telegram_mcp.server import media
+    from better_telegram_mcp.tools.media import MediaOptions
 
     old_backend = srv._backend
     old_pending = srv._pending_auth
@@ -103,8 +104,10 @@ async def test_media_send_photo(mock_backend):
         srv._pending_auth = False
         result = await media(
             action="send_photo",
-            chat_id=123,
-            file_path_or_url="https://example.com/photo.jpg",
+            options=MediaOptions(
+                chat_id=123,
+                file_path_or_url="https://example.com/photo.jpg",
+            ),
         )
         assert "message_id" in result
     finally:
@@ -290,6 +293,7 @@ async def test_chat_blocked_during_pending_auth(mock_backend):
 async def test_media_blocked_during_pending_auth(mock_backend):
     import better_telegram_mcp.server as srv
     from better_telegram_mcp.server import media
+    from better_telegram_mcp.tools.media import MediaOptions
 
     old_backend = srv._backend
     old_pending = srv._pending_auth
@@ -299,8 +303,10 @@ async def test_media_blocked_during_pending_auth(mock_backend):
         result = json.loads(
             await media(
                 action="send_photo",
-                chat_id=123,
-                file_path_or_url="https://example.com/photo.jpg",
+                options=MediaOptions(
+                    chat_id=123,
+                    file_path_or_url="https://example.com/photo.jpg",
+                ),
             )
         )
         assert "error" in result
@@ -496,6 +502,7 @@ async def test_media_returns_setup_hint_when_unconfigured():
     """media tool returns setup instructions when unconfigured."""
     import better_telegram_mcp.server as srv
     from better_telegram_mcp.server import media
+    from better_telegram_mcp.tools.media import MediaOptions
 
     old = srv._unconfigured
     try:
@@ -503,8 +510,10 @@ async def test_media_returns_setup_hint_when_unconfigured():
         result = json.loads(
             await media(
                 action="send_photo",
-                chat_id=123,
-                file_path_or_url="https://example.com/photo.jpg",
+                options=MediaOptions(
+                    chat_id=123,
+                    file_path_or_url="https://example.com/photo.jpg",
+                ),
             )
         )
         assert result["error"] == "Not configured"


### PR DESCRIPTION
The `media` tool in `src/better_telegram_mcp/server.py` previously had 6 parameters, which triggered a "Too Many Parameters" warning/issue. This PR refactors the tool to use the existing `MediaOptions` Pydantic model as a single parameter for all optional media-related arguments (`chat_id`, `file_path_or_url`, `message_id`, `caption`, `output_dir`).

Changes:
- Refactored `media(action, chat_id, ...)` to `media(action, options)`.
- Initialized `options = MediaOptions()` inside the function if `None` to comply with Ruff rule B008.
- Updated all occurrences of `await media(...)` in `tests/test_server.py` to use the new signature.
- Verified that `ruff check` and `ruff format` pass.

This refactoring improves code maintainability and aligns the `media` tool with the pattern used by other tools in the codebase (e.g., `contact`, `message`).

---
*PR created automatically by Jules for task [1735665929588951129](https://jules.google.com/task/1735665929588951129) started by @n24q02m*