### PR TITLE
🎨 Palette: Restore input focus on network error in credential form

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,7 @@
 ## 2024-05-05 - Focus First Invalid Input on Form Validation Failure
 **Learning:** Bringing focus to the first invalid input when client-side form validation fails is a low-effort, high-impact a11y/UX pattern that works natively without relying solely on screen reader ARIA live regions to announce errors.
 **Action:** Always add `.focus()` calls when interrupting form submissions with JS validation logic.
+
+## 2024-06-25 - Focus Management in Async Forms
+**Learning:** In asynchronous form flows (e.g., fetch API calls in `credential_form.py`), failing to explicitly restore keyboard focus to the input field within error handling branches (like `.catch()` blocks) causes screen readers and keyboard users to lose their context upon network or validation failures. This creates a frustrating experience where users have to navigate back to the input to correct the issue.
+**Action:** Always ensure that keyboard focus is returned to the relevant interactive element (e.g., `inputEl.focus();`) after an asynchronous operation fails and the UI is reset.

--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -677,6 +677,7 @@ def render_telegram_credential_form(
                         buttonEl.disabled = false;
                         buttonEl.removeAttribute("aria-busy");
                         buttonEl.textContent = "Verify";
+                        inputEl.focus();
                     }});
             }}
 


### PR DESCRIPTION
🎨 **Palette: Restore Focus on Network Error**

**💡 What:** 
Added `inputEl.focus();` to the `.catch()` error handler of the `submitStep` fetch request in the Telegram credential form.

**🎯 Why:**
When an asynchronous validation step (like verifying an OTP code or password) fails due to a network error, the form removes the loading/disabled state and shows an error message. However, the keyboard focus was getting dropped because it wasn't explicitly returned to the input field. This forces keyboard and screen reader users to manually navigate back to the input to try again, which is a frustrating experience.

**♿ Accessibility:**
This micro-UX improvement ensures that context is never lost. By explicitly returning focus to the input element (`inputEl.focus();`), screen readers will immediately announce the input again, and keyboard users can seamlessly retry their submission without disruption.

---
*PR created automatically by Jules for task [3720723780387925238](https://jules.google.com/task/3720723780387925238) started by @n24q02m*