### PR TITLE
[TEST] Missing tests for _not_ready_response

### DIFF
--- a/tests/test_not_ready_response.py
+++ b/tests/test_not_ready_response.py
@@ -1,0 +1,30 @@
+import json
+
+import better_telegram_mcp.server as srv
+
+
+def test_not_ready_response_unconfigured():
+    """Test _not_ready_response when _unconfigured is True."""
+    old_unconfigured = srv._unconfigured
+    try:
+        srv._unconfigured = True
+        response = srv._not_ready_response()
+        data = json.loads(response)
+        assert data["error"] == "Not configured"
+        assert "setup" in data
+        assert "relay" in data["setup"]
+    finally:
+        srv._unconfigured = old_unconfigured
+
+
+def test_not_ready_response_authenticated_error():
+    """Test _not_ready_response when _unconfigured is False."""
+    old_unconfigured = srv._unconfigured
+    try:
+        srv._unconfigured = False
+        response = srv._not_ready_response()
+        data = json.loads(response)
+        assert "error" in data
+        assert "not authenticated" in data["error"].lower()
+    finally:
+        srv._unconfigured = old_unconfigured


### PR DESCRIPTION
This PR adds missing unit tests for the `_not_ready_response` function in `src/better_telegram_mcp/server.py`. 

The function `_not_ready_response` is used to inform the user when the server is not yet ready to handle requests, either because it's unconfigured or pending authentication. 

Changes:
- Created `tests/test_not_ready_response.py` with tests covering both logic branches.
- Verified that tests pass and that the codebase remains linted.

---
*PR created automatically by Jules for task [7543584357706991992](https://jules.google.com/task/7543584357706991992) started by @n24q02m*