### PR TITLE
fix(deps): regenerate uv.lock without path sources for Docker

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.10.0"
+version = "4.11.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },
@@ -112,7 +112,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.27.0" },
-    { name = "n24q02m-mcp-core", directory = "../mcp-core/packages/core-py" },
+    { name = "n24q02m-mcp-core", specifier = ">=1.14.0" },
     { name = "pydantic", specifier = ">=2.9,<2.13" },
     { name = "pydantic-settings", specifier = ">=2.14.0" },
     { name = "starlette", specifier = ">=1.0.0" },
@@ -728,7 +728,7 @@ wheels = [
 [[package]]
 name = "n24q02m-mcp-core"
 version = "1.14.0"
-source = { directory = "../mcp-core/packages/core-py" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
     { name = "cryptography" },
@@ -741,29 +741,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "authlib", specifier = ">=1.7.2" },
-    { name = "cryptography", specifier = ">=48.0.0" },
-    { name = "fastmcp", specifier = ">=3.2.4" },
-    { name = "filelock", specifier = ">=3.29.0" },
-    { name = "httpx", specifier = ">=0.28.1" },
-    { name = "loguru", specifier = ">=0.7.3" },
-    { name = "platformdirs", specifier = ">=4.9.6" },
-    { name = "pydantic", specifier = ">=2.12.5,<2.13" },
-    { name = "starlette", specifier = ">=1.0.0" },
-    { name = "tomli-w", specifier = ">=1.2.0" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pytest", specifier = ">=9.0.3" },
-    { name = "pytest-asyncio", specifier = ">=1.3.0" },
-    { name = "pytest-cov", specifier = ">=7.1.0" },
-    { name = "pytest-timeout", specifier = ">=2.4.0" },
-    { name = "ruff", specifier = ">=0.15.12" },
-    { name = "ty", specifier = ">=0.0.34" },
+sdist = { url = "https://files.pythonhosted.org/packages/4c/76/e247032467d5e4b224145485219155ddcd9f041b50a8473ef8be168bc069/n24q02m_mcp_core-1.14.0.tar.gz", hash = "sha256:cd5d1fa31a60fe4aa49f461618b4acf4987cb9bb8e06c096c1da6bac13848fd9", size = 192400, upload-time = "2026-05-06T12:56:33.198Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/77/aed34c84240b7dd2edb3a2e38e0dbdb0c83554c957c47389efe2edf7bdce/n24q02m_mcp_core-1.14.0-py3-none-any.whl", hash = "sha256:f35a7fd5fd9c23532d62f55cf7948ad754dca3f0805ec2101642b1d6e1ce1a7e", size = 123365, upload-time = "2026-05-06T12:56:32.026Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
BETA cascade Docker build failed because uv.lock referenced `[tool.uv.sources]` path `../mcp-core/packages/core-py` which doesn't exist in Docker context. Regenerate with `UV_NO_SOURCES=1` so lockfile uses PyPI resolution. Local dev still uses path source via pyproject (uv sync without UV_NO_SOURCES). Per feedback_uv_lock_docker_trap.md.