### PR TITLE
[FIX] Unused Import: annotations in credential_state.py

### DIFF
--- a/src/better_telegram_mcp/credential_state.py
+++ b/src/better_telegram_mcp/credential_state.py
@@ -15,8 +15,6 @@ Hot-reload: after credentials land, the ``on_configured`` callback
 work immediately without restart.
 """
 
-from __future__ import annotations
-
 import contextvars
 import os
 from collections.abc import Awaitable, Callable


### PR DESCRIPTION
This PR removes the unused `from __future__ import annotations` import from `src/better_telegram_mcp/credential_state.py`. This import is redundant for the project's Python 3.13 target as no forward references requiring postponed evaluation are present in this module. The fix ensures a cleaner codebase and adheres to standard linting best practices. 

Verification performed:
- `ruff check` and `ruff format` passed.
- Core unit tests (`pytest tests/test_credential_state.py` and the full suite) passed (559/559).

---
*PR created automatically by Jules for task [13554026793865484835](https://jules.google.com/task/13554026793865484835) started by @n24q02m*