### PR TITLE
[FIX] Unused Import: annotations

### DIFF
--- a/src/better_telegram_mcp/tools/help_tool.py
+++ b/src/better_telegram_mcp/tools/help_tool.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import asyncio
 from pathlib import Path
 


### PR DESCRIPTION
Removed the redundant `from __future__ import annotations` import from `src/better_telegram_mcp/tools/help_tool.py`. Since the project targets Python 3.13, this import is unnecessary for modern type hint syntax used in this file.

Changes:
- Removed `from __future__ import annotations` from `src/better_telegram_mcp/tools/help_tool.py`.
- Formatted the file with `ruff format`.

Verification:
- Ran `PYTHONPATH=src uv run --no-sync pytest tests/test_tools/test_help_tool.py`.
- Ran `uv run --no-sync ruff check src/better_telegram_mcp/tools/help_tool.py`.
- Ran `uv run --no-sync ty check src/better_telegram_mcp/tools/help_tool.py`.
- Ran the core test suite to ensure no regressions.

---
*PR created automatically by Jules for task [17644812380794843061](https://jules.google.com/task/17644812380794843061) started by @n24q02m*