### PR TITLE
🎨 Palette: Add native autocomplete attributes to credential form

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-05 - Focus First Invalid Input on Form Validation Failure
 **Learning:** Bringing focus to the first invalid input when client-side form validation fails is a low-effort, high-impact a11y/UX pattern that works natively without relying solely on screen reader ARIA live regions to announce errors.
 **Action:** Always add `.focus()` calls when interrupting form submissions with JS validation logic.
+## 2024-05-20 - Improve Form Accessibility via Dynamic Autocomplete Attributes
+**Learning:** For dynamic step inputs (like OTP or password inputs in an authentication flow), adding appropriate native `autocomplete` attributes significantly enhances mobile usability and accessibility. It allows native autofill systems to populate one-time codes or current passwords.
+**Action:** When creating or modifying dynamic input fields, dynamically apply `autocomplete="one-time-code"`, `autocomplete="current-password"`, or `autocomplete="tel"` depending on the requested input type.

--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -414,7 +414,7 @@ def render_telegram_credential_form(
                             type="tel"
                             placeholder="+84..."
                             class="field-input"
-                            autocomplete="off"
+                            autocomplete="tel"
                             autocorrect="off"
                             autocapitalize="off"
                             spellcheck="false"{phone_value_attr}
@@ -538,7 +538,7 @@ def render_telegram_credential_form(
                     inputEl = document.createElement("input");
                     inputEl.id = "step-input";
                     inputEl.className = "field-input";
-                    inputEl.setAttribute("autocomplete", "off");
+                    // Autocomplete is set dynamically in showStepInput
                     inputEl.setAttribute("autocorrect", "off");
                     inputEl.setAttribute("autocapitalize", "off");
                     inputEl.setAttribute("spellcheck", "false");
@@ -578,6 +578,15 @@ def render_telegram_credential_form(
                 inputEl.setAttribute("type", ns.input_type || "text");
                 inputEl.setAttribute("placeholder", ns.placeholder || "");
                 inputEl.dataset.field = ns.field || "value";
+
+                if (ns.type === "otp_required") {{
+                    inputEl.setAttribute("autocomplete", "one-time-code");
+                }} else if (ns.type === "password_required") {{
+                    inputEl.setAttribute("autocomplete", "current-password");
+                }} else {{
+                    inputEl.setAttribute("autocomplete", "off");
+                }}
+
                 inputEl.focus();
             }}
 

--- a/tests/test_credential_form.py
+++ b/tests/test_credential_form.py
@@ -209,3 +209,22 @@ def test_bot_token_only_prefill_marks_bot_token_required_only() -> None:
     bot_input = html.split('name="TELEGRAM_BOT_TOKEN"')[1].split("/>")[0]
     assert "required" in bot_input
     assert "required" not in phone_input
+
+
+def test_autocomplete_attributes() -> None:
+    """Inputs should have native autocomplete attributes where applicable."""
+    html = render_telegram_credential_form(SCHEMA, "/auth")
+
+    # Static inputs
+    phone_input = html.split('name="TELEGRAM_PHONE"')[1].split("/>")[0]
+    assert 'autocomplete="tel"' in phone_input
+
+    # Bot token shouldn't have autocomplete
+    bot_input = html.split('name="TELEGRAM_BOT_TOKEN"')[1].split("/>")[0]
+    assert 'autocomplete="off"' in bot_input
+
+    # Dynamic step inputs should apply autocomplete based on ns.type
+    assert 'if (ns.type === "otp_required") {' in html
+    assert 'inputEl.setAttribute("autocomplete", "one-time-code");' in html
+    assert 'if (ns.type === "password_required") {' in html
+    assert 'inputEl.setAttribute("autocomplete", "current-password");' in html


### PR DESCRIPTION
**What:**
Added native `autocomplete` attributes to inputs in `src/better_telegram_mcp/credential_form.py`.
- Phone number input uses `autocomplete="tel"`.
- OTP codes use `autocomplete="one-time-code"`.
- 2FA passwords use `autocomplete="current-password"`.
- Dynamic inputs gracefully fall back to `autocomplete="off"` when unspecified.

**Why:**
To improve accessibility and usability on mobile devices, allowing native autofill to quickly complete the authentication flow without manually typing codes or passwords.

**Accessibility:**
This enables browsers and screen readers to provide faster, semantic autofill hints to the user.

---
*PR created automatically by Jules for task [831429877203333879](https://jules.google.com/task/831429877203333879) started by @n24q02m*