### PR TITLE
🎨 Palette: Improve credential form accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,7 @@
 ## 2024-06-25 - Focus Management in Async Forms
 **Learning:** In asynchronous form flows (e.g., fetch API calls in `credential_form.py`), failing to explicitly restore keyboard focus to the input field within error handling branches (like `.catch()` blocks) causes screen readers and keyboard users to lose their context upon network or validation failures. This creates a frustrating experience where users have to navigate back to the input to correct the issue.
 **Action:** Always ensure that keyboard focus is returned to the relevant interactive element (e.g., `inputEl.focus();`) after an asynchronous operation fails and the UI is reset.
+
+## 2024-07-28 - W3C ARIA Tablist Pattern Keyboard Navigation
+**Learning:** For custom tabbed interfaces (like the Bot Mode / User Mode toggle), setting `role="tablist"` and `role="tab"` is not enough for complete accessibility. Users relying on keyboard navigation expect the W3C ARIA Tablist pattern, which specifically dictates that `Tab` moves focus *into* the active tab, and `ArrowLeft` / `ArrowRight` navigate *between* tabs. Without this keyboard event handling, custom tab arrays remain difficult or confusing to navigate for screen reader and keyboard-only users.
+**Action:** When implementing custom tabs, always include a W3C-compliant roving `tabindex` (setting `tabindex="0"` on the active tab and `tabindex="-1"` on inactive tabs) and add `keydown` event listeners to handle `ArrowLeft` and `ArrowRight` keys for seamlessly shifting focus and selection between the tab buttons.

--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -66,6 +66,8 @@ def render_telegram_credential_form(
     user_tab_class = "tab active" if initial_tab == "user" else "tab"
     bot_tab_aria = "true" if initial_tab == "bot" else "false"
     user_tab_aria = "true" if initial_tab == "user" else "false"
+    bot_tab_tabindex = "0" if initial_tab == "bot" else "-1"
+    user_tab_tabindex = "0" if initial_tab == "user" else "-1"
     bot_panel_class = "tab-panel active" if initial_tab == "bot" else "tab-panel"
     user_panel_class = "tab-panel active" if initial_tab == "user" else "tab-panel"
     # ``required`` is set on the active panel's inputs only; the inactive
@@ -373,8 +375,8 @@ def render_telegram_credential_form(
             </div>
 
             <div class="tabs" role="tablist">
-                <button type="button" id="tab-bot" class="{bot_tab_class}" data-tab="bot" role="tab" aria-selected="{bot_tab_aria}" aria-controls="panel-bot">Bot Mode</button>
-                <button type="button" id="tab-user" class="{user_tab_class}" data-tab="user" role="tab" aria-selected="{user_tab_aria}" aria-controls="panel-user">User Mode</button>
+                <button type="button" id="tab-bot" class="{bot_tab_class}" data-tab="bot" role="tab" aria-selected="{bot_tab_aria}" tabindex="{bot_tab_tabindex}" aria-controls="panel-bot">Bot Mode</button>
+                <button type="button" id="tab-user" class="{user_tab_class}" data-tab="user" role="tab" aria-selected="{user_tab_aria}" tabindex="{user_tab_tabindex}" aria-controls="panel-user">User Mode</button>
             </div>
 
             <form id="credential-form" novalidate>
@@ -445,7 +447,9 @@ def render_telegram_credential_form(
 
             // --- Tab switching -------------------------------------------------
             var tabs = document.querySelectorAll(".tab");
-            tabs.forEach(function (tab) {{
+            var tabsArray = Array.prototype.slice.call(tabs);
+
+            tabs.forEach(function (tab, index) {{
                 tab.addEventListener("click", function () {{
                     if (tab.disabled) {{
                         return;
@@ -454,9 +458,11 @@ def render_telegram_credential_form(
                     tabs.forEach(function (t) {{
                         t.classList.remove("active");
                         t.setAttribute("aria-selected", "false");
+                        t.setAttribute("tabindex", "-1");
                     }});
                     tab.classList.add("active");
                     tab.setAttribute("aria-selected", "true");
+                    tab.setAttribute("tabindex", "0");
                     document.querySelectorAll(".tab-panel").forEach(function (p) {{
                         p.classList.remove("active");
                     }});
@@ -476,6 +482,24 @@ def render_telegram_credential_form(
                         panel.querySelectorAll(".field-input").forEach(function (i) {{
                             i.setAttribute("required", "");
                         }});
+                    }}
+                }});
+
+                // Keyboard navigation for W3C ARIA tablist pattern
+                tab.addEventListener("keydown", function(e) {{
+                    var targetIndex = -1;
+                    if (e.key === "ArrowRight") {{
+                        targetIndex = index + 1;
+                        if (targetIndex >= tabsArray.length) targetIndex = 0;
+                    }} else if (e.key === "ArrowLeft") {{
+                        targetIndex = index - 1;
+                        if (targetIndex < 0) targetIndex = tabsArray.length - 1;
+                    }}
+
+                    if (targetIndex !== -1) {{
+                        e.preventDefault();
+                        tabsArray[targetIndex].focus();
+                        tabsArray[targetIndex].click();
                     }}
                 }});
             }});
@@ -772,6 +796,15 @@ def render_telegram_credential_form(
                                 submitBtn.textContent = "Connect";
                                 form.querySelectorAll(".field-input").forEach(function (i) {{ i.disabled = false; }});
                                 tabs.forEach(function (t) {{ t.disabled = false; }});
+
+                                // Restore focus to the first visible input field so users can immediately correct it
+                                var activePanel = document.querySelector('.tab-panel.active');
+                                if (activePanel) {{
+                                    var firstInput = activePanel.querySelector('.field-input');
+                                    if (firstInput) {{
+                                        firstInput.focus();
+                                    }}
+                                }}
                             }}
                         }});
                     }})
@@ -782,6 +815,15 @@ def render_telegram_credential_form(
                         submitBtn.textContent = "Connect";
                         form.querySelectorAll(".field-input").forEach(function (i) {{ i.disabled = false; }});
                         tabs.forEach(function (t) {{ t.disabled = false; }});
+
+                        // Restore focus to the first visible input field so users can immediately correct it
+                        var activePanel = document.querySelector('.tab-panel.active');
+                        if (activePanel) {{
+                            var firstInput = activePanel.querySelector('.field-input');
+                            if (firstInput) {{
+                                firstInput.focus();
+                            }}
+                        }}
                     }});
             }});
         }})();


### PR DESCRIPTION
🎨 Palette: Credential Form Accessibility Improvements

💡 **What:** 
- Added the standard W3C ARIA tablist pattern to the Bot/User mode toggle, providing roving `tabindex` and full keyboard arrow navigation (`ArrowLeft`, `ArrowRight`).
- Implemented focus management logic in the asynchronous submit flow. If a credential verification request fails, the keyboard focus now automatically returns to the active input field.
- Documented these a11y patterns in `.jules/palette.md`.

🎯 **Why:** 
Previously, keyboard-only or screen reader users could easily access the tab controls but were unable to properly navigate them without native standard keyboard controls. Furthermore, failing form submission due to incorrect tokens or network errors would result in a loss of focus context, frustrating users who would have to tab repeatedly back into the form to retry.

♿ **Accessibility:**
- W3C ARIA Tablist pattern (Roving Tabindex + Arrow Key Navigation).
- Asynchronous form focus restoration (`.focus()` on active panel's first input upon `.catch` or error response).

---
*PR created automatically by Jules for task [5642974026641552578](https://jules.google.com/task/5642974026641552578) started by @n24q02m*