### PR TITLE
[FIX] Unused Import: annotations

### DIFF
--- a/src/better_telegram_mcp/__main__.py
+++ b/src/better_telegram_mcp/__main__.py
@@ -1,6 +1,3 @@
-from __future__ import annotations
-
-
 def _cli() -> None:
     from .server import main
 


### PR DESCRIPTION
This PR removes the unused `from __future__ import annotations` import from `src/better_telegram_mcp/__main__.py`. This import is redundant in this file as there are no forward references or complex type hints that require it.

Changes:
- Removed `from __future__ import annotations` from `src/better_telegram_mcp/__main__.py`
- Verified the fix with `ruff check` and `ruff format`
- Successfully ran the unit test suite and a smoke test of the module (`python -m better_telegram_mcp --help`)

---
*PR created automatically by Jules for task [353481440912143663](https://jules.google.com/task/353481440912143663) started by @n24q02m*