### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TOCTOU vulnerability in file writing

### DIFF
--- a/src/better_telegram_mcp/auth/per_user_session_store.py
+++ b/src/better_telegram_mcp/auth/per_user_session_store.py
@@ -29,6 +29,22 @@ _KDF_ITERATIONS = 600_000
 _NONCE_SIZE = 12
 
 
+def _secure_write_bytes(path: Path, data: bytes) -> None:
+    flags = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
+    mode = stat.S_IRUSR | stat.S_IWUSR
+    fd = os.open(path, flags, mode)
+    try:
+        os.chmod(path, mode)
+    except OSError:
+        pass
+    with os.fdopen(fd, "wb") as f:
+        f.write(data)
+
+
+def _secure_write_text(path: Path, text: str) -> None:
+    _secure_write_bytes(path, text.encode("utf-8"))
+
+
 @dataclass
 class SessionInfo:
     """Per-user session metadata."""
@@ -76,11 +92,7 @@ class PerUserSessionStore:
     def _persist_salt(self, salt: bytes) -> None:
         """Save random salt to disk (called on first store)."""
         self._salt_path.parent.mkdir(parents=True, exist_ok=True)
-        self._salt_path.write_bytes(salt)
-        try:
-            self._salt_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
-        except OSError:
-            pass
+        _secure_write_bytes(self._salt_path, salt)
 
     @staticmethod
     def _resolve_or_generate_secret(data_dir: Path) -> str:
@@ -90,11 +102,7 @@ class PerUserSessionStore:
             return secret_path.read_text().strip()
         data_dir.mkdir(parents=True, exist_ok=True)
         secret = os.urandom(32).hex()
-        secret_path.write_text(secret)
-        try:
-            secret_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
-        except OSError:
-            pass  # Windows may not support chmod
+        _secure_write_text(secret_path, secret)
         return secret
 
     def _derive_key(self) -> bytes:
@@ -145,11 +153,7 @@ class PerUserSessionStore:
         self._cached_sessions = copy.deepcopy(sessions)
         plaintext = json.dumps(sessions).encode()
         encrypted = self._encrypt(plaintext)
-        self._path.write_bytes(encrypted)
-        try:
-            self._path.chmod(stat.S_IRUSR | stat.S_IWUSR)
-        except OSError:
-            pass
+        _secure_write_bytes(self._path, encrypted)
 
     def store(self, bearer: str, info: SessionInfo) -> None:
         """Store a session for the given bearer token."""

--- a/src/better_telegram_mcp/transports/credential_store.py
+++ b/src/better_telegram_mcp/transports/credential_store.py
@@ -21,6 +21,22 @@ _KDF_ITERATIONS = 600_000
 _NONCE_SIZE = 12
 
 
+def _secure_write_bytes(path: Path, data: bytes) -> None:
+    flags = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
+    mode = stat.S_IRUSR | stat.S_IWUSR
+    fd = os.open(path, flags, mode)
+    try:
+        os.chmod(path, mode)
+    except OSError:
+        pass
+    with os.fdopen(fd, "wb") as f:
+        f.write(data)
+
+
+def _secure_write_text(path: Path, text: str) -> None:
+    _secure_write_bytes(path, text.encode("utf-8"))
+
+
 class CredentialStore:
     """Server-side encrypted credential storage.
 
@@ -51,11 +67,7 @@ class CredentialStore:
         # New installation: generate random salt
         salt = os.urandom(16)
         self._salt_path.parent.mkdir(parents=True, exist_ok=True)
-        self._salt_path.write_bytes(salt)
-        try:
-            self._salt_path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0o600
-        except OSError:
-            pass
+        _secure_write_bytes(self._salt_path, salt)
         return salt
 
     @staticmethod
@@ -66,11 +78,7 @@ class CredentialStore:
             return secret_path.read_text().strip()
         data_dir.mkdir(parents=True, exist_ok=True)
         secret = os.urandom(32).hex()
-        secret_path.write_text(secret)
-        try:
-            secret_path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0o600
-        except OSError:
-            pass  # Windows may not support chmod
+        _secure_write_text(secret_path, secret)
         return secret
 
     def _derive_key(self) -> bytes:
@@ -92,11 +100,7 @@ class CredentialStore:
         # Migrate from legacy hardcoded salt to random salt on re-encryption
         if self._salt == _LEGACY_SALT:
             new_salt = os.urandom(16)
-            self._salt_path.write_bytes(new_salt)
-            try:
-                self._salt_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
-            except OSError:
-                pass
+            _secure_write_bytes(self._salt_path, new_salt)
             self._salt = new_salt
             self._cached_key = None  # Force re-derivation
 
@@ -106,11 +110,7 @@ class CredentialStore:
         plaintext = json.dumps(credentials).encode()
         ciphertext = aesgcm.encrypt(nonce, plaintext, None)
         self._cached_credentials = copy.deepcopy(credentials)
-        self._path.write_bytes(nonce + ciphertext)
-        try:
-            self._path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0o600
-        except OSError:
-            pass  # Windows may not support chmod
+        _secure_write_bytes(self._path, nonce + ciphertext)
 
     def load(self) -> dict[str, str] | None:
         """Load and decrypt credentials. Returns None if not found."""


### PR DESCRIPTION
🛡️ **Sentinel: [CRITICAL] Fix insecure file creation (TOCTOU) vulnerability**

**🚨 Severity:** CRITICAL
**💡 Vulnerability:** Sensitive files (such as salts, API secrets, and AES-encrypted user credentials/session data) were being written to disk using standard `Path.write_bytes()` and `Path.write_text()`. These methods create files using the default umask (often `0644`, world-readable). The application subsequently invoked `os.chmod()` to restrict the file to `0o600`. This left a brief Time-Of-Check-To-Time-Of-Use (TOCTOU) window where local attackers could theoretically intercept the sensitive data.
**🎯 Impact:** Local privilege escalation/data leak. Any user on the host system could read the generated encryption secrets or credentials immediately upon creation before `chmod` took effect.
**🔧 Fix:** Implemented `_secure_write_bytes` and `_secure_write_text` helper functions. These use atomic system calls (`os.open` with `O_CREAT | O_WRONLY | O_TRUNC` and `0o600` mode) to guarantee the file is created with restricted permissions from the absolute start. Updated both `credential_store.py` and `per_user_session_store.py` to use these helpers.
**✅ Verification:** The fix is covered by existing test suites in `tests/test_transports/test_credential_store.py` and `tests/test_per_user_session_store.py` which have been executed and pass.

(Sentinel journal skipped as this pattern is now securely recorded via memory instructions.)

---
*PR created automatically by Jules for task [6238358745103566455](https://jules.google.com/task/6238358745103566455) started by @n24q02m*