### PR TITLE
[FIX] Unused Import: annotations

### DIFF
--- a/src/better_telegram_mcp/tools/messages.py
+++ b/src/better_telegram_mcp/tools/messages.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Callable, Coroutine
 from typing import Any
 

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.1b1"
+version = "4.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
Removed the unused `from __future__ import annotations` import from `src/better_telegram_mcp/tools/messages.py`. This import was not being used for post-poned evaluation of annotations and was flagged by linting tools.

---
*PR created automatically by Jules for task [17297665401948237760](https://jules.google.com/task/17297665401948237760) started by @n24q02m*