### PR TITLE
[FIX] Unused Import: annotations

### DIFF
--- a/src/better_telegram_mcp/resources.py
+++ b/src/better_telegram_mcp/resources.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from mcp.server.fastmcp import FastMCP
 
 


### PR DESCRIPTION
This PR removes the unused `from __future__ import annotations` import from `src/better_telegram_mcp/resources.py`. 
The import was redundant as there are no forward references or complex type hints in the file that require it, especially given the project's Python 3.13 requirement. 
The change has been verified by running `ruff check` and relevant unit tests.

---
*PR created automatically by Jules for task [11630730711599791659](https://jules.google.com/task/11630730711599791659) started by @n24q02m*