### PR TITLE
🎨 Palette: Improve native autofill for phone, OTP, and password inputs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-05 - Focus First Invalid Input on Form Validation Failure
 **Learning:** Bringing focus to the first invalid input when client-side form validation fails is a low-effort, high-impact a11y/UX pattern that works natively without relying solely on screen reader ARIA live regions to announce errors.
 **Action:** Always add `.focus()` calls when interrupting form submissions with JS validation logic.
+## 2024-08-01 - Utilize Specific Autocomplete Attributes for Dynamic Injection
+**Learning:** For dynamically injected inputs handling sensitive or standard patterns like OTPs and passwords, using precise `autocomplete` attributes (`tel`, `one-time-code`, `current-password`) significantly enhances mobile accessibility and native autofill capabilities (SMS integration, password manager prompts).
+**Action:** Always map dynamically injected input contexts (such as `otp_code` or `password`) to their exact HTML5 `autocomplete` tokens rather than defaulting them all to `autocomplete="off"`.

--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -414,7 +414,7 @@ def render_telegram_credential_form(
                             type="tel"
                             placeholder="+84..."
                             class="field-input"
-                            autocomplete="off"
+                            autocomplete="tel"
                             autocorrect="off"
                             autocapitalize="off"
                             spellcheck="false"{phone_value_attr}
@@ -538,7 +538,13 @@ def render_telegram_credential_form(
                     inputEl = document.createElement("input");
                     inputEl.id = "step-input";
                     inputEl.className = "field-input";
-                    inputEl.setAttribute("autocomplete", "off");
+                    if (ns.field === "otp_code") {{
+                        inputEl.setAttribute("autocomplete", "one-time-code");
+                    }} else if (ns.field === "password") {{
+                        inputEl.setAttribute("autocomplete", "current-password");
+                    }} else {{
+                        inputEl.setAttribute("autocomplete", "off");
+                    }}
                     inputEl.setAttribute("autocorrect", "off");
                     inputEl.setAttribute("autocapitalize", "off");
                     inputEl.setAttribute("spellcheck", "false");

--- a/tests/test_credential_form.py
+++ b/tests/test_credential_form.py
@@ -200,6 +200,22 @@ def test_bot_mode_marks_bot_token_required_only() -> None:
     assert "required" not in phone_input
 
 
+def test_phone_field_uses_tel_autocomplete() -> None:
+    """Phone input must use autocomplete='tel' for mobile autofill."""
+    html = render_telegram_credential_form(SCHEMA, "/auth")
+    phone_input = html.split('name="TELEGRAM_PHONE"')[1].split("/>")[0]
+    assert 'autocomplete="tel"' in phone_input
+
+
+def test_dynamic_step_autocomplete_logic() -> None:
+    """Step logic must dynamically assign autocomplete for OTP and 2FA."""
+    html = render_telegram_credential_form(SCHEMA, "/auth")
+    assert 'ns.field === "otp_code"' in html
+    assert 'setAttribute("autocomplete", "one-time-code")' in html
+    assert 'ns.field === "password"' in html
+    assert 'setAttribute("autocomplete", "current-password")' in html
+
+
 def test_bot_token_only_prefill_marks_bot_token_required_only() -> None:
     """Bot mode with prefill: only bot token input has ``required`` attr."""
     html = render_telegram_credential_form(


### PR DESCRIPTION
🎨 Palette: Improve native autofill for phone, OTP, and password inputs

**What:** Replaced the blanket `autocomplete="off"` in `credential_form.py` with standard HTML5 autocomplete tokens (`tel`, `one-time-code`, `current-password`) where applicable.
**Why:** Enhances the user experience significantly on mobile devices and within password managers, allowing seamless one-tap native autofill of standard security inputs.
**Accessibility:** Promotes native screen-reader interactions by utilizing semantic browser inputs.

---
*PR created automatically by Jules for task [9633849534723996915](https://jules.google.com/task/9633849534723996915) started by @n24q02m*