### PR TITLE
[FIX] Predictable Salt Used for PBKDF2 Key Derivation

### DIFF
--- a/src/better_telegram_mcp/auth/per_user_session_store.py
+++ b/src/better_telegram_mcp/auth/per_user_session_store.py
@@ -71,8 +71,15 @@ class PerUserSessionStore:
         """Load persisted salt, fallback to legacy, or generate new one."""
         if self._salt_path.exists():
             return self._salt_path.read_bytes()
-        # Legacy: use hardcoded salt for backward compat on first read
-        return _LEGACY_SALT
+
+        # Backward compatibility: existing sessions use legacy hardcoded salt
+        if self._path.exists():
+            return _LEGACY_SALT
+
+        # New installation: generate random salt and persist atomically
+        salt = os.urandom(16)
+        self._persist_salt(salt)
+        return salt
 
     def _persist_salt(self, salt: bytes) -> None:
         """Save random salt to disk (atomic 0o600 write, no TOCTOU window)."""

--- a/tests/test_per_user_session_store.py
+++ b/tests/test_per_user_session_store.py
@@ -242,3 +242,31 @@ class TestPerUserSessionStore:
             all_s = store.load_all()
             assert "b1" in all_s
             assert mock_read.call_count == 1
+
+
+def test_new_install_generates_random_salt(data_dir: Path):
+    """If no salt file and no session file exist, generate and persist a new salt."""
+    from better_telegram_mcp.auth.per_user_session_store import _LEGACY_SALT
+
+    store = PerUserSessionStore(data_dir, secret="test")
+
+    # Verify a new salt was generated and persisted
+    assert store._salt != _LEGACY_SALT
+    assert len(store._salt) == 16
+    assert (data_dir / ".session-salt").exists()
+    assert (data_dir / ".session-salt").read_bytes() == store._salt
+
+
+def test_legacy_install_uses_legacy_salt(data_dir: Path):
+    """If no salt file exists but a session file exists, use the legacy salt."""
+    from better_telegram_mcp.auth.per_user_session_store import _LEGACY_SALT
+
+    # Simulate legacy session file
+    (data_dir / "sessions.enc").write_bytes(b"some-encrypted-data")
+
+    store = PerUserSessionStore(data_dir, secret="test")
+
+    # Verify it falls back to legacy salt
+    assert store._salt == _LEGACY_SALT
+    # It should NOT persist the legacy salt to the salt file automatically during resolution
+    assert not (data_dir / ".session-salt").exists()

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.1b1"
+version = "4.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
This PR addresses a security issue where a predictable, hardcoded salt was being used as the default for PBKDF2 key derivation in `PerUserSessionStore`.

Changes:
- Modified `_resolve_salt` to check for the existence of `sessions.enc` before falling back to `_LEGACY_SALT`.
- If it's a new installation (no salt file and no session file), a random 16-byte salt is generated and stored in `.session-salt`.
- Updated `tests/test_per_user_session_store.py` with new test cases covering fresh installations and legacy migrations.

This ensures that new users get unique salts while maintaining backward compatibility for existing encrypted session files.

---
*PR created automatically by Jules for task [15630437712682126906](https://jules.google.com/task/15630437712682126906) started by @n24q02m*