### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TOCTOU vulnerability in secure file writing

### DIFF
--- a/src/better_telegram_mcp/transports/credential_store.py
+++ b/src/better_telegram_mcp/transports/credential_store.py
@@ -56,15 +56,20 @@ def _atomic_write_bytes_0600(path: Path, data: bytes) -> None:
     if hasattr(os, "O_CLOEXEC"):
         flags |= os.O_CLOEXEC
     fd = os.open(str(path), flags, _OWNER_RW)
+
+    # os.open mode only applies to newly created files. We must explicitly chmod
+    # to enforce permissions on existing files before writing to avoid silent truncation.
     try:
-        os.write(fd, data)
-    finally:
-        os.close(fd)
-    try:
-        os.chmod(str(path), _OWNER_RW)
+        if hasattr(os, "fchmod"):
+            os.fchmod(fd, _OWNER_RW)
+        else:
+            os.chmod(str(path), _OWNER_RW)
     except OSError:
         # Windows may not support chmod / non-POSIX FS
         pass
+
+    with os.fdopen(fd, "wb") as f:
+        f.write(data)
 
 
 class CredentialStore:


### PR DESCRIPTION
This PR fixes a Time-of-Check to Time-of-Use (TOCTOU) vulnerability during secure file writing.

**Vulnerability:**
In `_atomic_write_bytes_0600`, `os.open` with `O_CREAT | O_WRONLY | O_TRUNC` and `0o600` mode correctly locks down newly created files, but on POSIX systems, `open()`'s `mode` parameter is ignored if the file already exists. The existing file retains its previous permissions. The code previously wrote the sensitive data with `os.write()` and *then* called `os.chmod(path, 0o600)`. If a file like `credentials.enc` was previously created with permissive permissions (e.g., `0644`), an attacker could read the sensitive data written to the file before `os.chmod` secured it.

**Fix:**
This PR calls `os.fchmod(fd, 0o600)` on the open file descriptor *before* any sensitive data is written, ensuring that the permissions are strict before the file is populated. It falls back to `os.chmod(path, 0o600)` if `os.fchmod` is not available (like on Windows). Additionally, it replaces `os.write(fd, data)` with `with os.fdopen(fd, "wb") as f: f.write(data)`. This ensures proper closing and prevents silent file truncation, as `os.write()` can write partial payloads without raising an error.

**Impact:**
Prevents brief periods of data exposure when overwriting sensitive credentials on POSIX systems and resolves potential silent data corruption.

---
*PR created automatically by Jules for task [3548440453389692245](https://jules.google.com/task/3548440453389692245) started by @n24q02m*