### PR TITLE
🎨 Palette: Add ARIA live regions to dynamic form elements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-05 - Focus First Invalid Input on Form Validation Failure
 **Learning:** Bringing focus to the first invalid input when client-side form validation fails is a low-effort, high-impact a11y/UX pattern that works natively without relying solely on screen reader ARIA live regions to announce errors.
 **Action:** Always add `.focus()` calls when interrupting form submissions with JS validation logic.
+## 2026-05-18 - Adding ARIA Live Regions to Dynamic Form Elements
+**Learning:** When using vanilla JavaScript to dynamically inject status and error messages into the DOM, simply setting `display: block` or creating a new element is insufficient for screen readers. The parent container must have an appropriate ARIA role (`status` or `alert`) and `aria-live` attribute (`polite` or `assertive`) to trigger assistive technology announcements.
+**Action:** Proactively assign `role="status"` and `aria-live="polite"` for non-interruptive success/info messages, and `role="alert"` and `aria-live="assertive"` for critical errors when dynamically creating or updating elements in pure JS components.

--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -428,7 +428,7 @@ def render_telegram_credential_form(
 
                 <button type="submit" class="submit-btn" id="submit-btn">Connect</button>
 
-                <div class="status-box" id="status-box" role="alert"></div>
+                <div class="status-box" id="status-box" role="alert" aria-live="polite"></div>
             </form>
         </div>
     </div>
@@ -558,6 +558,7 @@ def render_telegram_credential_form(
                     errorEl.id = "step-error";
                     errorEl.className = "status-box error";
                     errorEl.setAttribute("role", "alert");
+                    errorEl.setAttribute("aria-live", "assertive");
                     errorEl.style.display = "none";
                     container.appendChild(errorEl);
 
@@ -622,6 +623,8 @@ def render_telegram_credential_form(
                                     }}
                                     var done = document.createElement("div");
                                     done.className = "status-box success";
+                                    done.setAttribute("role", "status");
+                                    done.setAttribute("aria-live", "polite");
                                     done.style.display = "block";
                                     if (typeof pendingRedirectUrl === "string" && pendingRedirectUrl.length > 0) {{
                                         done.textContent = "Setup complete! Redirecting...";


### PR DESCRIPTION
**💡 What:** Added `aria-live` and `role` attributes to the main status box, dynamic error elements, and success elements in `src/better_telegram_mcp/credential_form.py`.
**🎯 Why:** Since these status messages are dynamically injected into the DOM via JavaScript after fetch requests, screen readers will not naturally announce them unless explicitly instructed.
**♿ Accessibility:**
- Main status container (`#status-box`) now explicitly has `aria-live="polite"` so screen readers track its changes.
- Dynamically created step error elements now explicitly have `aria-live="assertive"`.
- Dynamically created done/success elements now use `role="status"` and `aria-live="polite"`.

---
*PR created automatically by Jules for task [11717314625108262401](https://jules.google.com/task/11717314625108262401) started by @n24q02m*