### PR TITLE
fix: canonicalize blocked-path check to close macOS firmlink bypass

### DIFF
--- a/src/better_telegram_mcp/backends/security.py
+++ b/src/better_telegram_mcp/backends/security.py
@@ -82,6 +82,37 @@ def _normalize_for_prefix_check(path: Path) -> str:
     return path_str if path_str.endswith("/") else path_str + "/"
 
 
+def _is_under_blocked_prefix(
+    resolved: Path, lexical: Path, prefixes: tuple[str, ...]
+) -> str | None:
+    """Return the blocked prefix that ``resolved``/``lexical`` falls under, else None.
+
+    Robust against the macOS firmlink layout (``/etc`` -> ``/private/etc``):
+    each blocked prefix directory is itself canonicalized with ``realpath`` so
+    the containment check compares like-for-like canonical paths rather than
+    relying on a hand-rolled ``/private`` string strip. Containment uses
+    ``Path.is_relative_to`` (a proper path-segment check) instead of a naive
+    ``startswith``, so siblings such as ``/etc-decoy`` are not mistaken for
+    ``/etc``. The pre-resolution (lexical) path is also checked so a symlink
+    cannot mask an attempt that targets a blocked prefix literally.
+    """
+    candidates = {resolved, lexical}
+    for prefix in prefixes:
+        prefix_dir = Path(prefix.rstrip("/"))
+        # Compare against both the literal blocked dir and its canonical form so
+        # the same blocklist works on Linux and macOS firmlink layouts.
+        blocked_dirs = {prefix_dir}
+        try:
+            blocked_dirs.add(prefix_dir.resolve())
+        except OSError:
+            pass
+        for candidate in candidates:
+            for blocked in blocked_dirs:
+                if candidate == blocked or candidate.is_relative_to(blocked):
+                    return prefix
+    return None
+
+
 def validate_file_path(file_path: str, *, allowed_dir: Path | None = None) -> Path:
     """Validate local file path is safe (no traversal to sensitive files)."""
     # Sentinel: Expand user (`~`) before resolving to prevent TOCTOU bypasses where
@@ -98,16 +129,15 @@ def validate_file_path(file_path: str, *, allowed_dir: Path | None = None) -> Pa
         "/var/log/",
         "/root/",
     )
-    # Check BOTH the lexical (pre-resolve) and resolved paths. On macOS
-    # `/etc` resolves to `/private/etc` via firmlinks, so we must check the
-    # raw input as well, and normalize `/private/*` in the resolved path.
-    lexical_str = Path(file_path).expanduser().as_posix()
-    lexical_check = lexical_str if lexical_str.endswith("/") else lexical_str + "/"
-    resolved_check = _normalize_for_prefix_check(path)
-    for prefix in _blocked_prefixes:
-        if lexical_check.startswith(prefix) or resolved_check.startswith(prefix):
-            msg = f"Access to {prefix} is blocked for security"
-            raise SecurityError(msg)
+    # Check BOTH the lexical (pre-resolve) and resolved paths against canonical
+    # blocked dirs. On macOS `/etc` resolves to `/private/etc` via firmlinks, so
+    # the helper canonicalizes each blocked prefix and uses path-segment
+    # containment rather than a fragile `/private` string strip + startswith.
+    lexical = Path(file_path).expanduser()
+    blocked = _is_under_blocked_prefix(path, lexical, _blocked_prefixes)
+    if blocked is not None:
+        msg = f"Access to {blocked} is blocked for security"
+        raise SecurityError(msg)
     # Block dotfiles in home directories (SSH keys, secrets, etc.)
     parts = path.parts
     for part in parts:
@@ -145,16 +175,13 @@ def validate_output_dir(output_dir: str, *, base_dir: Path | None = None) -> Pat
         "/boot/",
         "/lib/",
     )
