### PR TITLE
[FIX] Unused Import: annotations

### DIFF
--- a/src/better_telegram_mcp/transports/http.py
+++ b/src/better_telegram_mcp/transports/http.py
@@ -25,8 +25,6 @@ Per spec ``2026-05-01-stdio-pure-http-multiuser.md``: there is no
 is handled in ``server.main()`` and never reaches this module.
 """
 
-from __future__ import annotations
-
 import os
 from contextvars import ContextVar
 from typing import Any


### PR DESCRIPTION
Removed the redundant `from __future__ import annotations` from `src/better_telegram_mcp/transports/http.py`. This import is unnecessary in Python 3.13 as the file does not use forward references that require it for the current type hints. Verified that the removal does not break functionality or tests.

---
*PR created automatically by Jules for task [5491568486649513022](https://jules.google.com/task/5491568486649513022) started by @n24q02m*