### PR TITLE
[FIX] Unused Import: annotations

### DIFF
--- a/src/better_telegram_mcp/utils/formatting.py
+++ b/src/better_telegram_mcp/utils/formatting.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import json
 from typing import Any
 

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.1b1"
+version = "4.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
Removed redundant `from __future__ import annotations` from `src/better_telegram_mcp/utils/formatting.py`. The project targets Python 3.13 where modern type hint syntax is natively supported, and this specific file contains no forward references requiring the import. Verified with unit tests and consumer check.

---
*PR created automatically by Jules for task [10486207541533009459](https://jules.google.com/task/10486207541533009459) started by @n24q02m*