### PR TITLE
[FIX] Unused Import: annotations

### DIFF
--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -10,8 +10,6 @@ form (same ``showStepInput``/``submitStep`` behavior, same ``/otp`` endpoint
 derivation) so the chained OTP flow works transparently.
 """
 
-from __future__ import annotations
-
 import html as html_module
 from typing import Any
 

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.1b1"
+version = "4.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
Removed unused `from __future__ import annotations` from `credential_form.py` as it is not needed for Python 3.13 and was flagged as unused.

---
*PR created automatically by Jules for task [8322595946844660573](https://jules.google.com/task/8322595946844660573) started by @n24q02m*