### PR TITLE
[PERF] Awaiting in a loop during session cleanup

### DIFF
--- a/src/better_telegram_mcp/auth/telegram_auth_provider.py
+++ b/src/better_telegram_mcp/auth/telegram_auth_provider.py
@@ -353,32 +353,43 @@ class TelegramAuthProvider:
     async def cleanup_expired(self) -> int:
         """Remove expired sessions. Returns count of removed sessions."""
         sessions = self._store.load_all()
-        removed = 0
         now = time.time()
 
-        for bearer, info in sessions.items():
-            if now - info.created_at > _SESSION_TTL:
-                await self.revoke_session(bearer)
-                removed += 1
+        to_revoke = [
+            bearer
+            for bearer, info in sessions.items()
+            if now - info.created_at > _SESSION_TTL
+        ]
+        if to_revoke:
+            await asyncio.gather(*(self.revoke_session(b) for b in to_revoke))
 
         # Clean up stale pending OTPs (5 min TTL) using chronological insertion order.
         # Since start_user_auth pops-then-reinserts each bearer, the oldest entries
         # are always at the front, so we can stop at the first non-stale entry instead
         # of scanning the full dict on every cleanup tick.
+        to_disconnect_pending = []
         while self._pending_otps:
             bearer, pending = next(iter(self._pending_otps.items()))
             if now - pending["created_at"] <= 300:
                 break
             self._pending_otps.pop(bearer)
-            try:
-                await pending["backend"].disconnect()
-            except Exception as exc:  # pragma: no cover - best-effort cleanup
-                logger.warning(
-                    "Error disconnecting stale OTP backend {}: {}", bearer[:8], exc
-                )
-            removed += 1
+            to_disconnect_pending.append((bearer, pending))
 
-        return removed
+        if to_disconnect_pending:
+
+            async def _disconnect_stale(bearer: str, pending: dict) -> None:
+                try:
+                    await pending["backend"].disconnect()
+                except Exception as exc:  # pragma: no cover - best-effort cleanup
+                    logger.warning(
+                        "Error disconnecting stale OTP backend {}: {}", bearer[:8], exc
+                    )
+
+            await asyncio.gather(
+                *(_disconnect_stale(b, p) for b, p in to_disconnect_pending)
+            )
+
+        return len(to_revoke) + len(to_disconnect_pending)
 
     async def shutdown(self) -> None:
         """Disconnect all active backends concurrently. Call on server shutdown.

--- a/tests/test_telegram_auth_provider_cleanup.py
+++ b/tests/test_telegram_auth_provider_cleanup.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from loguru import logger
 
+from better_telegram_mcp.auth.per_user_session_store import SessionInfo
 from better_telegram_mcp.auth.telegram_auth_provider import TelegramAuthProvider
 
 
@@ -51,3 +52,62 @@ async def test_shutdown_logs_pending_otp_disconnect_error(
         assert "Error disconnecting pending OTP backend test-bea" in caplog.text
     finally:
         logger.remove(handler_id)
+
+
+async def test_cleanup_expired_sessions_and_otps(
+    provider: TelegramAuthProvider,
+) -> None:
+    """Verify that cleanup_expired correctly identifies and removes expired sessions and stale OTPs."""
+    now = time.time()
+
+    # 1. Setup expired and non-expired sessions
+    expired_info = SessionInfo(
+        session_name="expired",
+        mode="user",
+        phone="+111",
+        created_at=now - (40 * 24 * 60 * 60),
+    )
+    valid_info = SessionInfo(
+        session_name="valid", mode="user", phone="+222", created_at=now
+    )
+
+    provider._store.load_all = MagicMock(
+        return_value={"expired-bearer": expired_info, "valid-bearer": valid_info}
+    )
+
+    # Mock revoke_session
+    provider.revoke_session = AsyncMock(return_value=True)
+
+    # 2. Setup stale and non-stale pending OTPs
+    stale_backend = AsyncMock()
+    valid_backend = AsyncMock()
+
+    provider._pending_otps["stale-otp"] = {
+        "bearer": "stale-otp",
+        "backend": stale_backend,
+        "phone": "+333",
+        "phone_code_hash": "hash1",
+        "session_name": "s1",
+        "created_at": now - 600,  # 10 min ago
+    }
+    provider._pending_otps["valid-otp"] = {
+        "bearer": "valid-otp",
+        "backend": valid_backend,
+        "phone": "+444",
+        "phone_code_hash": "hash2",
+        "session_name": "s2",
+        "created_at": now,
+    }
+
+    # 3. Run cleanup
+    removed_count = await provider.cleanup_expired()
+
+    # 4. Verify results
+    # 1 expired session + 1 stale OTP
+    assert removed_count == 2
+    provider.revoke_session.assert_called_once_with("expired-bearer")
+    stale_backend.disconnect.assert_called_once()
+    valid_backend.disconnect.assert_not_called()
+
+    assert "stale-otp" not in provider._pending_otps
+    assert "valid-otp" in provider._pending_otps


### PR DESCRIPTION
Optimized `cleanup_expired` in `TelegramAuthProvider` to perform session revocations and pending OTP disconnections concurrently using `asyncio.gather`. This replaces the previous sequential loops, significantly improving cleanup performance when multiple items are expired or stale by avoiding O(N) network latency. Added targeted unit tests in `tests/test_telegram_auth_provider_cleanup.py`.

---
*PR created automatically by Jules for task [14350212825382308034](https://jules.google.com/task/14350212825382308034) started by @n24q02m*