### PR TITLE
[TEST] Missing error test for server.message

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -77,6 +77,29 @@ async def test_message_send(mock_backend):
 
 
 @pytest.mark.asyncio
+async def test_message_backend_exception(mock_backend):
+    """message tool returns error string when backend raises an exception."""
+    import better_telegram_mcp.server as srv
+    from better_telegram_mcp.server import message
+
+    old_backend = srv._backend
+    old_pending = srv._pending_auth
+    try:
+        srv._backend = mock_backend
+        srv._pending_auth = False
+        mock_backend.send_message.side_effect = RuntimeError("Backend failure")
+
+        result_str = await message(action="send", chat_id=123, text="hi")
+        result = json.loads(result_str)
+        assert "error" in result
+        assert "RuntimeError" in result["error"]
+        assert "Operation failed" in result["error"]
+    finally:
+        srv._backend = old_backend
+        srv._pending_auth = old_pending
+
+
+@pytest.mark.asyncio
 async def test_chat_list(mock_backend):
     import better_telegram_mcp.server as srv
     from better_telegram_mcp.server import chat


### PR DESCRIPTION
Added `test_message_backend_exception` to `tests/test_server.py` to verify that the `message` tool correctly catches and returns exceptions raised by the backend. This improves test coverage for the tool's error handling path.

---
*PR created automatically by Jules for task [15026307292969003774](https://jules.google.com/task/15026307292969003774) started by @n24q02m*