### PR TITLE
[TEST] Missing tests for _needs_2fa_password

### DIFF
--- a/tests/test_relay_setup.py
+++ b/tests/test_relay_setup.py
@@ -257,20 +257,23 @@ class TestSanitizeError:
 
 
 class TestNeeds2faPassword:
-    def test_password_keyword(self):
-        assert _needs_2fa_password("SessionPasswordNeeded") is True
-
-    def test_2fa_keyword(self):
-        assert _needs_2fa_password("2fa authentication required") is True
-
-    def test_two_factor_keyword(self):
-        assert _needs_2fa_password("Two-factor auth needed") is True
-
-    def test_srp_keyword(self):
-        assert _needs_2fa_password("SRP protocol required") is True
-
-    def test_no_match(self):
-        assert _needs_2fa_password("Invalid phone number") is False
+    @pytest.mark.parametrize(
+        "error_msg,expected",
+        [
+            ("SESSION_PASSWORD_NEEDED", True),
+            ("SessionPasswordNeeded", True),
+            ("password required", True),
+            ("2fa authentication required", True),
+            ("Two-factor auth needed", True),
+            ("SRP protocol required", True),
+            ("Needs TWO-FACTOR", True),
+            ("Invalid phone number", False),
+            ("CODE_INVALID", False),
+            ("", False),
+        ],
+    )
+    def test_needs_2fa_password(self, error_msg: str, expected: bool):
+        assert _needs_2fa_password(error_msg) is expected
 
 
 # --- _is_user_mode_config ---

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.1b1"
+version = "4.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
Refactored TestNeeds2faPassword in tests/test_relay_setup.py to use pytest.mark.parametrize. Added comprehensive test cases including 'SESSION_PASSWORD_NEEDED', various case variations, and all keywords handled by the implementation ('password', '2fa', 'two-factor', 'srp'). Verified that 34 tests pass and src/better_telegram_mcp/relay_setup.py maintains 100% coverage.

---
*PR created automatically by Jules for task [9947044063783956873](https://jules.google.com/task/9947044063783956873) started by @n24q02m*