### PR TITLE
[FIX] Potential Exposure of Telegram Bot Token in Error Messages

### DIFF
--- a/src/better_telegram_mcp/backends/bot_backend.py
+++ b/src/better_telegram_mcp/backends/bot_backend.py
@@ -26,21 +26,37 @@ class BotBackend(TelegramBackend):
         self._connected = False
         self._bot_info: dict[str, Any] = {}
 
+    def _redact(self, message: str) -> str:
+        if not self._token:
+            return message
+        return message.replace(self._token, "[REDACTED]")
+
     async def _call(self, method: str, **params: Any) -> Any:
-        data = {k: v for k, v in params.items() if v is not None}
-        resp = await self._client.post(method, json=data)
-        body = resp.json()
+        try:
+            data = {k: v for k, v in params.items() if v is not None}
+            resp = await self._client.post(method, json=data)
+            body = resp.json()
+        except Exception as e:
+            raise TelegramAPIError(self._redact(str(e))) from e
+
         if not body.get("ok"):
             desc = body.get("description", "Unknown error")
-            raise TelegramAPIError(desc, body.get("error_code", resp.status_code))
+            raise TelegramAPIError(
+                self._redact(desc), body.get("error_code", resp.status_code)
+            )
         return body.get("result")
 
     async def _call_form(self, method: str, files: dict, **params: Any) -> Any:
-        data = {k: str(v) for k, v in params.items() if v is not None}
-        resp = await self._client.post(method, data=data, files=files)
-        body = resp.json()
+        try:
+            data = {k: str(v) for k, v in params.items() if v is not None}
+            resp = await self._client.post(method, data=data, files=files)
+            body = resp.json()
+        except Exception as e:
+            raise TelegramAPIError(self._redact(str(e))) from e
+
         if not body.get("ok"):
-            raise TelegramAPIError(body.get("description", "Unknown error"))
+            desc = body.get("description", "Unknown error")
+            raise TelegramAPIError(self._redact(desc))
         return body.get("result")
 
     # --- Connection ---
@@ -55,7 +71,9 @@ class BotBackend(TelegramBackend):
                     "https://t.me/BotFather"
                 )
                 raise TelegramAPIError(msg) from e
-            raise ConnectionError(f"Failed to connect to Bot API: {e}") from e
+            raise ConnectionError(
+                self._redact(f"Failed to connect to Bot API: {e}")
+            ) from e
 
     async def disconnect(self) -> None:
         await self._client.aclose()

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.1b1"
+version = "4.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
This PR addresses a security concern where the Telegram Bot Token could be exposed in exception strings during network failures or API errors.

### Changes:
- **`BotBackend._redact`**: A new helper method that replaces any instance of the `self._token` with `"[REDACTED]"`.
- **`BotBackend._call` & `_call_form`**: Wrapped `httpx` requests and JSON decoding in `try...except` blocks. If an exception occurs (e.g., `ConnectError` containing the URL with the token), the exception message is redacted before being re-raised as a `TelegramAPIError`.
- **`BotBackend.connect`**: Updated to ensure that the `ConnectionError` raised upon connection failure also passes its message through `_redact`.

### Verification:
- Created a reproduction script that simulated `httpx` errors and verified that the token was successfully replaced with `[REDACTED]` in the resulting exception string.
- Ran the full test suite (`pytest tests`), which passed with 559 successful tests.
- Verified code style with `ruff`.

---
*PR created automatically by Jules for task [12563657707922206375](https://jules.google.com/task/12563657707922206375) started by @n24q02m*