### PR TITLE
[FIX] Unused Import: annotations

### DIFF
--- a/src/better_telegram_mcp/auth/in_memory_session_store.py
+++ b/src/better_telegram_mcp/auth/in_memory_session_store.py
@@ -12,8 +12,6 @@ See ~/projects/.superpower/mcp-core/specs/2026-04-30-trust-model-alignment.md
 § 4.D3 + § 5.A8.
 """
 
-from __future__ import annotations
-
 import copy
 
 from .per_user_session_store import SessionInfo


### PR DESCRIPTION
Removed the redundant `from __future__ import annotations` import from `src/better_telegram_mcp/auth/in_memory_session_store.py`. This import is unnecessary as the project targets Python 3.13 and no forward references requiring postponed evaluation are present in this module.

---
*PR created automatically by Jules for task [14198983473951353813](https://jules.google.com/task/14198983473951353813) started by @n24q02m*