### PR TITLE
⚡ Bolt: Batch cleanup_expired disconnects for O(1) latency

### DIFF
--- a/src/better_telegram_mcp/auth/telegram_auth_provider.py
+++ b/src/better_telegram_mcp/auth/telegram_auth_provider.py
@@ -355,11 +355,20 @@ class TelegramAuthProvider:
         sessions = self._store.load_all()
         removed = 0
         now = time.time()
+        tasks = []
 
         for bearer, info in sessions.items():
             if now - info.created_at > _SESSION_TTL:
-                await self.revoke_session(bearer)
+                tasks.append(self.revoke_session(bearer))
                 removed += 1
+
+        async def _disconnect_pending(bearer: str, pending: dict) -> None:
+            try:
+                await pending["backend"].disconnect()
+            except Exception as exc:  # pragma: no cover - best-effort cleanup
+                logger.warning(
+                    "Error disconnecting stale OTP backend {}: {}", bearer[:8], exc
+                )
 
         # Clean up stale pending OTPs (5 min TTL) using chronological insertion order.
         # Since start_user_auth pops-then-reinserts each bearer, the oldest entries
@@ -370,13 +379,14 @@ class TelegramAuthProvider:
             if now - pending["created_at"] <= 300:
                 break
             self._pending_otps.pop(bearer)
-            try:
-                await pending["backend"].disconnect()
-            except Exception as exc:  # pragma: no cover - best-effort cleanup
-                logger.warning(
-                    "Error disconnecting stale OTP backend {}: {}", bearer[:8], exc
-                )
+            tasks.append(_disconnect_pending(bearer, pending))
             removed += 1
+
+        if tasks:
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            for r in results:
+                if isinstance(r, Exception):
+                    logger.warning(f"Error during cleanup_expired: {r}")
 
         return removed
 

--- a/tests/test_telegram_auth_provider_cleanup.py
+++ b/tests/test_telegram_auth_provider_cleanup.py
@@ -51,3 +51,51 @@ async def test_shutdown_logs_pending_otp_disconnect_error(
         assert "Error disconnecting pending OTP backend test-bea" in caplog.text
     finally:
         logger.remove(handler_id)
+
+
+async def test_cleanup_expired_concurrently(
+    provider: TelegramAuthProvider,
+) -> None:
+    """Disconnects should run in parallel (asyncio.gather), not serially."""
+    import asyncio
+    import time
+
+    N = 5
+    delay = 0.1  # seconds per disconnect
+
+    # Register N pending OTPs with a slow mock disconnect
+    disconnects: list[AsyncMock] = []
+
+    for i in range(N):
+        mock_backend = AsyncMock()
+
+        async def slow_disconnect() -> None:
+            await asyncio.sleep(delay)
+
+        mock_backend.disconnect = AsyncMock(side_effect=slow_disconnect)
+        disconnects.append(mock_backend.disconnect)
+
+        provider._pending_otps[f"stale-{i}"] = {
+            "bearer": f"stale-{i}",
+            "backend": mock_backend,
+            "phone": "+1234567890",
+            "phone_code_hash": "hash",
+            "session_name": f"test-session-{i}",
+            "created_at": time.time() - 301,  # Expired
+        }
+
+    assert len(provider._pending_otps) == N
+
+    start = time.perf_counter()
+    await provider.cleanup_expired()
+    elapsed = time.perf_counter() - start
+
+    # All disconnect() were awaited.
+    assert all(d.called for d in disconnects)
+
+    # Concurrent: must be substantially less than N * delay.
+    assert elapsed < N * delay * 0.7, (
+        f"cleanup_expired took {elapsed:.3f}s for {N}x{delay:.3f}s tasks -- "
+        "looks like disconnects ran serially instead of via asyncio.gather"
+    )
+    assert len(provider._pending_otps) == 0

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.2b1"
+version = "4.12.3"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
⚡ Bolt: Batch cleanup_expired disconnects to eliminate O(N) sequential latency

💡 What: Modified `TelegramAuthProvider.cleanup_expired` to collect session revocations and pending OTP backend disconnects into a list and execute them concurrently via `asyncio.gather(*tasks, return_exceptions=True)`, rather than awaiting them one-by-one in a loop.

🎯 Why: Disconnecting Telethon backends involves an MTProto roundtrip. When `cleanup_expired` ran sequentially, the total time scaled linearly with the number of expired sessions (O(N) * RTT). This blocked the event loop unnecessarly and delayed server responsiveness during cleanup cycles. 

📊 Impact: Reduces total cleanup time from O(N) * RTT to ~O(1) * RTT (approx the duration of the slowest single disconnect), drastically improving background task efficiency when multiple sessions expire simultaneously.

🔬 Measurement: Added `test_cleanup_expired_concurrently` which injects a 0.1s synthetic delay per mock backend; it verifies N=5 disconnects execute in ~0.1s instead of 0.5s.

---
*PR created automatically by Jules for task [15277250198225526980](https://jules.google.com/task/15277250198225526980) started by @n24q02m*