### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in secure credential stores

### DIFF
--- a/src/better_telegram_mcp/auth/per_user_session_store.py
+++ b/src/better_telegram_mcp/auth/per_user_session_store.py
@@ -73,28 +73,48 @@ class PerUserSessionStore:
         # Legacy: use hardcoded salt for backward compat on first read
         return _LEGACY_SALT
 
+    @classmethod
+    def _secure_write(cls, path: Path, data: bytes) -> None:
+        """Securely write data to a file with 0o600 permissions to prevent TOCTOU."""
+        flags = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
+        mode = stat.S_IRUSR | stat.S_IWUSR  # 0o600
+        try:
+            fd = os.open(path, flags, mode)
+        except OSError:
+            # Fallback if os.open fails (e.g. unusual platform restrictions)
+            path.write_bytes(data)
+            try:
+                path.chmod(mode)
+            except OSError:
+                pass
+            return
+
+        try:
+            # os.open mode only applies to new files; enforce on existing files
+            try:
+                os.chmod(path, mode)
+            except OSError:
+                pass
+            with os.fdopen(fd, "wb") as f:
+                f.write(data)
+        except Exception:
+            os.close(fd)
+            raise
+
     def _persist_salt(self, salt: bytes) -> None:
         """Save random salt to disk (called on first store)."""
         self._salt_path.parent.mkdir(parents=True, exist_ok=True)
-        self._salt_path.write_bytes(salt)
-        try:
-            self._salt_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
-        except OSError:
-            pass
+        self._secure_write(self._salt_path, salt)
 
-    @staticmethod
-    def _resolve_or_generate_secret(data_dir: Path) -> str:
+    @classmethod
+    def _resolve_or_generate_secret(cls, data_dir: Path) -> str:
         """Load persisted secret or generate a new one."""
         secret_path = data_dir / ".secret"
         if secret_path.exists():
             return secret_path.read_text().strip()
         data_dir.mkdir(parents=True, exist_ok=True)
         secret = os.urandom(32).hex()
-        secret_path.write_text(secret)
-        try:
-            secret_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
-        except OSError:
-            pass  # Windows may not support chmod
+        cls._secure_write(secret_path, secret.encode("utf-8"))
         return secret
 
     def _derive_key(self) -> bytes:
@@ -145,11 +165,7 @@ class PerUserSessionStore:
         self._cached_sessions = copy.deepcopy(sessions)
         plaintext = json.dumps(sessions).encode()
         encrypted = self._encrypt(plaintext)
-        self._path.write_bytes(encrypted)
-        try:
-            self._path.chmod(stat.S_IRUSR | stat.S_IWUSR)
-        except OSError:
-            pass
+        self._secure_write(self._path, encrypted)
 
     def store(self, bearer: str, info: SessionInfo) -> None:
         """Store a session for the given bearer token."""

--- a/src/better_telegram_mcp/transports/credential_store.py
+++ b/src/better_telegram_mcp/transports/credential_store.py
@@ -39,6 +39,34 @@ class CredentialStore:
         self._cached_key: bytes | None = None
         self._cached_credentials: dict[str, str] | None = None
 
+    @classmethod
+    def _secure_write(cls, path: Path, data: bytes) -> None:
+        """Securely write data to a file with 0o600 permissions to prevent TOCTOU."""
+        flags = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
+        mode = stat.S_IRUSR | stat.S_IWUSR  # 0o600
+        try:
+            fd = os.open(path, flags, mode)
+        except OSError:
+            # Fallback if os.open fails (e.g. unusual platform restrictions)
+            path.write_bytes(data)
+            try:
+                path.chmod(mode)
+            except OSError:
+                pass
+            return
+
+        try:
+            # os.open mode only applies to new files; enforce on existing files
+            try:
+                os.chmod(path, mode)
+            except OSError:
+                pass
+            with os.fdopen(fd, "wb") as f:
+                f.write(data)
+        except Exception:
+            os.close(fd)
+            raise
+
     def _resolve_salt(self) -> bytes:
         """Load persisted salt, fallback to legacy, or generate new one."""
         if self._salt_path.exists():
@@ -51,26 +79,18 @@ class CredentialStore:
         # New installation: generate random salt
         salt = os.urandom(16)
         self._salt_path.parent.mkdir(parents=True, exist_ok=True)
-        self._salt_path.write_bytes(salt)
-        try:
-            self._salt_path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0o600
-        except OSError:
-            pass
+        self._secure_write(self._salt_path, salt)
         return salt
 
-    @staticmethod
-    def _resolve_or_generate_secret(data_dir: Path) -> str:
+    @classmethod
+    def _resolve_or_generate_secret(cls, data_dir: Path) -> str:
         """Load persisted secret or generate a new one."""
         secret_path = data_dir / ".secret"
         if secret_path.exists():
             return secret_path.read_text().strip()
         data_dir.mkdir(parents=True, exist_ok=True)
         secret = os.urandom(32).hex()
-        secret_path.write_text(secret)
-        try:
-            secret_path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0o600
-        except OSError:
-            pass  # Windows may not support chmod
+        cls._secure_write(secret_path, secret.encode("utf-8"))
         return secret
 
     def _derive_key(self) -> bytes:
@@ -92,11 +112,7 @@ class CredentialStore:
         # Migrate from legacy hardcoded salt to random salt on re-encryption
         if self._salt == _LEGACY_SALT:
             new_salt = os.urandom(16)
-            self._salt_path.write_bytes(new_salt)
-            try:
-                self._salt_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
-            except OSError:
-                pass
+            self._secure_write(self._salt_path, new_salt)
             self._salt = new_salt
             self._cached_key = None  # Force re-derivation
 
@@ -106,11 +122,7 @@ class CredentialStore:
         plaintext = json.dumps(credentials).encode()
         ciphertext = aesgcm.encrypt(nonce, plaintext, None)
         self._cached_credentials = copy.deepcopy(credentials)
-        self._path.write_bytes(nonce + ciphertext)
-        try:
-            self._path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0o600
-        except OSError:
-            pass  # Windows may not support chmod
+        self._secure_write(self._path, nonce + ciphertext)
 
     def load(self) -> dict[str, str] | None:
         """Load and decrypt credentials. Returns None if not found."""


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Time-Of-Check to Time-Of-Use (TOCTOU) vulnerability during sensitive file creation. Files containing cryptographic material (salts, secrets, encrypted session databases) in `CredentialStore` and `PerUserSessionStore` were being created with default system umask permissions and subsequently restricted via a separate `chmod` call. This left a brief window where malicious local processes could read the sensitive files.
🎯 **Impact:** Exfiltration of application server secrets, cryptographic salts, or decrypted Telegram session credentials by malicious actors with access to the same host environment.
🔧 **Fix:** Introduced a `_secure_write` method using `os.open(path, os.O_CREAT | os.O_WRONLY | os.O_TRUNC, stat.S_IRUSR | stat.S_IWUSR)`. This ensures that sensitive files are securely created with strictly restrictive `0o600` permissions right from the start. Includes fallback handling for atypical environments.
✅ **Verification:** Verified by running the test suite locally (`pytest` and `ruff`) and confirming the patch logic effectively handles new and existing file updates safely.

---
*PR created automatically by Jules for task [2143748386686517432](https://jules.google.com/task/2143748386686517432) started by @n24q02m*