### PR TITLE
⚡ Bolt: Revert get_messages to iter_messages to improve memory efficiency

### DIFF
--- a/src/better_telegram_mcp/backends/user_backend.py
+++ b/src/better_telegram_mcp/backends/user_backend.py
@@ -237,11 +237,13 @@ class UserBackend(TelegramBackend):
     ) -> list[dict[str, Any]]:
         client = self._ensure_client()
         entity = chat_id if chat_id is not None else None
-        # Bolt: Using get_messages() with search parameter is more efficient than
-        # async iteration (iter_messages) for retrieving a specific number of results,
-        # as it fetches them in a single bulk request.
-        messages = await client.get_messages(entity, search=query, limit=limit)
-        return [self._serialize_message(msg) for msg in messages]
+        # Bolt: Avoid the get_messages() anti-pattern, which just calls
+        # iter_messages(...).collect(). Using async comprehensions improves
+        # memory efficiency without worsening network latency.
+        return [
+            self._serialize_message(msg)
+            async for msg in client.iter_messages(entity, search=query, limit=limit)
+        ]
 
     async def get_history(
         self,
@@ -254,10 +256,13 @@ class UserBackend(TelegramBackend):
         kwargs: dict[str, Any] = {"limit": limit}
         if offset_id is not None:
             kwargs["offset_id"] = offset_id
-        # Bolt: using get_messages() is more efficient for fetching a specific
-        # number of messages as it avoids the overhead of async iteration.
-        messages = await client.get_messages(chat_id, **kwargs)
-        return [self._serialize_message(m) for m in messages]
+        # Bolt: Avoid the get_messages() anti-pattern, which just calls
+        # iter_messages(...).collect(). Using async comprehensions improves
+        # memory efficiency without worsening network latency.
+        return [
+            self._serialize_message(m)
+            async for m in client.iter_messages(chat_id, **kwargs)
+        ]
 
     # --- Chats ---
     async def list_chats(self, *, limit: int = 50) -> list[dict[str, Any]]:

--- a/tests/test_backends/test_user_backend.py
+++ b/tests/test_backends/test_user_backend.py
@@ -317,7 +317,14 @@ class TestSearchMessages:
 
         msgs = [_mock_message(msg_id=i, text=f"msg{i}") for i in range(3)]
 
-        mock_client.get_messages.return_value = msgs
+        mock_iter_messages = MagicMock()
+
+        async def mock_iter(*args, **kwargs):
+            mock_iter_messages(*args, **kwargs)
+            for m in msgs:
+                yield m
+
+        mock_client.iter_messages = mock_iter
 
         settings = _make_settings(tmp_path)
         backend = UserBackend(settings)
@@ -327,13 +334,21 @@ class TestSearchMessages:
 
         assert len(result) == 3
         assert result[0]["message_id"] == 0
+        mock_iter_messages.assert_called_once_with(None, search="test", limit=10)
 
     async def test_search_per_chat(self, tmp_path, mock_client, mock_client_class):
         from better_telegram_mcp.backends.user_backend import UserBackend
 
         msgs = [_mock_message(msg_id=1, text="found")]
 
-        mock_client.get_messages.return_value = msgs
+        mock_iter_messages = MagicMock()
+
+        async def mock_iter(*args, **kwargs):
+            mock_iter_messages(*args, **kwargs)
+            for m in msgs:
+                yield m
+
+        mock_client.iter_messages = mock_iter
 
         settings = _make_settings(tmp_path)
         backend = UserBackend(settings)
@@ -343,6 +358,7 @@ class TestSearchMessages:
 
         assert len(result) == 1
         assert result[0]["text"] == "found"
+        mock_iter_messages.assert_called_once_with(456, search="test", limit=5)
 
 
 class TestGetHistory:
@@ -351,7 +367,14 @@ class TestGetHistory:
 
         msgs = [_mock_message(msg_id=i) for i in range(5)]
 
-        mock_client.get_messages = AsyncMock(return_value=msgs)
+        mock_iter_messages = MagicMock()
+
+        async def mock_iter(*args, **kwargs):
+            mock_iter_messages(*args, **kwargs)
+            for m in msgs:
+                yield m
+
+        mock_client.iter_messages = mock_iter
 
         settings = _make_settings(tmp_path)
         backend = UserBackend(settings)
@@ -360,14 +383,21 @@ class TestGetHistory:
         result = await backend.get_history(123, limit=5)
 
         assert len(result) == 5
-        mock_client.get_messages.assert_awaited_once_with(123, limit=5)
+        mock_iter_messages.assert_called_once_with(123, limit=5)
 
     async def test_get_history_with_offset(
         self, tmp_path, mock_client, mock_client_class
     ):
         from better_telegram_mcp.backends.user_backend import UserBackend
 
-        mock_client.get_messages = AsyncMock(return_value=[])
+        mock_iter_messages = MagicMock()
+
+        async def mock_iter(*args, **kwargs):
+            mock_iter_messages(*args, **kwargs)
+            for _ in []:
+                yield _
+
+        mock_client.iter_messages = mock_iter
 
         settings = _make_settings(tmp_path)
         backend = UserBackend(settings)
@@ -375,7 +405,7 @@ class TestGetHistory:
 
         await backend.get_history(123, limit=10, offset_id=50)
 
-        mock_client.get_messages.assert_awaited_once_with(123, limit=10, offset_id=50)
+        mock_iter_messages.assert_called_once_with(123, limit=10, offset_id=50)
 
 
 class TestListChats:


### PR DESCRIPTION
💡 What: The optimization implemented
Replaced instances of `client.get_messages(...)` with `[self._serialize_message(msg) async for msg in client.iter_messages(...)]` within the UserBackend's message fetching methods (`search_messages` and `get_history`). Updated unit tests to correctly mock the `iter_messages` async generator.

🎯 Why: The performance problem it solves
Telethon's `get_messages()` function collects all results from `iter_messages()` into memory before returning them. This does not optimize network throughput but forces the server to materialize potentially large lists of Message objects simultaneously, increasing peak memory usage. Utilizing async comprehensions over `iter_messages` allows processing elements one-by-one.

📊 Impact: Expected performance improvement
Improves memory efficiency by avoiding intermediate full-list allocations of Telethon Message objects. Memory scaling remains bounded by the serialized output size rather than doubling during processing.

🔬 Measurement: How to verify the improvement
Run the full test suite (`uv run --no-sync pytest`). The modifications strictly preserve API functionality and external latency behavior. Memory improvements are mostly visible through allocation profiling when fetching large histories.

---
*PR created automatically by Jules for task [6050861486728184400](https://jules.google.com/task/6050861486728184400) started by @n24q02m*