### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in file creation

### DIFF
--- a/src/better_telegram_mcp/auth/per_user_session_store.py
+++ b/src/better_telegram_mcp/auth/per_user_session_store.py
@@ -29,6 +29,24 @@ _KDF_ITERATIONS = 600_000
 _NONCE_SIZE = 12
 
 
+def _secure_write(path: Path, data: bytes | str) -> None:
+    """Write data to a file securely, ensuring strict permissions on creation.
+
+    Uses os.open with O_CREAT and 0o600 to prevent TOCTOU window where file
+    could be briefly readable by others before chmod.
+    """
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    mode = stat.S_IRUSR | stat.S_IWUSR  # 0o600
+    fd = os.open(path, flags, mode)
+    try:
+        if isinstance(data, str):
+            os.write(fd, data.encode("utf-8"))
+        else:
+            os.write(fd, data)
+    finally:
+        os.close(fd)
+
+
 @dataclass
 class SessionInfo:
     """Per-user session metadata."""
@@ -76,11 +94,7 @@ class PerUserSessionStore:
     def _persist_salt(self, salt: bytes) -> None:
         """Save random salt to disk (called on first store)."""
         self._salt_path.parent.mkdir(parents=True, exist_ok=True)
-        self._salt_path.write_bytes(salt)
-        try:
-            self._salt_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
-        except OSError:
-            pass
+        _secure_write(self._salt_path, salt)
 
     @staticmethod
     def _resolve_or_generate_secret(data_dir: Path) -> str:
@@ -90,11 +104,7 @@ class PerUserSessionStore:
             return secret_path.read_text().strip()
         data_dir.mkdir(parents=True, exist_ok=True)
         secret = os.urandom(32).hex()
-        secret_path.write_text(secret)
-        try:
-            secret_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
-        except OSError:
-            pass  # Windows may not support chmod
+        _secure_write(secret_path, secret)
         return secret
 
     def _derive_key(self) -> bytes:
@@ -145,11 +155,7 @@ class PerUserSessionStore:
         self._cached_sessions = copy.deepcopy(sessions)
         plaintext = json.dumps(sessions).encode()
         encrypted = self._encrypt(plaintext)
-        self._path.write_bytes(encrypted)
-        try:
-            self._path.chmod(stat.S_IRUSR | stat.S_IWUSR)
-        except OSError:
-            pass
+        _secure_write(self._path, encrypted)
 
     def store(self, bearer: str, info: SessionInfo) -> None:
         """Store a session for the given bearer token."""

--- a/src/better_telegram_mcp/auth/per_user_session_store.py
+++ b/src/better_telegram_mcp/auth/per_user_session_store.py
@@ -35,7 +35,7 @@ def _secure_write(path: Path, data: bytes | str) -> None:
     Uses os.open with O_CREAT and 0o600 to prevent TOCTOU window where file
     could be briefly readable by others before chmod.
     """
-    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_BINARY", 0)
     mode = stat.S_IRUSR | stat.S_IWUSR  # 0o600
     fd = os.open(path, flags, mode)
     try:

--- a/src/better_telegram_mcp/transports/credential_store.py
+++ b/src/better_telegram_mcp/transports/credential_store.py
@@ -27,7 +27,7 @@ def _secure_write(path: Path, data: bytes | str) -> None:
     Uses os.open with O_CREAT and 0o600 to prevent TOCTOU window where file
     could be briefly readable by others before chmod.
     """
-    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_BINARY", 0)
     mode = stat.S_IRUSR | stat.S_IWUSR  # 0o600
     fd = os.open(path, flags, mode)
     try:

--- a/src/better_telegram_mcp/transports/credential_store.py
+++ b/src/better_telegram_mcp/transports/credential_store.py
@@ -21,6 +21,24 @@ _KDF_ITERATIONS = 600_000
 _NONCE_SIZE = 12
 
 
