### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF bypass via mixed-case URL schemes

### DIFF
--- a/src/better_telegram_mcp/backends/bot_backend.py
+++ b/src/better_telegram_mcp/backends/bot_backend.py
@@ -248,7 +248,7 @@ class BotBackend(TelegramBackend):
         }
         method = method_map.get(media_type, "sendDocument")
 
-        if file_path_or_url.startswith(("http://", "https://")):
+        if file_path_or_url.lower().startswith(("http://", "https://")):
             validate_url(file_path_or_url)
             field = media_type if media_type != "document" else "document"
             return await self._call(

--- a/src/better_telegram_mcp/backends/user_backend.py
+++ b/src/better_telegram_mcp/backends/user_backend.py
@@ -445,7 +445,7 @@ class UserBackend(TelegramBackend):
         elif media_type == "video":
             kwargs["video_note"] = False
 
-        if file_path_or_url.startswith(("http://", "https://")):
+        if file_path_or_url.lower().startswith(("http://", "https://")):
             validate_url(file_path_or_url)
         else:
             validate_file_path(file_path_or_url)

--- a/tests/test_backends/test_bot_backend.py
+++ b/tests/test_backends/test_bot_backend.py
@@ -297,6 +297,15 @@ async def test_send_media_url():
     assert result["message_id"] == 50
 
 
+async def test_send_media_mixed_case_url():
+    msg = {"message_id": 50}
+    bot = _make_bot(msg)
+    result = await bot.send_media(
+        123, "photo", "hTtPs://example.com/photo.jpg", caption="Nice"
+    )
+    assert result["message_id"] == 50
+
+
 async def test_send_media_file(tmp_path):
     f = tmp_path / "test.jpg"
     f.write_bytes(b"fake image data")

--- a/tests/test_backends/test_user_backend.py
+++ b/tests/test_backends/test_user_backend.py
@@ -913,7 +913,9 @@ class TestSendMedia:
             123, "https://example.com/photo.jpg", caption="Nice"
         )
 
-    async def test_send_media_mixed_case_url(self, tmp_path, mock_client, mock_client_class):
+    async def test_send_media_mixed_case_url(
+        self, tmp_path, mock_client, mock_client_class
+    ):
         from better_telegram_mcp.backends.user_backend import UserBackend
 
         mock_client.send_file = AsyncMock(return_value=_mock_message())

--- a/tests/test_backends/test_user_backend.py
+++ b/tests/test_backends/test_user_backend.py
@@ -913,6 +913,24 @@ class TestSendMedia:
             123, "https://example.com/photo.jpg", caption="Nice"
         )
 
+    async def test_send_media_mixed_case_url(self, tmp_path, mock_client, mock_client_class):
+        from better_telegram_mcp.backends.user_backend import UserBackend
+
+        mock_client.send_file = AsyncMock(return_value=_mock_message())
+
+        settings = _make_settings(tmp_path)
+        backend = UserBackend(settings)
+        await backend.connect()
+
+        result = await backend.send_media(
+            123, "photo", "hTtPs://example.com/photo.jpg", caption="Nice"
+        )
+
+        assert result["message_id"] == 1
+        mock_client.send_file.assert_awaited_once_with(
+            123, "hTtPs://example.com/photo.jpg", caption="Nice"
+        )
+
     async def test_send_voice(self, tmp_path, mock_client, mock_client_class):
         from better_telegram_mcp.backends.user_backend import UserBackend
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: SSRF bypass via mixed-case URL schemes in media handlers.
🎯 Impact: Attackers could provide mixed-case URLs (e.g., `hTtP://169.254.169.254/`) to bypass `validate_url()` protections against local and internal networks, causing the server to perform requests against restricted metadata or private endpoints.
🔧 Fix: Updated the prefix check in `bot_backend.py` and `user_backend.py` to use `.lower().startswith(("http://", "https://"))`, ensuring all valid HTTP/HTTPS URLs are properly routed to the SSRF validator before being processed.
✅ Verification: Covered by new unit tests `test_send_media_mixed_case_url` in both backend test suites to confirm mixed-case URLs are appropriately captured and validated.

---
*PR created automatically by Jules for task [13877185520446502283](https://jules.google.com/task/13877185520446502283) started by @n24q02m*