### PR TITLE
🎨 Palette: Improve autocomplete UX in credential form

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Added Autocomplete to Telegram Credential Form
+**Learning:** Using generic `autocomplete="off"` for auth forms harms mobile usability. Using standard browser hints like `autocomplete="tel"`, `autocomplete="one-time-code"`, and `autocomplete="current-password"` significantly improves the login experience by enabling browser-native autofill.
+**Action:** When creating forms, particularly for credential entry and multi-step OTP flows, dynamically map the server-provided `ns.type` to specific browser `autocomplete` strings.

--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -414,7 +414,7 @@ def render_telegram_credential_form(
                             type="tel"
                             placeholder="+84..."
                             class="field-input"
-                            autocomplete="off"
+                            autocomplete="tel"
                             autocorrect="off"
                             autocapitalize="off"
                             spellcheck="false"{phone_value_attr}
@@ -538,7 +538,7 @@ def render_telegram_credential_form(
                     inputEl = document.createElement("input");
                     inputEl.id = "step-input";
                     inputEl.className = "field-input";
-                    inputEl.setAttribute("autocomplete", "off");
+                    inputEl.setAttribute("autocomplete", ns.type === "otp_required" ? "one-time-code" : ns.type === "password_required" ? "current-password" : "off");
                     inputEl.setAttribute("autocorrect", "off");
                     inputEl.setAttribute("autocapitalize", "off");
                     inputEl.setAttribute("spellcheck", "false");

--- a/tests/test_credential_form.py
+++ b/tests/test_credential_form.py
@@ -36,6 +36,7 @@ def test_contains_phone_field() -> None:
     html = render_telegram_credential_form(SCHEMA, "/auth")
     assert "TELEGRAM_PHONE" in html
     assert "MTProto" in html
+    assert 'autocomplete="tel"' in html
 
 
 def test_posts_to_submit_url() -> None:
@@ -48,6 +49,7 @@ def test_supports_otp_multi_step() -> None:
     assert "otp_required" in html
     assert "password_required" in html
     assert "/otp" in html
+    assert 'ns.type === "otp_required" ? "one-time-code" : ns.type === "password_required" ? "current-password" : "off"' in html
 
 
 def test_uses_safe_dom_methods() -> None:

--- a/tests/test_credential_form.py
+++ b/tests/test_credential_form.py
@@ -49,7 +49,10 @@ def test_supports_otp_multi_step() -> None:
     assert "otp_required" in html
     assert "password_required" in html
     assert "/otp" in html
-    assert 'ns.type === "otp_required" ? "one-time-code" : ns.type === "password_required" ? "current-password" : "off"' in html
+    assert (
+        'ns.type === "otp_required" ? "one-time-code" : ns.type === "password_required" ? "current-password" : "off"'
+        in html
+    )
 
 
 def test_uses_safe_dom_methods() -> None:


### PR DESCRIPTION
💡 What: Replaced generic `autocomplete="off"` with specific standard types: `tel` for phone input, `one-time-code` for OTP challenges, and `current-password` for password challenges.
🎯 Why: Makes the login and verification process much more frictionless, especially on mobile where entering phone numbers or OTPs can be tedious. It lets native password managers and browser autofill perform correctly.
📸 Before/After: Not a visual UI layout change, but improves the system keyboard popup.
♿ Accessibility: Enables browser automation to interpret the field types correctly, aiding screen reader and autofill tools.

---
*PR created automatically by Jules for task [3339177995311671241](https://jules.google.com/task/3339177995311671241) started by @n24q02m*