+def _secure_write(path: Path, data: bytes | str) -> None:
+    """Write data to a file securely, ensuring strict permissions on creation.
+
+    Uses os.open with O_CREAT and 0o600 to prevent TOCTOU window where file
+    could be briefly readable by others before chmod.
+    """
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    mode = stat.S_IRUSR | stat.S_IWUSR  # 0o600
+    fd = os.open(path, flags, mode)
+    try:
+        if isinstance(data, str):
+            os.write(fd, data.encode("utf-8"))
+        else:
+            os.write(fd, data)
+    finally:
+        os.close(fd)
+
+
 class CredentialStore:
     """Server-side encrypted credential storage.
 
@@ -51,11 +69,7 @@ class CredentialStore:
         # New installation: generate random salt
         salt = os.urandom(16)
         self._salt_path.parent.mkdir(parents=True, exist_ok=True)
-        self._salt_path.write_bytes(salt)
-        try:
-            self._salt_path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0o600
-        except OSError:
-            pass
+        _secure_write(self._salt_path, salt)
         return salt
 
     @staticmethod
@@ -66,11 +80,7 @@ class CredentialStore:
             return secret_path.read_text().strip()
         data_dir.mkdir(parents=True, exist_ok=True)
         secret = os.urandom(32).hex()
-        secret_path.write_text(secret)
-        try:
-            secret_path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0o600
-        except OSError:
-            pass  # Windows may not support chmod
+        _secure_write(secret_path, secret)
         return secret
 
     def _derive_key(self) -> bytes:
@@ -92,11 +102,7 @@ class CredentialStore:
         # Migrate from legacy hardcoded salt to random salt on re-encryption
         if self._salt == _LEGACY_SALT:
             new_salt = os.urandom(16)
-            self._salt_path.write_bytes(new_salt)
-            try:
-                self._salt_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
-            except OSError:
-                pass
+            _secure_write(self._salt_path, new_salt)
             self._salt = new_salt
             self._cached_key = None  # Force re-derivation
 
@@ -106,11 +112,7 @@ class CredentialStore:
         plaintext = json.dumps(credentials).encode()
         ciphertext = aesgcm.encrypt(nonce, plaintext, None)
         self._cached_credentials = copy.deepcopy(credentials)
-        self._path.write_bytes(nonce + ciphertext)
-        try:
-            self._path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0o600
-        except OSError:
-            pass  # Windows may not support chmod
+        _secure_write(self._path, nonce + ciphertext)
 
     def load(self) -> dict[str, str] | None:
         """Load and decrypt credentials. Returns None if not found."""

--- a/tests/test_transports/test_credential_store.py
+++ b/tests/test_transports/test_credential_store.py
@@ -212,17 +212,3 @@ class TestCredentialStore:
         salt_path = data_dir / ".salt"
         assert salt_path.exists()
         assert len(store._salt) == 16
-
-    def test_chmod_failure_swallowed(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-    ) -> None:
-        """Test that OSError during chmod is silently ignored."""
-
-        def mock_chmod(*args, **kwargs):
-            raise OSError("chmod failed")
-
-        monkeypatch.setattr("pathlib.Path.chmod", mock_chmod)
-
-        store = CredentialStore(tmp_path)
-        # Store writing triggers credential chmod
-        store.store({"api_id": "123"})

--- a/tests/test_utils/test_formatting.py
+++ b/tests/test_utils/test_formatting.py
@@ -82,7 +82,7 @@ def test_err_unicode_handling():
 
 def test_err_non_string_input():
     # err() expects a str, but json.dumps handles other types too
-    result = err(123)  # type: ignore
+    result = err(123)
     assert json.loads(result) == {"error": 123}
 
 


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Files for encryption salts, master secrets, and stored credentials were being written using `Path.write_bytes()` and `Path.write_text()`, and their permissions were restricted using `.chmod(0o600)` immediately afterward. This created a Time-of-Check Time-of-Use (TOCTOU) vulnerability where the sensitive files could potentially be read by unauthorized users during the brief window between creation and permission modification.
🎯 **Impact:** Unauthorized access to the master encryption secret or the encrypted stored sessions/credentials file by local users.
🔧 **Fix:** Introduced a `_secure_write` helper using `os.open` with `O_CREAT` and mode `0o600` (`stat.S_IRUSR | stat.S_IWUSR`). Replaced all unsafe file writing and delayed `chmod` calls with atomic secure writes in `src/better_telegram_mcp/transports/credential_store.py` and `src/better_telegram_mcp/auth/per_user_session_store.py`.
✅ **Verification:** Verified by ensuring the test suite passes properly and confirming no regression in storing and loading capabilities.

---
*PR created automatically by Jules for task [9965723357782371008](https://jules.google.com/task/9965723357782371008) started by @n24q02m*