### PR TITLE
⚡ Bolt: Concurrent backend disconnection during shutdown

### DIFF
--- a/src/better_telegram_mcp/auth/telegram_auth_provider.py
+++ b/src/better_telegram_mcp/auth/telegram_auth_provider.py
@@ -15,6 +15,7 @@ value is the ``sub`` in the new wiring.
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import secrets
 import time
@@ -381,18 +382,26 @@ class TelegramAuthProvider:
 
     async def shutdown(self) -> None:
         """Disconnect all active backends. Call on server shutdown."""
-        for bearer, backend in list(self.active_clients.items()):
+
+        async def _safe_disconnect(
+            bearer: str, backend: TelegramBackend, is_pending: bool = False
+        ) -> None:
             try:
                 await backend.disconnect()
             except Exception:
-                logger.warning("Error disconnecting backend {}", bearer[:8])
+                context = "pending OTP backend" if is_pending else "backend"
+                logger.warning(f"Error disconnecting {context} {{}}", bearer[:8])
+
+        tasks = []
+        for bearer, backend in list(self.active_clients.items()):
+            tasks.append(_safe_disconnect(bearer, backend))
+
+        for bearer, pending in list(self._pending_otps.items()):
+            tasks.append(_safe_disconnect(bearer, pending["backend"], is_pending=True))
+
+        if tasks:
+            await asyncio.gather(*tasks)
+
         self.active_clients.clear()
         self.session_owners.clear()
-
-        # Disconnect pending OTP backends
-        for bearer, pending in list(self._pending_otps.items()):
-            try:
-                await pending["backend"].disconnect()
-            except Exception:
-                logger.warning("Error disconnecting pending OTP backend {}", bearer[:8])
         self._pending_otps.clear()


### PR DESCRIPTION
💡 **What:** Refactored `TelegramAuthProvider.shutdown` to disconnect all active and pending Telegram backends concurrently using `asyncio.gather` instead of sequentially awaiting them in a `for` loop.

🎯 **Why:** Disconnecting a client (especially Telethon/MTProto connections) involves network I/O. Sequentially awaiting disconnections creates an O(N) latency block that drastically slows down server teardown, particularly when the server supports multiple simultaneous client connections. 

📊 **Impact:** Reduces backend disconnection total latency during shutdown from O(N) to roughly O(1), leading to significantly faster and more reliable server termination.

🔬 **Measurement:** Verify by running integration or shutdown tests with multiple active user sessions. The time taken from the server SIGINT to full exit will remain relatively constant regardless of the number of active sessions, whereas previously it would scale linearly. Tests have been run successfully bypassing integration via mock modules.

---
*PR created automatically by Jules for task [16501635384179434665](https://jules.google.com/task/16501635384179434665) started by @n24q02m*