### PR TITLE
⚡ Bolt: Concurrent backend disconnections during shutdown

### DIFF
--- a/src/better_telegram_mcp/auth/telegram_auth_provider.py
+++ b/src/better_telegram_mcp/auth/telegram_auth_provider.py
@@ -381,18 +381,26 @@ class TelegramAuthProvider:
 
     async def shutdown(self) -> None:
         """Disconnect all active backends. Call on server shutdown."""
-        for bearer, backend in list(self.active_clients.items()):
+        import asyncio
+
+        async def _safe_disconnect(backend: TelegramBackend, bearer: str, label: str) -> None:
             try:
                 await backend.disconnect()
             except Exception:
-                logger.warning("Error disconnecting backend {}", bearer[:8])
+                logger.warning("Error disconnecting {} {}", label, bearer[:8])
+
+        # Bolt: Use asyncio.gather for concurrent execution instead of sequentially
+        # awaiting backend.disconnect() in a loop to prevent O(N) network latency
+        # from blocking the server during shutdown.
+        tasks = []
+        for bearer, backend in list(self.active_clients.items()):
+            tasks.append(_safe_disconnect(backend, bearer, "backend"))
+        for bearer, pending in list(self._pending_otps.items()):
+            tasks.append(_safe_disconnect(pending["backend"], bearer, "pending OTP backend"))
+
+        if tasks:
+            await asyncio.gather(*tasks)
+
         self.active_clients.clear()
         self.session_owners.clear()
-
-        # Disconnect pending OTP backends
-        for bearer, pending in list(self._pending_otps.items()):
-            try:
-                await pending["backend"].disconnect()
-            except Exception:
-                logger.warning("Error disconnecting pending OTP backend {}", bearer[:8])
         self._pending_otps.clear()

--- a/src/better_telegram_mcp/auth/telegram_auth_provider.py
+++ b/src/better_telegram_mcp/auth/telegram_auth_provider.py
@@ -383,7 +383,9 @@ class TelegramAuthProvider:
         """Disconnect all active backends. Call on server shutdown."""
         import asyncio
 
-        async def _safe_disconnect(backend: TelegramBackend, bearer: str, label: str) -> None:
+        async def _safe_disconnect(
+            backend: TelegramBackend, bearer: str, label: str
+        ) -> None:
             try:
                 await backend.disconnect()
             except Exception:
@@ -396,7 +398,9 @@ class TelegramAuthProvider:
         for bearer, backend in list(self.active_clients.items()):
             tasks.append(_safe_disconnect(backend, bearer, "backend"))
         for bearer, pending in list(self._pending_otps.items()):
-            tasks.append(_safe_disconnect(pending["backend"], bearer, "pending OTP backend"))
+            tasks.append(
+                _safe_disconnect(pending["backend"], bearer, "pending OTP backend")
+            )
 
         if tasks:
             await asyncio.gather(*tasks)


### PR DESCRIPTION
💡 **What:** Replaced sequential `await backend.disconnect()` calls with a single `await asyncio.gather(*tasks)` in `TelegramAuthProvider.shutdown()`. Also wrapped each call in a safe async helper to ensure isolated error handling.
🎯 **Why:** In multi-user mode, sequentially disconnecting each user's Telethon backend introduces O(N) network latency, slowing down server shutdown significantly.
📊 **Impact:** Reduces backend disconnection latency during shutdown from O(N) to O(1) in terms of network requests, making server restarts/shutdowns predictably fast.
🔬 **Measurement:** Can be verified by observing server shutdown time with many active sessions.

---
*PR created automatically by Jules for task [2513170487372212179](https://jules.google.com/task/2513170487372212179) started by @n24q02m*