### PR TITLE
🎨 Palette: Add specific autocomplete attributes to credential form

### DIFF
--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -414,7 +414,7 @@ def render_telegram_credential_form(
                             type="tel"
                             placeholder="+84..."
                             class="field-input"
-                            autocomplete="off"
+                            autocomplete="tel"
                             autocorrect="off"
                             autocapitalize="off"
                             spellcheck="false"{phone_value_attr}
@@ -573,12 +573,20 @@ def render_telegram_credential_form(
                         }}
                     }});
                 }}
-
                 promptEl.textContent = ns.text || "";
                 inputEl.setAttribute("type", ns.input_type || "text");
                 inputEl.setAttribute("placeholder", ns.placeholder || "");
                 inputEl.dataset.field = ns.field || "value";
+                if (ns.type === "otp_required") {{
+                    inputEl.setAttribute("autocomplete", "one-time-code");
+                }} else if (ns.type === "password_required") {{
+                    inputEl.setAttribute("autocomplete", "current-password");
+                }} else {{
+                    inputEl.setAttribute("autocomplete", "off");
+                }}
                 inputEl.focus();
+
+
             }}
 
             function submitStep() {{

--- a/tests/test_credential_form.py
+++ b/tests/test_credential_form.py
@@ -36,6 +36,7 @@ def test_contains_phone_field() -> None:
     html = render_telegram_credential_form(SCHEMA, "/auth")
     assert "TELEGRAM_PHONE" in html
     assert "MTProto" in html
+    assert 'autocomplete="tel"' in html
 
 
 def test_posts_to_submit_url() -> None:
@@ -209,3 +210,9 @@ def test_bot_token_only_prefill_marks_bot_token_required_only() -> None:
     bot_input = html.split('name="TELEGRAM_BOT_TOKEN"')[1].split("/>")[0]
     assert "required" in bot_input
     assert "required" not in phone_input
+
+
+def test_contains_autocomplete_js_logic() -> None:
+    html = render_telegram_credential_form(SCHEMA, "/auth")
+    assert "one-time-code" in html
+    assert "current-password" in html


### PR DESCRIPTION
- **What**: Added specific `autocomplete` attributes to credential form input fields. The phone number input now uses `autocomplete="tel"`. The dynamically generated multi-factor step inputs conditionally use `autocomplete="one-time-code"` for OTP verification and `autocomplete="current-password"` for passwords.
- **Why**: Improves mobile accessibility and streamlines the login experience by allowing browser password managers and mobile keyboards to correctly suggest and autofill phone numbers, OTP verification codes (especially those received via SMS), and saved passwords.
- **Accessibility**: Enhances form usability for users relying on browser autofill, reducing cognitive load and friction. Tests were updated and verified to ensure structural logic captures the new logic appropriately.

---
*PR created automatically by Jules for task [16465654750591601769](https://jules.google.com/task/16465654750591601769) started by @n24q02m*