### PR TITLE
🎨 Palette: Improve autocomplete UX in credential form

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-05 - Focus First Invalid Input on Form Validation Failure
 **Learning:** Bringing focus to the first invalid input when client-side form validation fails is a low-effort, high-impact a11y/UX pattern that works natively without relying solely on screen reader ARIA live regions to announce errors.
 **Action:** Always add `.focus()` calls when interrupting form submissions with JS validation logic.
+## 2024-08-01 - Enhance Context-Specific Autocomplete Attributes
+**Learning:** For inputs capturing sensitive or context-specific data like phone numbers (`tel`), one-time codes (`one-time-code`), or passwords (`current-password`), directly specifying the `autocomplete` attribute significantly enhances native mobile and desktop autofill behavior.
+**Action:** Always verify if an input gathers context-specific data (e.g. phone numbers or 2FA codes). If it does, ensure the `autocomplete` attribute matches its explicit purpose rather than defaulting to `off` to reduce friction for the user.

--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -414,7 +414,7 @@ def render_telegram_credential_form(
                             type="tel"
                             placeholder="+84..."
                             class="field-input"
-                            autocomplete="off"
+                            autocomplete="tel"
                             autocorrect="off"
                             autocapitalize="off"
                             spellcheck="false"{phone_value_attr}
@@ -538,7 +538,6 @@ def render_telegram_credential_form(
                     inputEl = document.createElement("input");
                     inputEl.id = "step-input";
                     inputEl.className = "field-input";
-                    inputEl.setAttribute("autocomplete", "off");
                     inputEl.setAttribute("autocorrect", "off");
                     inputEl.setAttribute("autocapitalize", "off");
                     inputEl.setAttribute("spellcheck", "false");
@@ -576,6 +575,13 @@ def render_telegram_credential_form(
 
                 promptEl.textContent = ns.text || "";
                 inputEl.setAttribute("type", ns.input_type || "text");
+                if (ns.type === "otp_required") {{
+                    inputEl.setAttribute("autocomplete", "one-time-code");
+                }} else if (ns.type === "password_required") {{
+                    inputEl.setAttribute("autocomplete", "current-password");
+                }} else {{
+                    inputEl.setAttribute("autocomplete", "off");
+                }}
                 inputEl.setAttribute("placeholder", ns.placeholder || "");
                 inputEl.dataset.field = ns.field || "value";
                 inputEl.focus();

--- a/tests/test_credential_form.py
+++ b/tests/test_credential_form.py
@@ -38,6 +38,18 @@ def test_contains_phone_field() -> None:
     assert "MTProto" in html
 
 
+def test_telephone_input_autocomplete() -> None:
+    html = render_telegram_credential_form(SCHEMA, "/auth")
+    assert 'autocomplete="tel"' in html
+    assert 'name="TELEGRAM_PHONE"' in html
+
+
+def test_show_step_input_dynamic_autocomplete() -> None:
+    html = render_telegram_credential_form(SCHEMA, "/auth")
+    assert 'inputEl.setAttribute("autocomplete", "one-time-code")' in html
+    assert 'inputEl.setAttribute("autocomplete", "current-password")' in html
+
+
 def test_posts_to_submit_url() -> None:
     html = render_telegram_credential_form(SCHEMA, "/authorize?nonce=xyz")
     assert "/authorize?nonce=xyz" in html


### PR DESCRIPTION
🎨 Palette: Improve autocomplete UX in credential form

💡 **What:** 
- Updated the `TELEGRAM_PHONE` `<input>` attribute `autocomplete="off"` to `autocomplete="tel"`.
- Added dynamic JS attribute assignment for the multi-step `showStepInput` container logic to allow `autocomplete="one-time-code"` for OTPs and `autocomplete="current-password"` for standard 2FA verification.
- Added respective unit tests for the functionality within `test_credential_form.py`

🎯 **Why:** 
Hardcoding `autocomplete="off"` on explicit/sensitive verification fields creates unnecessary friction, especially on mobile browsers and for desktop password managers. Providing accurate context-hints enables native seamless autofill behavior.

♿ **Accessibility:**
These adjustments improve the usability and workflow of accessibility tools, assistive mobile touch keyboards, and password-management plugins.

---
*PR created automatically by Jules for task [10784782306436093322](https://jules.google.com/task/10784782306436093322) started by @n24q02m*