### PR TITLE
🎨 Palette: Add autocomplete attributes to credential form

### DIFF
--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -414,7 +414,7 @@ def render_telegram_credential_form(
                             type="tel"
                             placeholder="+84..."
                             class="field-input"
-                            autocomplete="off"
+                            autocomplete="tel"
                             autocorrect="off"
                             autocapitalize="off"
                             spellcheck="false"{phone_value_attr}
@@ -538,7 +538,13 @@ def render_telegram_credential_form(
                     inputEl = document.createElement("input");
                     inputEl.id = "step-input";
                     inputEl.className = "field-input";
-                    inputEl.setAttribute("autocomplete", "off");
+                    if (ns && ns.type === "otp_required") {{
+                        inputEl.setAttribute("autocomplete", "one-time-code");
+                    }} else if (ns && ns.type === "password_required") {{
+                        inputEl.setAttribute("autocomplete", "current-password");
+                    }} else {{
+                        inputEl.setAttribute("autocomplete", "off");
+                    }}
                     inputEl.setAttribute("autocorrect", "off");
                     inputEl.setAttribute("autocapitalize", "off");
                     inputEl.setAttribute("spellcheck", "false");


### PR DESCRIPTION
I've implemented a small UX improvement for the Telegram credential setup form! I added specific `autocomplete` attributes to the form inputs to help browsers and password managers easily recognize and prefill them. Specifically, the phone number input now uses `autocomplete="tel"`, and the dynamically generated multi-step inputs (like OTP and passwords) use `autocomplete="one-time-code"` and `autocomplete="current-password"`. This makes the login process smoother and more accessible.

---
*PR created automatically by Jules for task [11712264438688290311](https://jules.google.com/task/11712264438688290311) started by @n24q02m*