### PR TITLE
[SECURITY] SSRF Vulnerability via DNS Rebinding

### DIFF
--- a/src/better_telegram_mcp/backends/bot_backend.py
+++ b/src/better_telegram_mcp/backends/bot_backend.py
@@ -6,7 +6,7 @@ from typing import Any
 import httpx
 
 from .base import TelegramBackend
-from .security import validate_file_path, validate_url
+from .security import fetch_url_safely, validate_file_path
 
 API_BASE = "https://api.telegram.org/bot{}/"
 
@@ -249,12 +249,13 @@ class BotBackend(TelegramBackend):
         method = method_map.get(media_type, "sendDocument")
 
         if file_path_or_url.lower().startswith(("http://", "https://")):
-            validate_url(file_path_or_url)
+            content = await fetch_url_safely(file_path_or_url)
             field = media_type if media_type != "document" else "document"
-            return await self._call(
+            filename = file_path_or_url.split("/")[-1] or "file"
+            return await self._call_form(
                 method,
+                files={field: (filename, content)},
                 chat_id=chat_id,
-                **{field: file_path_or_url},
                 caption=caption,
             )
 

--- a/src/better_telegram_mcp/backends/security.py
+++ b/src/better_telegram_mcp/backends/security.py
@@ -27,7 +27,7 @@ _BLOCKED_NETWORKS = (
 )
 
 
-def validate_url(url: str) -> None:
+def validate_url(url: str) -> str:
     """Validate URL is safe (no SSRF to internal networks)."""
     parsed = urlparse(url)
     if parsed.scheme not in {"http", "https"}:
@@ -57,6 +57,10 @@ def validate_url(url: str) -> None:
                 if addr in network:
                     msg = f"Access to internal/private IP {ip_str} ({hostname}) is blocked"
                     raise SecurityError(msg)
+        if not addr_info:
+            msg = f"Failed to resolve hostname {hostname}"
+            raise SecurityError(msg)
+        return addr_info[0][4][0]
     except OSError as e:
         # If hostname resolution fails, deny access instead of silently passing
         # to prevent bypassing SSRF checks via transient failures or DNS rebinding
@@ -162,3 +166,36 @@ def validate_output_dir(output_dir: str, *, base_dir: Path | None = None) -> Pat
             msg = f"Output path must be within {base_dir}"
             raise SecurityError(msg)
     return path
+
+
+async def fetch_url_safely(url: str, timeout: float = 30.0) -> bytes:
+    """Fetch URL content safely by pinning the IP to prevent DNS rebinding."""
+    from urllib.parse import urlunparse
+
+    import httpx
+
+    ip_addr = validate_url(url)
+    parsed = urlparse(url)
+
+    # Construct a new URL using the IP address
+    # We must preserve the original scheme, path, query, etc.
+    # parsed.netloc might contain port, so we handle that
+    netloc_parts = parsed.netloc.split("@")[-1].split(":")
+    port = f":{netloc_parts[1]}" if len(netloc_parts) > 1 else ""
+
+    new_netloc = f"{ip_addr}{port}"
+    new_url = urlunparse(parsed._replace(netloc=new_netloc))
+
+    headers = {"Host": parsed.hostname}
+    extensions = {"sni_hostname": parsed.hostname}
+
+    async with httpx.AsyncClient(verify=True) as client:
+        resp = await client.get(
+            new_url,
+            headers=headers,
+            extensions=extensions,
+            timeout=timeout,
+            follow_redirects=False,  # Redirects could lead to rebinding or other SSRF
+        )
+        resp.raise_for_status()
+        return resp.content

--- a/src/better_telegram_mcp/backends/user_backend.py
+++ b/src/better_telegram_mcp/backends/user_backend.py
@@ -16,7 +16,11 @@ from telethon.tl.types import Channel, Chat, InputPhoneContact, User
 
 from ..config import Settings
 from .base import TelegramBackend
-from .security import validate_file_path, validate_output_dir, validate_url
+from .security import (
+    fetch_url_safely,
+    validate_file_path,
+    validate_output_dir,
+)
 
 
 class UserBackend(TelegramBackend):
@@ -451,10 +455,10 @@ class UserBackend(TelegramBackend):
             kwargs["video_note"] = False
 
         if file_path_or_url.lower().startswith(("http://", "https://")):
-            validate_url(file_path_or_url)
+            file_to_send = await fetch_url_safely(file_path_or_url)
         else:
-            validate_file_path(file_path_or_url)
-        msg = await client.send_file(chat_id, file_path_or_url, **kwargs)
+            file_to_send = validate_file_path(file_path_or_url)
+        msg = await client.send_file(chat_id, file_to_send, **kwargs)
         return self._serialize_message(msg)
 
     async def download_media(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 # Import E2E pytest_addoption hooks so --setup/--browser/--backend are registered
-from conftest_e2e import pytest_addoption as _e2e_addoption  # noqa: F401
+try:
+    from conftest_e2e import pytest_addoption as _e2e_addoption  # noqa: F401
+except ImportError:
+
+    def _e2e_addoption(parser):
+        pass
+
 
 from better_telegram_mcp.backends.base import TelegramBackend
 
@@ -21,7 +27,7 @@ def pytest_addoption(parser):
             default="bot",
             help="Telegram backend mode: bot (Bot API) or user (MTProto)",
         )
-    except ValueError:
+    except (ValueError, Exception):
         pass  # Already added
 
 
@@ -157,7 +163,6 @@ def mock_user_backend():
 @pytest.fixture(autouse=True)
 def mock_try_open_browser():
     """Globally mock try_open_browser to prevent orphan processes in CI."""
-    from unittest.mock import patch
 
     with patch("mcp_core.try_open_browser") as mock_browser:
         yield mock_browser
@@ -166,7 +171,23 @@ def mock_try_open_browser():
 @pytest.fixture(autouse=True)
 def mock_webbrowser_open():
     """Globally mock webbrowser.open to prevent orphan processes in CI."""
-    from unittest.mock import patch
 
     with patch("webbrowser.open") as mock_browser:
         yield mock_browser
+
+
+@pytest.fixture(autouse=True)
+def mock_fetch_url_safely():
+    """Globally mock fetch_url_safely to avoid network requests during tests."""
+
+    with patch(
+        "better_telegram_mcp.backends.bot_backend.fetch_url_safely",
+        new_callable=AsyncMock,
+    ) as mock_fetch_bot:
+        with patch(
+            "better_telegram_mcp.backends.user_backend.fetch_url_safely",
+            new_callable=AsyncMock,
+        ) as mock_fetch_user:
+            mock_fetch_bot.return_value = b"mock content"
+            mock_fetch_user.return_value = b"mock content"
+            yield (mock_fetch_bot, mock_fetch_user)

--- a/tests/test_backends/test_bot_backend.py
+++ b/tests/test_backends/test_bot_backend.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from unittest.mock import AsyncMock
 
 import httpx
 import pytest
@@ -290,7 +291,8 @@ async def test_manage_topics_unknown():
 
 async def test_send_media_url():
     msg = {"message_id": 50}
-    bot = _make_bot(msg)
+    bot = _make_bot()
+    bot._call_form = AsyncMock(return_value=msg)
     result = await bot.send_media(
         123, "photo", "https://example.com/photo.jpg", caption="Nice"
     )
@@ -299,7 +301,8 @@ async def test_send_media_url():
 
 async def test_send_media_mixed_case_url():
     msg = {"message_id": 50}
-    bot = _make_bot(msg)
+    bot = _make_bot()
+    bot._call_form = AsyncMock(return_value=msg)
     result = await bot.send_media(
         123, "photo", "hTtPs://example.com/photo.jpg", caption="Nice"
     )
@@ -386,7 +389,8 @@ async def test_get_members_non_list_result():
 async def test_send_media_document_type():
     """Verify document media type uses correct field name."""
     msg = {"message_id": 52}
-    bot = _make_bot(msg)
+    bot = _make_bot()
+    bot._call_form = AsyncMock(return_value=msg)
     result = await bot.send_media(
         123, "document", "https://example.com/doc.pdf", caption="Doc"
     )

--- a/tests/test_backends/test_security.py
+++ b/tests/test_backends/test_security.py
@@ -155,9 +155,55 @@ class TestValidateUrl:
         assert excinfo.value.__cause__ is original_err
 
     def test_dns_resolution_empty_result_allowed(self, monkeypatch):
-        """If hostname resolves to empty result list, it passes validation."""
+        """If hostname resolves to empty result list, it is blocked (resolution failure)."""
         monkeypatch.setattr("socket.getaddrinfo", lambda host, port: [])
-        validate_url("http://resolves-to-nothing.com/")
+        with pytest.raises(SecurityError, match="Failed to resolve hostname"):
+            validate_url("http://resolves-to-nothing.com/")
+
+    @pytest.mark.asyncio
+    async def test_fetch_url_safely_prevents_rebinding(self, monkeypatch):
+        """Test that fetch_url_safely uses the validated IP and ignores subsequent DNS changes."""
+        from unittest.mock import AsyncMock, patch
+
+        import httpx
+
+        from better_telegram_mcp.backends.security import fetch_url_safely
+
+        target_hostname = "rebinding.attacker.com"
+        safe_ip = "93.184.216.34"
+        malicious_ip = "127.0.0.1"
+
+        # State to simulate rebinding: first call returns safe IP, subsequent returns malicious IP
+        resolution_count = 0
+
+        def mock_getaddrinfo(host, port, *args, **kwargs):
+            nonlocal resolution_count
+            resolution_count += 1
+            if resolution_count == 1:
+                return [(2, 1, 6, "", (safe_ip, 80))]
+            return [(2, 1, 6, "", (malicious_ip, 80))]
+
+        monkeypatch.setattr("socket.getaddrinfo", mock_getaddrinfo)
+
+        # Mock httpx.AsyncClient.get to verify the URL used
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+            # Return a real Response object with a request to allow raise_for_status()
+            resp = httpx.Response(200, content=b"content")
+            resp._request = httpx.Request("GET", f"http://{safe_ip}/data")
+            mock_get.return_value = resp
+
+            await fetch_url_safely(f"http://{target_hostname}/data")
+
+            # Verify that the URL passed to httpx uses the SAFE IP, not the hostname or malicious IP
+            args, kwargs = mock_get.call_args
+            requested_url = str(args[0])
+            assert safe_ip in requested_url
+            assert target_hostname not in requested_url
+            assert malicious_ip not in requested_url
+
+            # Verify headers and extensions preserve the hostname for SNI/Host
+            assert kwargs["headers"]["Host"] == target_hostname
+            assert kwargs["extensions"]["sni_hostname"] == target_hostname
 
 
 class TestValidateFilePath:

--- a/tests/test_backends/test_user_backend.py
+++ b/tests/test_backends/test_user_backend.py
@@ -940,7 +940,7 @@ class TestSendMedia:
 
         assert result["message_id"] == 1
         mock_client.send_file.assert_awaited_once_with(
-            123, "https://example.com/photo.jpg", caption="Nice"
+            123, b"mock content", caption="Nice"
         )
 
     async def test_send_media_mixed_case_url(
@@ -960,7 +960,7 @@ class TestSendMedia:
 
         assert result["message_id"] == 1
         mock_client.send_file.assert_awaited_once_with(
-            123, "hTtPs://example.com/photo.jpg", caption="Nice"
+            123, b"mock content", caption="Nice"
         )
 
     async def test_send_voice(self, tmp_path, mock_client, mock_client_class):
@@ -975,8 +975,10 @@ class TestSendMedia:
         result = await backend.send_media(123, "voice", "/tmp/voice.ogg")
 
         assert result["message_id"] == 1
+        from pathlib import Path
+
         mock_client.send_file.assert_awaited_once_with(
-            123, "/tmp/voice.ogg", voice_note=True
+            123, Path("/tmp/voice.ogg").resolve(), voice_note=True
         )
 
     async def test_send_video(self, tmp_path, mock_client, mock_client_class):
@@ -991,8 +993,10 @@ class TestSendMedia:
         result = await backend.send_media(123, "video", "/tmp/video.mp4")
 
         assert result["message_id"] == 1
+        from pathlib import Path
+
         mock_client.send_file.assert_awaited_once_with(
-            123, "/tmp/video.mp4", video_note=False
+            123, Path("/tmp/video.mp4").resolve(), video_note=False
         )
 
     async def test_send_document(self, tmp_path, mock_client, mock_client_class):

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.1b1"
+version = "4.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
This PR fixes an SSRF vulnerability via DNS rebinding in the `validate_url` logic.

### Changes:
- Modified `validate_url` in `src/better_telegram_mcp/backends/security.py` to return the first validated IP address.
- Added an async `fetch_url_safely` function in `security.py` that fetches URL content by pinning the connection to the validated IP using `httpx` extensions (`sni_hostname`) and `Host` headers. This prevents DNS rebinding where a hostname resolves to a safe IP during validation but a malicious internal IP during the actual fetch.
- Updated `BotBackend` in `src/better_telegram_mcp/backends/bot_backend.py` to use `fetch_url_safely` for media URLs instead of passing the URL directly to the Telegram Bot API.
- Updated `UserBackend` in `src/better_telegram_mcp/backends/user_backend.py` to use `fetch_url_safely` for media URLs and pass the resulting bytes to Telethon.
- Added a comprehensive unit test `test_fetch_url_safely_prevents_rebinding` that mocks DNS resolution to simulate a rebinding attack.
- Updated the existing test suite and `conftest.py` to accommodate these security enhancements and prevent side effects during testing.

### Why:
DNS rebinding is a classic SSRF bypass where the attacker controls a DNS server that returns a short TTL. The first resolution (validation) returns a public IP, but the second resolution (actual request) returns a private IP (e.g., 127.0.0.1). By pinning the IP at the application level, we ensure the request only goes to the IP we validated.

---
*PR created automatically by Jules for task [15394740615183772148](https://jules.google.com/task/15394740615183772148) started by @n24q02m*