### PR TITLE
[FIX] Unused Import: annotations

### DIFF
--- a/src/better_telegram_mcp/tools/config_tool.py
+++ b/src/better_telegram_mcp/tools/config_tool.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Awaitable, Callable
 from typing import Any
 


### PR DESCRIPTION
This PR removes the redundant `from __future__ import annotations` directive from `src/better_telegram_mcp/tools/config_tool.py`. Since the project targets Python 3.13 and this specific module does not contain any forward references or complex type hints that require this import, it is safe to remove to reduce boilerplate and keep the code clean.

The change has been verified using `ruff check` and by running the existing unit test suite (`tests/test_tools/test_config_tool.py`), all of which passed.

---
*PR created automatically by Jules for task [12795530610216234228](https://jules.google.com/task/12795530610216234228) started by @n24q02m*