### PR TITLE
[FIX] Unused Import: annotations

### DIFF
--- a/src/better_telegram_mcp/tools/contacts.py
+++ b/src/better_telegram_mcp/tools/contacts.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from pydantic import BaseModel, Field
 
 from ..backends.base import ModeError, TelegramBackend

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.1b1"
+version = "4.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
This PR removes the unused `from __future__ import annotations` import from `src/better_telegram_mcp/tools/contacts.py`.

The import was identified as redundant because the file does not contain any forward references or complex type hinting that necessitates its use, particularly in the context of the project's Python 3.13 target.

**Changes:**
- Removed `from __future__ import annotations` from `src/better_telegram_mcp/tools/contacts.py`.

**Verification:**
- Ran `uv run ruff check src/better_telegram_mcp/tools/contacts.py` (All checks passed).
- Ran `uv run ruff format src/better_telegram_mcp/tools/contacts.py` (No changes).
- Ran `uv run ty check src/better_telegram_mcp/tools/contacts.py` (All checks passed).
- Ran unit tests: `PYTHONPATH=src uv run --no-sync pytest tests/test_tools/test_contacts.py` (13 passed).

---
*PR created automatically by Jules for task [12319954050332866818](https://jules.google.com/task/12319954050332866818) started by @n24q02m*