### PR TITLE
[TEST] Missing error test for server.chat

### DIFF
--- a/src/better_telegram_mcp/server.py
+++ b/src/better_telegram_mcp/server.py
@@ -17,7 +17,7 @@ from .tools.contacts import ContactsOptions, handle_contacts
 from .tools.help_tool import handle_help
 from .tools.media import MediaOptions, handle_media
 from .tools.messages import MessagesArgs, handle_messages
-from .utils.formatting import err, ok
+from .utils.formatting import err, ok, safe_error
 
 # Silence httpx INFO-level request logs so the bot token in the request URL
 # (https://api.telegram.org/bot<TOKEN>/...) cannot leak into stderr.
@@ -317,7 +317,10 @@ async def chat(
         topic_id=topic_id,
         topic_name=topic_name,
     )
-    return await handle_chats(get_backend(), action, opts)
+    try:
+        return await handle_chats(get_backend(), action, opts)
+    except Exception as e:
+        return safe_error(e)
 
 
 @mcp.tool(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -967,3 +967,27 @@ async def test_run_http():
         assert args[0] is mcp
         assert kwargs["server_name"] == "better-telegram-mcp"
         assert kwargs["port"] == 8080
+
+
+@pytest.mark.asyncio
+async def test_chat_error_handling(mock_backend):
+    """chat tool returns error string when handle_chats fails."""
+    import better_telegram_mcp.server as srv
+    from better_telegram_mcp.server import chat
+
+    old_backend = srv._backend
+    old_pending = srv._pending_auth
+    try:
+        srv._backend = mock_backend
+        srv._pending_auth = False
+        with patch(
+            "better_telegram_mcp.server.handle_chats",
+            side_effect=Exception("Tool failure"),
+        ):
+            result = await chat(action="list")
+            assert "error" in result
+            assert "Exception" in result
+            assert "Operation failed" in result
+    finally:
+        srv._backend = old_backend
+        srv._pending_auth = old_pending

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.1b1"
+version = "4.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
This PR addresses the missing error test for the `server.chat` tool.

Changes:
- Modified `src/better_telegram_mcp/server.py` to wrap the `chat` tool logic in a `try...except` block.
- Updated `chat` to return a sanitized error message using `safe_error(e)` when an exception occurs.
- Added a new test case `test_chat_error_handling` in `tests/test_server.py` to verify that exceptions in the tool are correctly caught and returned as error strings.

Verification:
- Created a reproduction script that confirmed the tool was previously crashing on unhandled exceptions.
- Verified that the new test case passes.
- Ran the full unit test suite (560 tests) and all passed.
- Performed linting and formatting with Ruff.

---
*PR created automatically by Jules for task [14424843181675768033](https://jules.google.com/task/14424843181675768033) started by @n24q02m*