### PR TITLE
[FIX] Unused Import: annotations

### DIFF
--- a/src/better_telegram_mcp/transports/credential_store.py
+++ b/src/better_telegram_mcp/transports/credential_store.py
@@ -4,8 +4,6 @@ Credentials stored at: DATA_DIR/credentials.enc
 Key derived from server secret (CREDENTIAL_SECRET env var or auto-generated).
 """
 
-from __future__ import annotations
-
 import copy
 import json
 import os

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.1b1"
+version = "4.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
Removed the unused `from __future__ import annotations` import from `src/better_telegram_mcp/transports/credential_store.py`. This import was not needed for the current code and its removal has no side effects. Verified with existing unit tests and linting.

---
*PR created automatically by Jules for task [2260434254357835800](https://jules.google.com/task/2260434254357835800) started by @n24q02m*