### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF routing bypass via case-sensitive scheme

### DIFF
--- a/src/better_telegram_mcp/backends/bot_backend.py
+++ b/src/better_telegram_mcp/backends/bot_backend.py
@@ -248,7 +248,7 @@ class BotBackend(TelegramBackend):
         }
         method = method_map.get(media_type, "sendDocument")
 
-        if file_path_or_url.startswith(("http://", "https://")):
+        if file_path_or_url.lower().startswith(("http://", "https://")):
             validate_url(file_path_or_url)
             field = media_type if media_type != "document" else "document"
             return await self._call(

--- a/src/better_telegram_mcp/backends/user_backend.py
+++ b/src/better_telegram_mcp/backends/user_backend.py
@@ -445,7 +445,7 @@ class UserBackend(TelegramBackend):
         elif media_type == "video":
             kwargs["video_note"] = False
 
-        if file_path_or_url.startswith(("http://", "https://")):
+        if file_path_or_url.lower().startswith(("http://", "https://")):
             validate_url(file_path_or_url)
         else:
             validate_file_path(file_path_or_url)


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix SSRF routing bypass via case-sensitive scheme

🚨 Severity: CRITICAL
💡 Vulnerability: The application used a case-sensitive `.startswith(("http://", "https://"))` check to route input to `validate_url` or `validate_file_path`. By using uppercase schemes (e.g., `HTTP://127.0.0.1/`), an attacker could bypass `validate_url`, falling through to `validate_file_path` (which ignored the scheme), and then the raw URL was passed to the underlying HTTP client, leading to Server-Side Request Forgery (SSRF).
🎯 Impact: Attackers could bypass SSRF protections and hit internal private networks (e.g. `127.0.0.1` or `169.254.169.254`) by providing mixed-case URL schemes.
🔧 Fix: Added `.lower()` before checking URL prefixes in media handlers (`bot_backend.py` and `user_backend.py`) to ensure all HTTP/HTTPS variations are securely routed through `validate_url`.
✅ Verification: Ran full unit test suite (557 tests pass) and verified case-insensitive checks correctly trigger `validate_url` to block internal IPs.

---
*PR created automatically by Jules for task [16865344032554892985](https://jules.google.com/task/16865344032554892985) started by @n24q02m*