### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in credential storage

### DIFF
--- a/src/better_telegram_mcp/auth/per_user_session_store.py
+++ b/src/better_telegram_mcp/auth/per_user_session_store.py
@@ -29,6 +29,26 @@ _KDF_ITERATIONS = 600_000
 _NONCE_SIZE = 12
 
 
+def _secure_write(path: Path, data: bytes | str) -> None:
+    """Securely write data to a file, avoiding TOCTOU vulnerability."""
+    # Ensure any existing file has strict permissions before we overwrite
+    try:
+        if path.exists():
+            path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+    except OSError:
+        pass
+
+    flags = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
+    mode = stat.S_IRUSR | stat.S_IWUSR  # 0o600
+    fd = os.open(path, flags, mode)
+    if isinstance(data, str):
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(data)
+    else:
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
+
+
 @dataclass
 class SessionInfo:
     """Per-user session metadata."""
@@ -76,11 +96,7 @@ class PerUserSessionStore:
     def _persist_salt(self, salt: bytes) -> None:
         """Save random salt to disk (called on first store)."""
         self._salt_path.parent.mkdir(parents=True, exist_ok=True)
-        self._salt_path.write_bytes(salt)
-        try:
-            self._salt_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
-        except OSError:
-            pass
+        _secure_write(self._salt_path, salt)
 
     @staticmethod
     def _resolve_or_generate_secret(data_dir: Path) -> str:
@@ -90,11 +106,7 @@ class PerUserSessionStore:
             return secret_path.read_text().strip()
         data_dir.mkdir(parents=True, exist_ok=True)
         secret = os.urandom(32).hex()
-        secret_path.write_text(secret)
-        try:
-            secret_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
-        except OSError:
-            pass  # Windows may not support chmod
+        _secure_write(secret_path, secret)
         return secret
 
     def _derive_key(self) -> bytes:
@@ -145,11 +157,7 @@ class PerUserSessionStore:
         self._cached_sessions = copy.deepcopy(sessions)
         plaintext = json.dumps(sessions).encode()
         encrypted = self._encrypt(plaintext)
-        self._path.write_bytes(encrypted)
-        try:
-            self._path.chmod(stat.S_IRUSR | stat.S_IWUSR)
-        except OSError:
-            pass
+        _secure_write(self._path, encrypted)
 
     def store(self, bearer: str, info: SessionInfo) -> None:
         """Store a session for the given bearer token."""

--- a/src/better_telegram_mcp/transports/credential_store.py
+++ b/src/better_telegram_mcp/transports/credential_store.py
@@ -21,6 +21,26 @@ _KDF_ITERATIONS = 600_000
 _NONCE_SIZE = 12
 
 
+def _secure_write(path: Path, data: bytes | str) -> None:
+    """Securely write data to a file, avoiding TOCTOU vulnerability."""
+    # Ensure any existing file has strict permissions before we overwrite
+    try:
+        if path.exists():
+            path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+    except OSError:
+        pass
+
+    flags = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
+    mode = stat.S_IRUSR | stat.S_IWUSR  # 0o600
+    fd = os.open(path, flags, mode)
+    if isinstance(data, str):
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(data)
+    else:
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
+
+
 class CredentialStore:
     """Server-side encrypted credential storage.
 
@@ -51,11 +71,7 @@ class CredentialStore:
         # New installation: generate random salt
         salt = os.urandom(16)
         self._salt_path.parent.mkdir(parents=True, exist_ok=True)
-        self._salt_path.write_bytes(salt)
-        try:
-            self._salt_path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0o600
-        except OSError:
-            pass
+        _secure_write(self._salt_path, salt)
         return salt
 
     @staticmethod
@@ -66,11 +82,7 @@ class CredentialStore:
             return secret_path.read_text().strip()
         data_dir.mkdir(parents=True, exist_ok=True)
         secret = os.urandom(32).hex()
-        secret_path.write_text(secret)
-        try:
-            secret_path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0o600
-        except OSError:
-            pass  # Windows may not support chmod
+        _secure_write(secret_path, secret)
         return secret
 
     def _derive_key(self) -> bytes:
@@ -92,11 +104,7 @@ class CredentialStore:
         # Migrate from legacy hardcoded salt to random salt on re-encryption
         if self._salt == _LEGACY_SALT:
             new_salt = os.urandom(16)
-            self._salt_path.write_bytes(new_salt)
-            try:
-                self._salt_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
-            except OSError:
-                pass
+            _secure_write(self._salt_path, new_salt)
             self._salt = new_salt
             self._cached_key = None  # Force re-derivation
 
@@ -106,11 +114,7 @@ class CredentialStore:
         plaintext = json.dumps(credentials).encode()
         ciphertext = aesgcm.encrypt(nonce, plaintext, None)
         self._cached_credentials = copy.deepcopy(credentials)
-        self._path.write_bytes(nonce + ciphertext)
-        try:
-            self._path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0o600
-        except OSError:
-            pass  # Windows may not support chmod
+        _secure_write(self._path, nonce + ciphertext)
 
     def load(self) -> dict[str, str] | None:
         """Load and decrypt credentials. Returns None if not found."""


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: Time-of-Check to Time-of-Use (TOCTOU) during sensitive credential file creation. The code wrote secrets to disk with default `umask` permissions and subsequently applied `chmod(0o600)`. 
🎯 **Impact**: Local attackers or untrusted processes on the same system could potentially read sensitive credential and encryption keys in the brief window between file creation and the `chmod` execution.
🔧 **Fix**: Replaced standard file writing with a `_secure_write` helper function utilizing `os.open(path, os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600)` and `os.fdopen()`, ensuring atomic permission locking upon file creation.
✅ **Verification**: Run `uv run pytest tests/test_transports/test_credential_store.py tests/test_per_user_session_store.py` to ensure credential storage operations succeed as expected.

---
*PR created automatically by Jules for task [18071073262174020782](https://jules.google.com/task/18071073262174020782) started by @n24q02m*