### PR TITLE
[TEST] Missing error test for server.contact

### DIFF
--- a/src/better_telegram_mcp/server.py
+++ b/src/better_telegram_mcp/server.py
@@ -385,18 +385,21 @@ async def contact(
     - add (phone, first_name -> last_name)
     - block (user_id -> unblock=true)
     """
-    if _unconfigured or _pending_auth:
-        return _not_ready_response()
+    try:
+        if _unconfigured or _pending_auth:
+            return _not_ready_response()
 
-    opts = ContactsOptions(
-        query=query,
-        phone=phone,
-        first_name=first_name,
-        last_name=last_name,
-        user_id=user_id,
-        unblock=unblock,
-    )
-    return await handle_contacts(get_backend(), action, options=opts)
+        opts = ContactsOptions(
+            query=query,
+            phone=phone,
+            first_name=first_name,
+            last_name=last_name,
+            user_id=user_id,
+            unblock=unblock,
+        )
+        return await handle_contacts(get_backend(), action, options=opts)
+    except Exception as e:
+        return str(e)
 
 
 @mcp.tool(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -132,6 +132,28 @@ async def test_contact_list(mock_backend):
 
 
 @pytest.mark.asyncio
+async def test_contact_error(mock_backend):
+    import better_telegram_mcp.server as srv
+    from better_telegram_mcp.server import contact
+
+    old_backend = srv._backend
+    old_pending = srv._pending_auth
+    try:
+        srv._backend = mock_backend
+        srv._pending_auth = False
+        with patch(
+            "better_telegram_mcp.server.handle_contacts",
+            side_effect=Exception("mock error"),
+        ):
+            # Currently this will raise Exception, later it will return "mock error"
+            result = await contact(action="list")
+            assert result == "mock error"
+    finally:
+        srv._backend = old_backend
+        srv._pending_auth = old_pending
+
+
+@pytest.mark.asyncio
 async def test_message_unknown_action(mock_backend):
     import better_telegram_mcp.server as srv
     from better_telegram_mcp.server import message


### PR DESCRIPTION
Wrapped the `contact` tool logic in `src/better_telegram_mcp/server.py` in a `try...except Exception as e:` block and returned `str(e)` on error, as requested. Added a corresponding unit test `test_contact_error` in `tests/test_server.py` to verify that exceptions from `handle_contacts` are correctly caught and returned. Verified with all relevant tests.

---
*PR created automatically by Jules for task [3474393642492584666](https://jules.google.com/task/3474393642492584666) started by @n24q02m*