### PR TITLE
🎨 Palette: Improve dark theme color contrast in credential form

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,3 +12,7 @@
 ## 2024-07-28 - W3C ARIA Tablist Pattern Keyboard Navigation
 **Learning:** For custom tabbed interfaces (like the Bot Mode / User Mode toggle), setting `role="tablist"` and `role="tab"` is not enough for complete accessibility. Users relying on keyboard navigation expect the W3C ARIA Tablist pattern, which specifically dictates that `Tab` moves focus *into* the active tab, and `ArrowLeft` / `ArrowRight` navigate *between* tabs. Without this keyboard event handling, custom tab arrays remain difficult or confusing to navigate for screen reader and keyboard-only users.
 **Action:** When implementing custom tabs, always include a W3C-compliant roving `tabindex` (setting `tabindex="0"` on the active tab and `tabindex="-1"` on inactive tabs) and add `keydown` event listeners to handle `ArrowLeft` and `ArrowRight` keys for seamlessly shifting focus and selection between the tab buttons.
+
+## 2024-07-28 - Contrast Requirements for Dark Themes
+**Learning:** Text using color `#666` fails WCAG AA 4.5:1 contrast requirements when placed against dark-themed backgrounds such as `#1a1a1a`.
+**Action:** When designing dark themes, ensure that subtle or secondary text elements (like `.server-id` and `.help-text`) are upgraded to at least `#888` or `#999` to maintain readability and accessibility standards.

--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -132,7 +132,7 @@ def render_telegram_credential_form(
 
         .server-id {{
             font-size: 0.8125rem;
-            color: #666;
+            color: #999;
             font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
             margin-bottom: 0.5rem;
         }}
@@ -213,6 +213,7 @@ def render_telegram_credential_form(
             font-weight: 500;
             color: #ccc;
             margin-bottom: 0.375rem;
+            cursor: pointer;
         }}
 
         .required-badge {{
@@ -253,7 +254,7 @@ def render_telegram_credential_form(
         }}
 
         .field-input::placeholder {{
-            color: #555;
+            color: #888;
         }}
 
         .field-input:disabled {{
@@ -264,7 +265,7 @@ def render_telegram_credential_form(
 
         .help-text {{
             font-size: 0.8125rem;
-            color: #666;
+            color: #999;
             margin-top: 0.375rem;
         }}
 


### PR DESCRIPTION
🎨 Palette: Improve dark theme color contrast in credential form

**💡 What:**
- Increased lightness of secondary text elements (`.server-id`, `.help-text`) in the credential form from `#666` to `#999`.
- Increased lightness of input placeholder text from `#555` to `#888`.
- Added a `cursor: pointer` style to the `.field-label` elements.
- Documented this contrast learning in the `.jules/palette.md` journal.

**🎯 Why:**
The original dark grey colors (`#666`, `#555`) fail the WCAG AA contrast ratio of 4.5:1 against the dark background colors (`#1a1a1a`, `#111`). This change improves the accessibility and readability of the form. Adding the pointer cursor to labels provides a clear visual cue that they are interactive and will focus the corresponding input.

**♿ Accessibility:**
- Improved color contrast for secondary text and placeholders to meet WCAG AA standards.
- Improved visual indication of label interactivity.

---
*PR created automatically by Jules for task [11624336799442264249](https://jules.google.com/task/11624336799442264249) started by @n24q02m*