### PR TITLE
🎨 Palette: Dynamic ARIA live regions for status messages

### DIFF
--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -485,6 +485,14 @@ def render_telegram_credential_form(
                 statusBox.className = "status-box " + type;
                 statusBox.textContent = message;
                 statusBox.style.display = "block";
+
+                if (type === "error") {{
+                    statusBox.setAttribute("role", "alert");
+                    statusBox.setAttribute("aria-live", "assertive");
+                }} else {{
+                    statusBox.setAttribute("role", "status");
+                    statusBox.setAttribute("aria-live", "polite");
+                }}
             }}
 
             // Derive /otp endpoint URL from submitUrl (replaces /authorize... with /otp).
@@ -560,6 +568,7 @@ def render_telegram_credential_form(
                     errorEl.id = "step-error";
                     errorEl.className = "status-box error";
                     errorEl.setAttribute("role", "alert");
+                    errorEl.setAttribute("aria-live", "assertive");
                     errorEl.style.display = "none";
                     container.appendChild(errorEl);
 
@@ -637,6 +646,8 @@ def render_telegram_credential_form(
                                     }}
                                     var done = document.createElement("div");
                                     done.className = "status-box success";
+                                    done.setAttribute("role", "status");
+                                    done.setAttribute("aria-live", "polite");
                                     done.style.display = "block";
                                     if (typeof pendingRedirectUrl === "string" && pendingRedirectUrl.length > 0) {{
                                         done.textContent = "Setup complete! Redirecting...";


### PR DESCRIPTION
💡 **What**: Added `role` and `aria-live` attributes to dynamically generated status messages and inline form errors inside the `credential_form.py` HTML template.

🎯 **Why**: Screen readers cannot inherently detect when standard DOM elements change text content. By explicitly tagging error messages as `role="alert"` / `aria-live="assertive"` and success states as `role="status"` / `aria-live="polite"`, visually impaired users are immediately informed of form validation states or successful submission without needing to manually locate the status text on the page.

♿ **Accessibility**: Significant improvement to form validation UX for keyboard and screen reader users.

---
*PR created automatically by Jules for task [11530271983071165934](https://jules.google.com/task/11530271983071165934) started by @n24q02m*