### PR TITLE
🎨 Palette: Add Autocomplete to Credential Form Inputs

### DIFF
--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -414,7 +414,7 @@ def render_telegram_credential_form(
                             type="tel"
                             placeholder="+84..."
                             class="field-input"
-                            autocomplete="off"
+                            autocomplete="tel"
                             autocorrect="off"
                             autocapitalize="off"
                             spellcheck="false"{phone_value_attr}
@@ -538,7 +538,6 @@ def render_telegram_credential_form(
                     inputEl = document.createElement("input");
                     inputEl.id = "step-input";
                     inputEl.className = "field-input";
-                    inputEl.setAttribute("autocomplete", "off");
                     inputEl.setAttribute("autocorrect", "off");
                     inputEl.setAttribute("autocapitalize", "off");
                     inputEl.setAttribute("spellcheck", "false");
@@ -576,6 +575,15 @@ def render_telegram_credential_form(
 
                 promptEl.textContent = ns.text || "";
                 inputEl.setAttribute("type", ns.input_type || "text");
+
+                if (ns.type === "otp_required") {{
+                    inputEl.setAttribute("autocomplete", "one-time-code");
+                }} else if (ns.type === "password_required") {{
+                    inputEl.setAttribute("autocomplete", "current-password");
+                }} else {{
+                    inputEl.setAttribute("autocomplete", "off");
+                }}
+
                 inputEl.setAttribute("placeholder", ns.placeholder || "");
                 inputEl.dataset.field = ns.field || "value";
                 inputEl.focus();


### PR DESCRIPTION
💡 What: Added appropriate `autocomplete` attributes (`tel`, `one-time-code`, and `current-password`) to authentication inputs in the credential form.
🎯 Why: OS and browser password managers, especially on mobile devices, rely heavily on `autocomplete` tags to provide native autofill suggestions (such as pasting a received SMS code). The form previously hardcoded `autocomplete="off"` for all dynamic fields, hurting user convenience.
♿ Accessibility: Reduces manual keyboard typing, especially for visually impaired or motor-impaired users utilizing password managers.

---
*PR created automatically by Jules for task [4214070081598250765](https://jules.google.com/task/4214070081598250765) started by @n24q02m*