### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in credential and session file creation

### DIFF
--- a/src/better_telegram_mcp/auth/per_user_session_store.py
+++ b/src/better_telegram_mcp/auth/per_user_session_store.py
@@ -29,6 +29,19 @@ _KDF_ITERATIONS = 600_000
 _NONCE_SIZE = 12
 
 
+def _secure_write(path: Path, data: bytes) -> None:
+    """Write data to a file securely with 0o600 permissions."""
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    mode = stat.S_IRUSR | stat.S_IWUSR
+    fd = os.open(path, flags, mode)
+    try:
+        os.chmod(path, mode)  # Enforce permissions on existing files
+    except OSError:
+        pass  # Windows may not support chmod
+    with os.fdopen(fd, "wb") as f:
+        f.write(data)
+
+
 @dataclass
 class SessionInfo:
     """Per-user session metadata."""
@@ -76,11 +89,7 @@ class PerUserSessionStore:
     def _persist_salt(self, salt: bytes) -> None:
         """Save random salt to disk (called on first store)."""
         self._salt_path.parent.mkdir(parents=True, exist_ok=True)
-        self._salt_path.write_bytes(salt)
-        try:
-            self._salt_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
-        except OSError:
-            pass
+        _secure_write(self._salt_path, salt)
 
     @staticmethod
     def _resolve_or_generate_secret(data_dir: Path) -> str:
@@ -90,11 +99,7 @@ class PerUserSessionStore:
             return secret_path.read_text().strip()
         data_dir.mkdir(parents=True, exist_ok=True)
         secret = os.urandom(32).hex()
-        secret_path.write_text(secret)
-        try:
-            secret_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
-        except OSError:
-            pass  # Windows may not support chmod
+        _secure_write(secret_path, secret.encode("utf-8"))
         return secret
 
     def _derive_key(self) -> bytes:
@@ -145,11 +150,7 @@ class PerUserSessionStore:
         self._cached_sessions = copy.deepcopy(sessions)
         plaintext = json.dumps(sessions).encode()
         encrypted = self._encrypt(plaintext)
-        self._path.write_bytes(encrypted)
-        try:
-            self._path.chmod(stat.S_IRUSR | stat.S_IWUSR)
-        except OSError:
-            pass
+        _secure_write(self._path, encrypted)
 
     def store(self, bearer: str, info: SessionInfo) -> None:
         """Store a session for the given bearer token."""

--- a/src/better_telegram_mcp/transports/credential_store.py
+++ b/src/better_telegram_mcp/transports/credential_store.py
@@ -21,6 +21,19 @@ _KDF_ITERATIONS = 600_000
 _NONCE_SIZE = 12
 
 
+def _secure_write(path: Path, data: bytes) -> None:
+    """Write data to a file securely with 0o600 permissions."""
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    mode = stat.S_IRUSR | stat.S_IWUSR
+    fd = os.open(path, flags, mode)
+    try:
+        os.chmod(path, mode)  # Enforce permissions on existing files
+    except OSError:
+        pass  # Windows may not support chmod
+    with os.fdopen(fd, "wb") as f:
+        f.write(data)
+
+
 class CredentialStore:
     """Server-side encrypted credential storage.
 
@@ -51,11 +64,7 @@ class CredentialStore:
         # New installation: generate random salt
         salt = os.urandom(16)
         self._salt_path.parent.mkdir(parents=True, exist_ok=True)
-        self._salt_path.write_bytes(salt)
-        try:
-            self._salt_path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0o600
-        except OSError:
-            pass
+        _secure_write(self._salt_path, salt)
         return salt
 
     @staticmethod
@@ -66,11 +75,7 @@ class CredentialStore:
             return secret_path.read_text().strip()
         data_dir.mkdir(parents=True, exist_ok=True)
         secret = os.urandom(32).hex()
-        secret_path.write_text(secret)
-        try:
-            secret_path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0o600
-        except OSError:
-            pass  # Windows may not support chmod
+        _secure_write(secret_path, secret.encode("utf-8"))
         return secret
 
     def _derive_key(self) -> bytes:
@@ -92,11 +97,7 @@ class CredentialStore:
         # Migrate from legacy hardcoded salt to random salt on re-encryption
         if self._salt == _LEGACY_SALT:
             new_salt = os.urandom(16)
-            self._salt_path.write_bytes(new_salt)
-            try:
-                self._salt_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
-            except OSError:
-                pass
+            _secure_write(self._salt_path, new_salt)
             self._salt = new_salt
             self._cached_key = None  # Force re-derivation
 
@@ -106,11 +107,7 @@ class CredentialStore:
         plaintext = json.dumps(credentials).encode()
         ciphertext = aesgcm.encrypt(nonce, plaintext, None)
         self._cached_credentials = copy.deepcopy(credentials)
-        self._path.write_bytes(nonce + ciphertext)
-        try:
-            self._path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0o600
-        except OSError:
-            pass  # Windows may not support chmod
+        _secure_write(self._path, nonce + ciphertext)
 
     def load(self) -> dict[str, str] | None:
         """Load and decrypt credentials. Returns None if not found."""

--- a/tests/test_transports/test_credential_store.py
+++ b/tests/test_transports/test_credential_store.py
@@ -212,17 +212,3 @@ class TestCredentialStore:
         salt_path = data_dir / ".salt"
         assert salt_path.exists()
         assert len(store._salt) == 16
-
-    def test_chmod_failure_swallowed(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-    ) -> None:
-        """Test that OSError during chmod is silently ignored."""
-
-        def mock_chmod(*args, **kwargs):
-            raise OSError("chmod failed")
-
-        monkeypatch.setattr("pathlib.Path.chmod", mock_chmod)
-
-        store = CredentialStore(tmp_path)
-        # Store writing triggers credential chmod
-        store.store({"api_id": "123"})


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: A Time-of-Check to Time-of-Use (TOCTOU) window existed when persisting secret salts, encrypted sessions, and encrypted credentials. The system wrote the files using standard `.write_bytes()` functions and subsequently applied `os.chmod()` to lock permissions to `0o600`. In the short time interval between creation and the chmod operation, files could be potentially read by other users.
🎯 Impact: Local system users could potentially access sensitive keys or session tokens if they read the file in the microsecond window between writing and permission restriction.
🔧 Fix: Abstracted write actions in `transports/credential_store.py` and `auth/per_user_session_store.py` into a robust `_secure_write` function. This function uses `os.open(..., os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600)` to ensure files are born strictly restricted. The function further enforces security on any pre-existing files by calling `os.chmod(path, 0o600)` explicitly, and writes safety via `os.fdopen`.
✅ Verification: Ran relevant credential store tests (and refactored testing to reflect the loss of explicit `chmod` calls) guaranteeing no regressions. Code passes all linting (`ruff format`/`ruff check`) and the overall test suite.

---
*PR created automatically by Jules for task [4889142207980278466](https://jules.google.com/task/4889142207980278466) started by @n24q02m*