### PR TITLE
[TEST] Missing edge case tests for _sanitize_error

### DIFF
--- a/tests/test_relay_setup.py
+++ b/tests/test_relay_setup.py
@@ -252,6 +252,25 @@ class TestSanitizeError:
     def test_passthrough_unknown_error(self):
         assert _sanitize_error("Some unknown error") == "Some unknown error"
 
+    def test_sanitize_error_empty(self):
+        assert _sanitize_error("") == ""
+
+    def test_sanitize_error_whitespace(self):
+        assert _sanitize_error("   ") == ""
+
+    def test_sanitize_error_long_string(self):
+        long_msg = "A" * 1000
+        assert _sanitize_error(long_msg) == long_msg
+
+    def test_sanitize_error_special_chars(self):
+        msg = "Error! @#$%^&*()_+"
+        assert _sanitize_error(msg) == msg
+
+    def test_sanitize_error_caused_by_variations(self):
+        assert _sanitize_error("Fail (CAUSED BY Error)") == "Fail"
+        assert _sanitize_error("Fail(caused by Error) ") == "Fail"
+        assert _sanitize_error("Fail (caused by 123)") == "Fail"
+
 
 # --- _needs_2fa_password ---
 

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.1b1"
+version = "4.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
This PR adds comprehensive edge case tests for the `_sanitize_error` utility in `src/better_telegram_mcp/relay_setup.py`. 

The added tests cover:
- Empty strings and whitespace-only strings.
- Very long strings (1000 characters).
- Strings containing special characters and symbols.
- Variations of the `(caused by ...)` suffix, including different casing, whitespace positioning, and internal content (e.g., numeric IDs).

These additions ensure the error sanitization logic remains robust across a variety of unexpected inputs. All 34 tests in `tests/test_relay_setup.py` passed successfully.

---
*PR created automatically by Jules for task [9490174447371677216](https://jules.google.com/task/9490174447371677216) started by @n24q02m*