### PR TITLE
[FIX] Unused Import: annotations

### DIFF
--- a/src/better_telegram_mcp/relay_setup.py
+++ b/src/better_telegram_mcp/relay_setup.py
@@ -11,8 +11,6 @@ verified through the ``/otp`` endpoint (see ``credential_state.save_credentials`
 and ``credential_state.on_step_submitted``).
 """
 
-from __future__ import annotations
-
 import re
 from pathlib import Path
 


### PR DESCRIPTION
This PR removes the unused `from __future__ import annotations` import from `src/better_telegram_mcp/relay_setup.py`. Since the project targets Python 3.13, modern type hinting syntax is natively supported, and this import is no longer necessary.

Changes:
- Removed `from __future__ import annotations` from `src/better_telegram_mcp/relay_setup.py`.

Verification:
- Ran `ruff check` and `ruff format` to ensure code quality.
- Ran `pytest tests/test_relay_setup.py` and all 29 tests passed.

---
*PR created automatically by Jules for task [3314565636248498828](https://jules.google.com/task/3314565636248498828) started by @n24q02m*