### PR TITLE
🎨 Palette: Add native autofill for better mobile accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-05 - Focus First Invalid Input on Form Validation Failure
 **Learning:** Bringing focus to the first invalid input when client-side form validation fails is a low-effort, high-impact a11y/UX pattern that works natively without relying solely on screen reader ARIA live regions to announce errors.
 **Action:** Always add `.focus()` calls when interrupting form submissions with JS validation logic.
+## 2024-05-16 - Autocomplete Attributes for Input Fields
+**Learning:** For mobile accessibility and native browser autofill, always utilize appropriate `autocomplete` attributes on input fields instead of leaving them as `autocomplete="off"` or omitted. This allows password managers and mobile browsers to accurately suggest user data like passwords, OTPs, or phone numbers.
+**Action:** When adding inputs (like `tel`, `one-time-code`, and `current-password`), add explicitly mapped `autocomplete` tags (e.g. `autocomplete="tel"`) to make them native-autofill friendly.

--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -414,7 +414,7 @@ def render_telegram_credential_form(
                             type="tel"
                             placeholder="+84..."
                             class="field-input"
-                            autocomplete="off"
+                            autocomplete="tel"
                             autocorrect="off"
                             autocapitalize="off"
                             spellcheck="false"{phone_value_attr}
@@ -538,7 +538,6 @@ def render_telegram_credential_form(
                     inputEl = document.createElement("input");
                     inputEl.id = "step-input";
                     inputEl.className = "field-input";
-                    inputEl.setAttribute("autocomplete", "off");
                     inputEl.setAttribute("autocorrect", "off");
                     inputEl.setAttribute("autocapitalize", "off");
                     inputEl.setAttribute("spellcheck", "false");
@@ -578,6 +577,15 @@ def render_telegram_credential_form(
                 inputEl.setAttribute("type", ns.input_type || "text");
                 inputEl.setAttribute("placeholder", ns.placeholder || "");
                 inputEl.dataset.field = ns.field || "value";
+
+                if (ns.type === "otp_required") {{
+                    inputEl.setAttribute("autocomplete", "one-time-code");
+                }} else if (ns.type === "password_required") {{
+                    inputEl.setAttribute("autocomplete", "current-password");
+                }} else {{
+                    inputEl.setAttribute("autocomplete", "off");
+                }}
+
                 inputEl.focus();
             }}
 

--- a/tests/test_credential_form.py
+++ b/tests/test_credential_form.py
@@ -200,6 +200,20 @@ def test_bot_mode_marks_bot_token_required_only() -> None:
     assert "required" not in phone_input
 
 
+def test_autocomplete_attributes() -> None:
+    html = render_telegram_credential_form(SCHEMA, "/auth")
+    phone_input = html.split('name="TELEGRAM_PHONE"')[1].split("/>")[0]
+    bot_input = html.split('name="TELEGRAM_BOT_TOKEN"')[1].split("/>")[0]
+    assert 'autocomplete="tel"' in phone_input
+    assert 'autocomplete="off"' in bot_input
+
+
+def test_dynamic_autocomplete_attributes() -> None:
+    html = render_telegram_credential_form(SCHEMA, "/auth")
+    assert 'inputEl.setAttribute("autocomplete", "one-time-code");' in html
+    assert 'inputEl.setAttribute("autocomplete", "current-password");' in html
+
+
 def test_bot_token_only_prefill_marks_bot_token_required_only() -> None:
     """Bot mode with prefill: only bot token input has ``required`` attr."""
     html = render_telegram_credential_form(


### PR DESCRIPTION
🎨 Palette: Add native autofill for better mobile accessibility

- Modified `credential_form.py` to use `autocomplete="tel"` for `TELEGRAM_PHONE` instead of `off`.
- Added dynamically generated autocomplete attributes (`one-time-code` and `current-password`) in `showStepInput` to enhance mobile accessibility and native autofill.
- Added tests `test_autocomplete_attributes` and `test_dynamic_autocomplete_attributes` to verify the presence of the tags.

---
*PR created automatically by Jules for task [10199307148730550426](https://jules.google.com/task/10199307148730550426) started by @n24q02m*