### PR TITLE
[FIX] Unused Import: annotations

### DIFF
--- a/src/better_telegram_mcp/tools/chats.py
+++ b/src/better_telegram_mcp/tools/chats.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Awaitable, Callable
 from typing import Any
 

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.1b1"
+version = "4.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
The `from __future__ import annotations` import in `src/better_telegram_mcp/tools/chats.py` was unused. Since the project targets Python 3.13 and there are no forward references in this specific file, the import is redundant and has been removed to clean up the code.

Verification:
- Run `uv run ruff check . --fix` and `uv run ruff format .` (passed)
- Run `uv run ty check` (passed with unrelated warnings)
- Run `PYTHONPATH=src uv run --no-sync pytest tests/test_tools/test_chats.py` (passed)
- Run full non-integration test suite (passed)

---
*PR created automatically by Jules for task [6310551325276894575](https://jules.google.com/task/6310551325276894575) started by @n24q02m*