### PR TITLE
fix: redact Telegram bot token from error messages

### DIFF
--- a/src/better_telegram_mcp/backends/bot_backend.py
+++ b/src/better_telegram_mcp/backends/bot_backend.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import httpx
 
+from ..relay_setup import redact_bot_token
 from .base import TelegramBackend
 from .security import fetch_url_safely, validate_file_path
 
@@ -28,19 +29,29 @@ class BotBackend(TelegramBackend):
 
     async def _call(self, method: str, **params: Any) -> Any:
         data = {k: v for k, v in params.items() if v is not None}
-        resp = await self._client.post(method, json=data)
+        try:
+            resp = await self._client.post(method, json=data)
+        except httpx.HTTPError as e:
+            # httpx exceptions include the request URL, which carries the bot
+            # token; redact before re-raising so it cannot leak into logs.
+            raise TelegramAPIError(redact_bot_token(str(e))) from None
         body = resp.json()
         if not body.get("ok"):
-            desc = body.get("description", "Unknown error")
+            desc = redact_bot_token(body.get("description", "Unknown error"))
             raise TelegramAPIError(desc, body.get("error_code", resp.status_code))
         return body.get("result")
 
     async def _call_form(self, method: str, files: dict, **params: Any) -> Any:
         data = {k: str(v) for k, v in params.items() if v is not None}
-        resp = await self._client.post(method, data=data, files=files)
+        try:
+            resp = await self._client.post(method, data=data, files=files)
+        except httpx.HTTPError as e:
+            raise TelegramAPIError(redact_bot_token(str(e))) from None
         body = resp.json()
         if not body.get("ok"):
-            raise TelegramAPIError(body.get("description", "Unknown error"))
+            raise TelegramAPIError(
+                redact_bot_token(body.get("description", "Unknown error"))
+            )
         return body.get("result")
 
     # --- Connection ---
@@ -55,7 +66,9 @@ class BotBackend(TelegramBackend):
                     "https://t.me/BotFather"
                 )
                 raise TelegramAPIError(msg) from e
-            raise ConnectionError(f"Failed to connect to Bot API: {e}") from e
+            raise ConnectionError(
+                redact_bot_token(f"Failed to connect to Bot API: {e}")
+            ) from e
 
     async def disconnect(self) -> None:
         await self._client.aclose()

--- a/src/better_telegram_mcp/relay_setup.py
+++ b/src/better_telegram_mcp/relay_setup.py
@@ -24,6 +24,12 @@ ALL_POSSIBLE_FIELDS = [
     "TELEGRAM_PHONE",
 ]
 
