### PR TITLE
🎨 Palette: Add semantic autocomplete attributes to credential form

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-05 - Focus First Invalid Input on Form Validation Failure
 **Learning:** Bringing focus to the first invalid input when client-side form validation fails is a low-effort, high-impact a11y/UX pattern that works natively without relying solely on screen reader ARIA live regions to announce errors.
 **Action:** Always add `.focus()` calls when interrupting form submissions with JS validation logic.
+## 2026-05-19 - Improve autofill accessibility in credential form
+**Learning:** Adding the `autocomplete` attribute to form inputs with semantically correct values (like `current-password` and `tel`) is a high-impact micro-UX improvement. It drastically improves browser and password manager integration, enabling seamless autofill functionality, especially on mobile devices.
+**Action:** When designing or maintaining authentication forms (like `credential_form.py`), always verify that static and dynamically generated inputs have the appropriate `autocomplete` attributes, moving away from default `"off"` values where contextually relevant.

--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -390,7 +390,7 @@ def render_telegram_credential_form(
                             type="password"
                             placeholder="123456:ABC-DEF..."
                             class="field-input"
-                            autocomplete="off"
+                            autocomplete="current-password"
                             autocorrect="off"
                             autocapitalize="off"
                             spellcheck="false"{bot_token_value_attr}
@@ -414,7 +414,7 @@ def render_telegram_credential_form(
                             type="tel"
                             placeholder="+84..."
                             class="field-input"
-                            autocomplete="off"
+                            autocomplete="tel"
                             autocorrect="off"
                             autocapitalize="off"
                             spellcheck="false"{phone_value_attr}
@@ -538,7 +538,6 @@ def render_telegram_credential_form(
                     inputEl = document.createElement("input");
                     inputEl.id = "step-input";
                     inputEl.className = "field-input";
-                    inputEl.setAttribute("autocomplete", "off");
                     inputEl.setAttribute("autocorrect", "off");
                     inputEl.setAttribute("autocapitalize", "off");
                     inputEl.setAttribute("spellcheck", "false");
@@ -578,6 +577,13 @@ def render_telegram_credential_form(
                 inputEl.setAttribute("type", ns.input_type || "text");
                 inputEl.setAttribute("placeholder", ns.placeholder || "");
                 inputEl.dataset.field = ns.field || "value";
+                if (ns.type === "otp_required") {{
+                    inputEl.setAttribute("autocomplete", "one-time-code");
+                }} else if (ns.type === "password_required") {{
+                    inputEl.setAttribute("autocomplete", "current-password");
+                }} else {{
+                    inputEl.setAttribute("autocomplete", "off");
+                }}
                 inputEl.focus();
             }}
 

--- a/tests/test_credential_form.py
+++ b/tests/test_credential_form.py
@@ -209,3 +209,23 @@ def test_bot_token_only_prefill_marks_bot_token_required_only() -> None:
     bot_input = html.split('name="TELEGRAM_BOT_TOKEN"')[1].split("/>")[0]
     assert "required" in bot_input
     assert "required" not in phone_input
+
+
+def test_autocomplete_attributes() -> None:
+    """Inputs should have semantic autocomplete attributes."""
+    html = render_telegram_credential_form(SCHEMA, "/auth")
+
+    # Static bot mode input
+    bot_input = html.split('name="TELEGRAM_BOT_TOKEN"')[1].split("/>")[0]
+    assert 'autocomplete="current-password"' in bot_input
+
+    # Static user mode input
+    phone_input = html.split('name="TELEGRAM_PHONE"')[1].split("/>")[0]
+    assert 'autocomplete="tel"' in phone_input
+
+    # Should have dynamic JS assignment
+    assert 'inputEl.setAttribute("autocomplete", "one-time-code");' in html
+    assert 'inputEl.setAttribute("autocomplete", "current-password");' in html
+
+    # And a fallback for other types
+    assert 'inputEl.setAttribute("autocomplete", "off");' in html


### PR DESCRIPTION
Added semantic `autocomplete` attributes to static and dynamic form inputs to improve UX by enabling browser and password manager autofill support.

---
*PR created automatically by Jules for task [15670791505430875941](https://jules.google.com/task/15670791505430875941) started by @n24q02m*