### PR TITLE
🎨 Palette: Add autocomplete attributes to credential form

### DIFF
--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -390,7 +390,7 @@ def render_telegram_credential_form(
                             type="password"
                             placeholder="123456:ABC-DEF..."
                             class="field-input"
-                            autocomplete="off"
+                            autocomplete="current-password"
                             autocorrect="off"
                             autocapitalize="off"
                             spellcheck="false"{bot_token_value_attr}
@@ -414,7 +414,7 @@ def render_telegram_credential_form(
                             type="tel"
                             placeholder="+84..."
                             class="field-input"
-                            autocomplete="off"
+                            autocomplete="tel"
                             autocorrect="off"
                             autocapitalize="off"
                             spellcheck="false"{phone_value_attr}
@@ -538,7 +538,7 @@ def render_telegram_credential_form(
                     inputEl = document.createElement("input");
                     inputEl.id = "step-input";
                     inputEl.className = "field-input";
-                    inputEl.setAttribute("autocomplete", "off");
+                    inputEl.setAttribute("autocomplete", "one-time-code");
                     inputEl.setAttribute("autocorrect", "off");
                     inputEl.setAttribute("autocapitalize", "off");
                     inputEl.setAttribute("spellcheck", "false");

--- a/tests/test_credential_form.py
+++ b/tests/test_credential_form.py
@@ -209,3 +209,10 @@ def test_bot_token_only_prefill_marks_bot_token_required_only() -> None:
     bot_input = html.split('name="TELEGRAM_BOT_TOKEN"')[1].split("/>")[0]
     assert "required" in bot_input
     assert "required" not in phone_input
+
+
+def test_inputs_have_correct_autocomplete() -> None:
+    html = render_telegram_credential_form(SCHEMA, "/auth")
+    assert 'autocomplete="current-password"' in html
+    assert 'autocomplete="tel"' in html
+    assert 'setAttribute("autocomplete", "one-time-code")' in html


### PR DESCRIPTION
🎨 Palette: Add proper `autocomplete` attributes to credential form

💡 What: Added `autocomplete="current-password"`, `autocomplete="tel"`, and `autocomplete="one-time-code"` to the respective input fields in the credential form.
🎯 Why: To improve the user experience by enabling password managers and mobile operating systems to assist the user with native autofill capabilities. The `one-time-code` addition is particularly valuable as it allows devices like iOS/Android to automatically surface SMS codes above the keyboard.
📸 Before/After: The visual appearance of the form is unchanged, but the underlying accessibility and autofill behaviour are improved.
♿ Accessibility: Improved accessibility by providing semantic context to assistive technologies and password managers.

---
*PR created automatically by Jules for task [10330350960520884329](https://jules.google.com/task/10330350960520884329) started by @n24q02m*