### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in credential storage

### DIFF
--- a/src/better_telegram_mcp/auth/per_user_session_store.py
+++ b/src/better_telegram_mcp/auth/per_user_session_store.py
@@ -29,6 +29,18 @@ _KDF_ITERATIONS = 600_000
 _NONCE_SIZE = 12
 
 
+def _secure_write_bytes(path: Path, data: bytes) -> None:
+    flags = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
+    mode = stat.S_IRUSR | stat.S_IWUSR
+    fd = os.open(str(path), flags, mode)
+    try:
+        os.chmod(path, mode)
+    except OSError:
+        pass
+    with os.fdopen(fd, "wb") as f:
+        f.write(data)
+
+
 @dataclass
 class SessionInfo:
     """Per-user session metadata."""
@@ -76,11 +88,7 @@ class PerUserSessionStore:
     def _persist_salt(self, salt: bytes) -> None:
         """Save random salt to disk (called on first store)."""
         self._salt_path.parent.mkdir(parents=True, exist_ok=True)
-        self._salt_path.write_bytes(salt)
-        try:
-            self._salt_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
-        except OSError:
-            pass
+        _secure_write_bytes(self._salt_path, salt)
 
     @staticmethod
     def _resolve_or_generate_secret(data_dir: Path) -> str:
@@ -90,11 +98,7 @@ class PerUserSessionStore:
             return secret_path.read_text().strip()
         data_dir.mkdir(parents=True, exist_ok=True)
         secret = os.urandom(32).hex()
-        secret_path.write_text(secret)
-        try:
-            secret_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
-        except OSError:
-            pass  # Windows may not support chmod
+        _secure_write_bytes(secret_path, secret.encode())
         return secret
 
     def _derive_key(self) -> bytes:
@@ -145,11 +149,7 @@ class PerUserSessionStore:
         self._cached_sessions = copy.deepcopy(sessions)
         plaintext = json.dumps(sessions).encode()
         encrypted = self._encrypt(plaintext)
-        self._path.write_bytes(encrypted)
-        try:
-            self._path.chmod(stat.S_IRUSR | stat.S_IWUSR)
-        except OSError:
-            pass
+        _secure_write_bytes(self._path, encrypted)
 
     def store(self, bearer: str, info: SessionInfo) -> None:
         """Store a session for the given bearer token."""

--- a/src/better_telegram_mcp/transports/credential_store.py
+++ b/src/better_telegram_mcp/transports/credential_store.py
@@ -21,6 +21,18 @@ _KDF_ITERATIONS = 600_000
 _NONCE_SIZE = 12
 
 
+def _secure_write_bytes(path: Path, data: bytes) -> None:
+    flags = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
+    mode = stat.S_IRUSR | stat.S_IWUSR
+    fd = os.open(str(path), flags, mode)
+    try:
+        os.chmod(path, mode)
+    except OSError:
+        pass
+    with os.fdopen(fd, "wb") as f:
+        f.write(data)
+
+
 class CredentialStore:
     """Server-side encrypted credential storage.
 
@@ -51,11 +63,7 @@ class CredentialStore:
         # New installation: generate random salt
         salt = os.urandom(16)
         self._salt_path.parent.mkdir(parents=True, exist_ok=True)
-        self._salt_path.write_bytes(salt)
-        try:
-            self._salt_path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0o600
-        except OSError:
-            pass
+        _secure_write_bytes(self._salt_path, salt)
         return salt
 
     @staticmethod
@@ -66,11 +74,7 @@ class CredentialStore:
             return secret_path.read_text().strip()
         data_dir.mkdir(parents=True, exist_ok=True)
         secret = os.urandom(32).hex()
-        secret_path.write_text(secret)
-        try:
-            secret_path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0o600
-        except OSError:
-            pass  # Windows may not support chmod
+        _secure_write_bytes(secret_path, secret.encode())
         return secret
 
     def _derive_key(self) -> bytes:
@@ -92,11 +96,7 @@ class CredentialStore:
         # Migrate from legacy hardcoded salt to random salt on re-encryption
         if self._salt == _LEGACY_SALT:
             new_salt = os.urandom(16)
-            self._salt_path.write_bytes(new_salt)
-            try:
-                self._salt_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
-            except OSError:
-                pass
+            _secure_write_bytes(self._salt_path, new_salt)
             self._salt = new_salt
             self._cached_key = None  # Force re-derivation
 
@@ -106,11 +106,7 @@ class CredentialStore:
         plaintext = json.dumps(credentials).encode()
         ciphertext = aesgcm.encrypt(nonce, plaintext, None)
         self._cached_credentials = copy.deepcopy(credentials)
-        self._path.write_bytes(nonce + ciphertext)
-        try:
-            self._path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0o600
-        except OSError:
-            pass  # Windows may not support chmod
+        _secure_write_bytes(self._path, nonce + ciphertext)
 
     def load(self) -> dict[str, str] | None:
         """Load and decrypt credentials. Returns None if not found."""


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Time-Of-Check to Time-Of-Use (TOCTOU) vulnerability where sensitive cryptographic keys, salts, and session configurations were created using default permissions (e.g. `0o644` depending on umask) and later locked down using `os.chmod()`.
🎯 **Impact:** Malicious local processes or users on the same machine could race to read the file contents in the brief window between creation and the `chmod` operation, leading to the leak of API keys, encryption secrets, or OAuth tokens.
🔧 **Fix:** Implemented `_secure_write_bytes(path, data)` in both credential and session stores. This helper leverages `os.open(..., os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600)` to ensure files are initialized with the strictest permissions atomically. Existing file modes are also enforced via a `chmod` wrapper before writing.
✅ **Verification:** Verified by checking code changes, linting with `ruff`, running all test suites successfully. Code review confirmed the fix behaves safely on both POSIX and non-POSIX environments.

---
*PR created automatically by Jules for task [2593345572124507274](https://jules.google.com/task/2593345572124507274) started by @n24q02m*