### PR TITLE
🎨 Palette: Add autocomplete attributes to improve form autofill

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-05 - Focus First Invalid Input on Form Validation Failure
 **Learning:** Bringing focus to the first invalid input when client-side form validation fails is a low-effort, high-impact a11y/UX pattern that works natively without relying solely on screen reader ARIA live regions to announce errors.
 **Action:** Always add `.focus()` calls when interrupting form submissions with JS validation logic.
+## 2024-07-28 - Improve Autofill with appropriate autocomplete attributes
+**Learning:** For inputs where we request sensitive and short-lived or predictable strings (like phone numbers, OTP codes, and passwords), explicitly defining the `autocomplete` attribute provides huge UX wins. Browsers and password managers can automatically pick up SMS verification codes (`autocomplete="one-time-code"`) or phone numbers (`autocomplete="tel"`), skipping tedious copy-paste.
+**Action:** Always set `autocomplete="tel"` for phone fields, `autocomplete="one-time-code"` for OTPs, and `autocomplete="current-password"` for passwords, particularly on dynamically generated form fields in JS.

--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -414,7 +414,7 @@ def render_telegram_credential_form(
                             type="tel"
                             placeholder="+84..."
                             class="field-input"
-                            autocomplete="off"
+                            autocomplete="tel"
                             autocorrect="off"
                             autocapitalize="off"
                             spellcheck="false"{phone_value_attr}
@@ -538,7 +538,7 @@ def render_telegram_credential_form(
                     inputEl = document.createElement("input");
                     inputEl.id = "step-input";
                     inputEl.className = "field-input";
-                    inputEl.setAttribute("autocomplete", "off");
+                    // Autocomplete is set dynamically below based on step type
                     inputEl.setAttribute("autocorrect", "off");
                     inputEl.setAttribute("autocapitalize", "off");
                     inputEl.setAttribute("spellcheck", "false");
@@ -576,6 +576,15 @@ def render_telegram_credential_form(
 
                 promptEl.textContent = ns.text || "";
                 inputEl.setAttribute("type", ns.input_type || "text");
+
+                var ac = "off";
+                if (ns.type === "otp_required") {{
+                    ac = "one-time-code";
+                }} else if (ns.type === "password_required" || ns.input_type === "password") {{
+                    ac = "current-password";
+                }}
+                inputEl.setAttribute("autocomplete", ac);
+
                 inputEl.setAttribute("placeholder", ns.placeholder || "");
                 inputEl.dataset.field = ns.field || "value";
                 inputEl.focus();


### PR DESCRIPTION
💡 What: Added appropriate `autocomplete` attributes to phone (`tel`), OTP (`one-time-code`), and password (`current-password`) inputs in the Telegram credential form.
🎯 Why: Enhances native browser and password manager autofill, particularly making the SMS verification flow much smoother on mobile devices by allowing quick code insertion.
♿ Accessibility: Ensures that form inputs explicitly declare their expected data type for assistive technologies.

---
*PR created automatically by Jules for task [936778043679736283](https://jules.google.com/task/936778043679736283) started by @n24q02m*