+# Telegram bot tokens have the shape "<bot_id>:<35-char secret>" and appear in
+# httpx request URLs (https://api.telegram.org/bot<token>/<method>), so they can
+# surface in transport-level exception messages. Mask them before logging or
+# returning any error string.
+_BOT_TOKEN_RE = re.compile(r"\d+:[A-Za-z0-9_-]{35,}")
+
 # Error sanitization patterns shared with credential_state.py.
 _CAUSED_BY_RE = re.compile(r"\s*\(caused by \w+\)\s*$", re.IGNORECASE)
 _ERROR_SIMPLIFICATIONS: list[tuple[re.Pattern[str], str]] = [
@@ -50,9 +56,21 @@ _ERROR_SIMPLIFICATIONS: list[tuple[re.Pattern[str], str]] = [
 ]
 
 
+def redact_bot_token(text: str) -> str:
+    """Mask any Telegram bot token embedded in ``text``.
+
+    Bot tokens can leak into transport-level error messages because httpx
+    includes the request URL (which carries the token) in its exceptions. The
+    bot id is preserved for debuggability while the secret is replaced.
+    """
+    return _BOT_TOKEN_RE.sub(
+        lambda m: m.group(0).split(":", 1)[0] + ":<redacted>", text
+    )
+
+
 def _sanitize_error(msg: str) -> str:
     """Simplify internal error messages to user-friendly text."""
-    cleaned = _CAUSED_BY_RE.sub("", msg).strip()
+    cleaned = redact_bot_token(_CAUSED_BY_RE.sub("", msg).strip())
     for pattern, friendly in _ERROR_SIMPLIFICATIONS:
         if pattern.match(cleaned):
             return friendly

--- a/tests/test_backends/test_bot_backend.py
+++ b/tests/test_backends/test_bot_backend.py
@@ -340,6 +340,69 @@ async def test_api_error_has_error_code():
     assert exc_info.value.error_code == 400
 
 
+# --- Bot token redaction ---
+
+# Token-shaped value (bot id + 35-char secret) assembled from parts so no
+# scanner-matchable literal exists in source. Not a real credential.
+_FAKE_SECRET = "AAE" + ("x" * 32)
+_FAKE_TOKEN = "123456789:" + _FAKE_SECRET
+
+
+async def test_transport_error_redacts_bot_token():
+    """httpx errors embed the request URL (with the token); it must be masked."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError(f"failed connecting to {request.url}")
+
+    bot = BotBackend(_FAKE_TOKEN)
+    bot._client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url=bot._base_url,
+    )
+    with pytest.raises(TelegramAPIError) as exc_info:
+        await bot.send_message(123, "hello")
+    message = str(exc_info.value)
+    assert _FAKE_SECRET not in message
+    assert "123456789:<redacted>" in message
+
+
+async def test_connect_transport_error_redacts_bot_token():
+    """ConnectionError wrapping during connect must not leak the token."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError(f"dns failure for {request.url}")
+
+    bot = BotBackend(_FAKE_TOKEN)
+    bot._client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url=bot._base_url,
+    )
+    # A transport failure surfaces as ConnectionError; neither it nor its
+    # chained cause may carry the token secret.
+    with pytest.raises(ConnectionError) as exc_info:
+        await bot.connect()
+    assert _FAKE_SECRET not in str(exc_info.value)
+    assert _FAKE_SECRET not in str(exc_info.value.__cause__)
+
+
+async def test_form_transport_error_redacts_bot_token():
+    """_call_form transport errors must also redact the token."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout(f"timeout on {request.url}")
+
+    bot = BotBackend(_FAKE_TOKEN)
+    bot._client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url=bot._base_url,
+    )
+    with pytest.raises(TelegramAPIError) as exc_info:
+        await bot._call_form(
+            "sendDocument", files={"document": ("t.txt", b"d")}, chat_id=1
+        )
+    assert _FAKE_SECRET not in str(exc_info.value)
+
+
 # --- Verify request body ---
 
 

--- a/tests/test_relay_setup.py
+++ b/tests/test_relay_setup.py
@@ -11,7 +11,37 @@ from better_telegram_mcp.relay_setup import (
     _is_user_mode_config,
     _needs_2fa_password,
     _sanitize_error,
+    redact_bot_token,
 )
+
+# Token-shaped value (bot id + 35-char secret) assembled from parts so no
+# scanner-matchable literal exists in source. Not a real credential.
+_FAKE_SECRET = "AAE" + ("x" * 32)
+_FAKE_TOKEN = "123456789:" + _FAKE_SECRET
+
+
+def test_redact_bot_token_in_url():
+    text = f"error posting https://api.telegram.org/bot{_FAKE_TOKEN}/getMe"
+    redacted = redact_bot_token(text)
+    assert _FAKE_SECRET not in redacted
+    assert "123456789:<redacted>" in redacted
+
+
+def test_redact_bot_token_standalone():
+    redacted = redact_bot_token(f"token {_FAKE_TOKEN} leaked into logs")
+    assert _FAKE_SECRET not in redacted
+
+
+def test_redact_bot_token_noop_when_absent():
+    text = "Bad Request: chat not found"
+    assert redact_bot_token(text) == text
+
+
+def test_sanitize_error_redacts_bot_token():
+    # _sanitize_error feeds logs/return values, so it must also strip tokens.
+    redacted = _sanitize_error(f"Connection failed using {_FAKE_TOKEN}")
+    assert _FAKE_SECRET not in redacted
+
 
 # --- Settings.from_relay_config ---
 


### PR DESCRIPTION
## Summary
- httpx exceptions include the request URL, which carries the bot token (`https://api.telegram.org/bot<token>/<method>`), so a transport-level failure could leak the token into logs and returned error strings.
- Added `redact_bot_token` in `relay_setup.py` (masks `\d+:[A-Za-z0-9_-]{35,}`, preserving the bot id for debuggability) and applied it on the `BotBackend` error paths (`_call`, `_call_form`, `connect`) and inside `_sanitize_error`.

## Test plan
- [x] `tests/test_relay_setup.py`: unit tests for `redact_bot_token` (URL, standalone, no-op when absent) and `_sanitize_error` redaction.
- [x] `tests/test_backends/test_bot_backend.py`: transport-error tests assert the token secret is masked in the raised error for `_call`, `_call_form`, and `connect`.
- [x] `uv run pytest -q` (93 passed in touched files; full suite green via pre-commit), `ruff check`, `ruff format --check`, `ty check` all clean.

Generated with [Claude Code](https://claude.com/claude-code)