-    # Check BOTH the lexical (pre-resolve) and resolved paths. On macOS
-    # `/etc` resolves to `/private/etc` via firmlinks, so we must check the
-    # raw input as well, and normalize `/private/*` in the resolved path.
-    lexical_str = Path(output_dir).expanduser().as_posix()
-    lexical_check = lexical_str if lexical_str.endswith("/") else lexical_str + "/"
-    resolved_check = _normalize_for_prefix_check(path)
-    for prefix in _blocked_prefixes:
-        if lexical_check.startswith(prefix) or resolved_check.startswith(prefix):
-            msg = f"Writing to {prefix} is blocked for security"
-            raise SecurityError(msg)
+    # Check BOTH the lexical (pre-resolve) and resolved paths against canonical
+    # blocked dirs (see _is_under_blocked_prefix for the macOS firmlink rationale).
+    lexical = Path(output_dir).expanduser()
+    blocked = _is_under_blocked_prefix(path, lexical, _blocked_prefixes)
+    if blocked is not None:
+        msg = f"Writing to {blocked} is blocked for security"
+        raise SecurityError(msg)
     # Block hidden directories
     for part in path.parts:
         if part.startswith(".") and part not in {".", ".."}:

--- a/tests/test_backends/test_security.py
+++ b/tests/test_backends/test_security.py
@@ -258,6 +258,36 @@ class TestValidateFilePath:
         with pytest.raises(SecurityError, match="/etc/"):
             validate_file_path(str(link))
 
+    @pytest.mark.skipif(_IS_WINDOWS, reason="Unix-only symlinks/firmlinks")
+    def test_symlink_to_blocked_dir_canonicalized(self, tmp_path):
+        """A symlinked directory pointing at /etc must be blocked after realpath.
+
+        This is the macOS-firmlink / symlink bypass: the symlink itself lives in
+        an allowed location, so a lexical check passes, but canonicalizing the
+        target reveals it lands under a blocked prefix (/etc, which on macOS is
+        the firmlink /private/etc).
+        """
+        link = tmp_path / "etc_link"
+        try:
+            os.symlink("/etc", link)
+        except OSError:
+            pytest.skip("Cannot create symlinks in this environment")
+
+        with pytest.raises(SecurityError, match="/etc/"):
+            validate_file_path(str(link / "passwd"))
+
+    @pytest.mark.skipif(_IS_WINDOWS, reason="Unix-only blocked paths")
+    def test_sibling_prefix_not_blocked(self):
+        """A path that merely shares a name prefix with a blocked dir is allowed.
+
+        The containment check is per path-segment (is_relative_to), so
+        ``/etc-decoy`` is NOT treated as being under ``/etc``.
+        """
+        # Non-existent sibling-prefix path resolves lexically and must pass the
+        # blocked-prefix gate (it is rejected later only if it hits another rule).
+        result = validate_file_path("/etcdecoy/file.txt")
+        assert str(result).endswith("file.txt")
+
     def test_allowed_dir_enforcement(self, tmp_path):
         photo = tmp_path / "photo.jpg"
         allowed = tmp_path / "uploads"


### PR DESCRIPTION
## Summary
- The blocked-prefix gate in `validate_file_path` / `validate_output_dir` matched paths with a naive `startswith` plus a hand-rolled `/private` string strip. On macOS the firmlink layout resolves `/etc`, `/var`, `/tmp` to `/private/*`, and the manual strip only covered a leading `/private/`, so a symlinked component could land under a blocked directory while evading the check.
- Added `_is_under_blocked_prefix`, which canonicalizes each blocked prefix with `realpath` and asserts containment with `Path.is_relative_to` (a per-segment check) against both the resolved and lexical candidate paths. Firmlinks are handled automatically and sibling names like `/etc-decoy` are no longer mistaken for `/etc`.

## Test plan
- [x] Added tests in `tests/test_backends/test_security.py`: a symlinked directory pointing at `/etc` is blocked after canonicalization, and a sibling-prefix path (`/etcdecoy/...`) is allowed. (Symlink case `skipif` win32 — runs on CI Linux/macOS; the canonical containment logic verified directly under a mocked firmlink resolution.)
- [x] Full suite green locally: 568 passed, 19 skipped, 140 deselected.
- [x] `ruff check` + `ruff format --check` + `ty check` clean on changed files.

Surgical change to the two resolvers via one shared helper; the pre-existing `_normalize_for_prefix_check` is retained (still covered by its own test).

Generated with [Claude Code](https://claude.com/claude-code)