### PR TITLE
⚡ Bolt: Concurrent network disconnects in Auth Cleanup

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-23 - Concurrent Task Execution in Auth Cleanup
+**Learning:** Found a performance bottleneck where `cleanup_expired` in `TelegramAuthProvider` would sequentially iterate through expired sessions and stale OTPs, using `await backend.disconnect()` for each. Because disconnecting requires a network roundtrip, this resulted in O(N) network latency, blocking the server's main loop and slowing down execution.
+**Action:** When a method needs to call an asynchronous cleanup task (e.g., disconnecting a client) over multiple items, gather the coroutines in a list and run them concurrently using `asyncio.gather()`. This reduces latency drastically.

--- a/src/better_telegram_mcp/auth/telegram_auth_provider.py
+++ b/src/better_telegram_mcp/auth/telegram_auth_provider.py
@@ -356,27 +356,37 @@ class TelegramAuthProvider:
         removed = 0
         now = time.time()
 
+        # ⚡ Bolt: Execute cleanup tasks concurrently
+        # Network disconnects can block the loop; gathering them makes it O(1) latency instead of O(N)
+        tasks = []
+
         for bearer, info in sessions.items():
             if now - info.created_at > _SESSION_TTL:
-                await self.revoke_session(bearer)
+                tasks.append(self.revoke_session(bearer))
                 removed += 1
 
         # Clean up stale pending OTPs (5 min TTL) using chronological insertion order.
         # Since start_user_auth pops-then-reinserts each bearer, the oldest entries
         # are always at the front, so we can stop at the first non-stale entry instead
         # of scanning the full dict on every cleanup tick.
+        async def _disconnect_stale_otp(bearer_id: str, backend: object) -> None:
+            try:
+                await backend.disconnect()  # type: ignore[attr-defined]
+            except Exception as exc:  # pragma: no cover - best-effort cleanup
+                logger.warning(
+                    "Error disconnecting stale OTP backend {}: {}", bearer_id[:8], exc
+                )
+
         while self._pending_otps:
             bearer, pending = next(iter(self._pending_otps.items()))
             if now - pending["created_at"] <= 300:
                 break
             self._pending_otps.pop(bearer)
-            try:
-                await pending["backend"].disconnect()
-            except Exception as exc:  # pragma: no cover - best-effort cleanup
-                logger.warning(
-                    "Error disconnecting stale OTP backend {}: {}", bearer[:8], exc
-                )
+            tasks.append(_disconnect_stale_otp(bearer, pending["backend"]))
             removed += 1
+
+        if tasks:
+            await asyncio.gather(*tasks)
 
         return removed
 


### PR DESCRIPTION
## ⚡ Bolt: Execute cleanup tasks concurrently in Auth Provider

**💡 What:** 
Modified `cleanup_expired` in `TelegramAuthProvider` to use `asyncio.gather()` for concurrent execution of the cleanup tasks (`revoke_session` for expired sessions and `disconnect` for stale pending OTPs).

**🎯 Why:**
Previously, `cleanup_expired` looped through expired sessions and stale OTPs, sequentially awaiting `revoke_session` or `backend.disconnect()`. Because each disconnect requires an MTProto network roundtrip, this resulted in O(N) total wait time, blocking the event loop proportionally to the number of stale entries. Gathering them turns the latency from O(N) to roughly O(1).

**📊 Impact:**
Reduces the overall execution time of periodic cleanup operations from O(N) network latency to a single network latency window, drastically improving server responsiveness when handling a large pool of expiring users.

**🔬 Measurement:**
Run the existing unit tests (`test_cleanup_expired_sessions` and `test_cleanup_stale_otps` in `tests/test_telegram_auth_provider.py`) to verify that sessions and OTPs are removed successfully. 

---
*PR created automatically by Jules for task [7909289552684916134](https://jules.google.com/task/7909289552684916134) started by @n24q02m*