### PR TITLE
[FIX] Unused Import: main

### DIFF
--- a/src/better_telegram_mcp/__init__.py
+++ b/src/better_telegram_mcp/__init__.py
@@ -1,10 +1,8 @@
 from importlib.metadata import PackageNotFoundError, version
 
-from .__main__ import _cli as main
-
 try:
     __version__ = version("better-telegram-mcp")
 except PackageNotFoundError:
     __version__ = "unknown"
 
-__all__ = ["main", "__version__"]
+__all__ = ["__version__"]

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.1b1"
+version = "4.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
Removed the unused import `main` (aliased from `_cli`) and its inclusion in `__all__` from `src/better_telegram_mcp/__init__.py`. This cleanup reduces the public API surface and resolves a linting issue. The CLI entry point remains fully functional as it is correctly defined in `pyproject.toml` pointing to `better_telegram_mcp.__main__:_cli`, and existing tests in `tests/test_main.py` and `tests/test_cli.py` confirm this.

---
*PR created automatically by Jules for task [634767946069978772](https://jules.google.com/task/634767946069978772) started by @n24q02m*