### PR TITLE
🎨 Palette: Improve native autofill accessibility in credential form

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-05 - Focus First Invalid Input on Form Validation Failure
 **Learning:** Bringing focus to the first invalid input when client-side form validation fails is a low-effort, high-impact a11y/UX pattern that works natively without relying solely on screen reader ARIA live regions to announce errors.
 **Action:** Always add `.focus()` calls when interrupting form submissions with JS validation logic.
+## 2026-05-17 - Native Autofill Support
+**Learning:** Forms requiring sensitive data (like bot tokens acting as passwords, or OTPs) can significantly benefit from native mobile and browser autofill capabilities. The `autocomplete="one-time-code"` is particularly powerful for OTP flows as it allows iOS/Android to suggest codes received via SMS directly over the keyboard.
+**Action:** When designing or refactoring authentication forms, always ensure the `autocomplete` attributes are set accurately (e.g., `tel`, `current-password`, `one-time-code`) rather than just setting them to `"off"`.

--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -390,7 +390,7 @@ def render_telegram_credential_form(
                             type="password"
                             placeholder="123456:ABC-DEF..."
                             class="field-input"
-                            autocomplete="off"
+                            autocomplete="current-password"
                             autocorrect="off"
                             autocapitalize="off"
                             spellcheck="false"{bot_token_value_attr}
@@ -414,7 +414,7 @@ def render_telegram_credential_form(
                             type="tel"
                             placeholder="+84..."
                             class="field-input"
-                            autocomplete="off"
+                            autocomplete="tel"
                             autocorrect="off"
                             autocapitalize="off"
                             spellcheck="false"{phone_value_attr}
@@ -538,7 +538,7 @@ def render_telegram_credential_form(
                     inputEl = document.createElement("input");
                     inputEl.id = "step-input";
                     inputEl.className = "field-input";
-                    inputEl.setAttribute("autocomplete", "off");
+                    inputEl.setAttribute("autocomplete", "off"); // Set dynamically below based on ns.type
                     inputEl.setAttribute("autocorrect", "off");
                     inputEl.setAttribute("autocapitalize", "off");
                     inputEl.setAttribute("spellcheck", "false");
@@ -576,6 +576,7 @@ def render_telegram_credential_form(
 
                 promptEl.textContent = ns.text || "";
                 inputEl.setAttribute("type", ns.input_type || "text");
+                inputEl.setAttribute("autocomplete", ns.type === "otp_required" ? "one-time-code" : ns.type === "password_required" ? "current-password" : "off");
                 inputEl.setAttribute("placeholder", ns.placeholder || "");
                 inputEl.dataset.field = ns.field || "value";
                 inputEl.focus();

--- a/tests/test_credential_form.py
+++ b/tests/test_credential_form.py
@@ -30,12 +30,22 @@ def test_contains_bot_token_field() -> None:
     html = render_telegram_credential_form(SCHEMA, "/auth")
     assert "TELEGRAM_BOT_TOKEN" in html
     assert "BotFather" in html
+    assert 'autocomplete="current-password"' in html
 
 
 def test_contains_phone_field() -> None:
     html = render_telegram_credential_form(SCHEMA, "/auth")
     assert "TELEGRAM_PHONE" in html
     assert "MTProto" in html
+    assert 'autocomplete="tel"' in html
+
+
+def test_dynamic_autocomplete_script() -> None:
+    html = render_telegram_credential_form(SCHEMA, "/auth")
+    assert (
+        'ns.type === "otp_required" ? "one-time-code" : ns.type === "password_required" ? "current-password" : "off"'
+        in html
+    )
 
 
 def test_posts_to_submit_url() -> None:


### PR DESCRIPTION
💡 **What**: Added specific native `autocomplete` attributes (`"tel"`, `"current-password"`, `"one-time-code"`) to the Telegram credential form fields, replacing generic `"off"` values.
🎯 **Why**: To significantly enhance mobile accessibility and reduce friction for users attempting to log in, enabling device OS-level password managers and SMS OTP interception.
♿ **Accessibility**: Better support for screen readers via context-aware input definitions, and improved motor-accessibility by allowing 1-tap form filling.

---
*PR created automatically by Jules for task [15246828005613844309](https://jules.google.com/task/15246828005613844309) started by @n24q02m*