### PR TITLE
[FIX] Unused Import: annotations

### DIFF
--- a/src/better_telegram_mcp/config.py
+++ b/src/better_telegram_mcp/config.py
@@ -1,10 +1,8 @@
-from __future__ import annotations
-
 import functools
 import os
 from functools import cached_property
 from pathlib import Path
-from typing import Literal
+from typing import Literal, Self
 
 from pydantic import model_validator
 from pydantic_settings import BaseSettings
@@ -51,7 +49,7 @@ class Settings(BaseSettings):
         )
 
     @model_validator(mode="after")
-    def _detect_mode(self) -> Settings:
+    def _detect_mode(self) -> Self:
         # Normalize empty strings to None (plugin.json sets env vars to "" by default)
         self.bot_token = _empty_to_none(self.bot_token)
         self.api_hash = _empty_to_none(self.api_hash)
@@ -82,7 +80,7 @@ class Settings(BaseSettings):
         )
 
     @classmethod
-    def from_relay_config(cls, config: dict[str, str]) -> Settings:
+    def from_relay_config(cls, config: dict[str, str]) -> Self:
         """Create Settings from relay config dict (from config file or relay setup).
 
         Args:


### PR DESCRIPTION
Refactored `src/better_telegram_mcp/config.py` to remove `from __future__ import annotations`. 
Since the project targets Python 3.13, forward references within the `Settings` class have been updated to use `typing.Self`, making the future import truly unnecessary while maintaining modern type hinting practices.

Verified with:
- `uv run ruff check`
- `uv run pytest tests/test_config.py`
- Manual import smoke test

---
*PR created automatically by Jules for task [763807615826567569](https://jules.google.com/task/763807615826567569) started by @n24q02m*