### PR TITLE
🎨 Palette: replace p with semantic label in credential form

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-29 - Accessibility Pattern: Semantic labels vs block elements with aria-labelledby
+**Learning:** When constructing dynamic HTML form inputs (e.g., in `credential_form.py`), using native semantic `<label for="...">` elements is significantly better than visual block elements like `<p>` paired with `aria-labelledby`.
+**Action:** Replace `promptEl = document.createElement("p");` and `inputEl.setAttribute("aria-labelledby", "step-prompt");` with a semantic `<label>` element linked to the input via the `for` attribute (or `htmlFor` in React). Native labels improve screen reader support, increase the clickable area, and render the ARIA attribute redundant.

--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -142,6 +142,7 @@ def render_telegram_credential_form(
         }}
 
         .form-title {{
+            display: block;
             font-size: 0.875rem;
             font-weight: 500;
             color: #aaa;
@@ -560,9 +561,10 @@ def render_telegram_credential_form(
                     container = document.createElement("div");
                     container.id = "step-container";
 
-                    promptEl = document.createElement("p");
+                    promptEl = document.createElement("label");
                     promptEl.id = "step-prompt";
                     promptEl.className = "form-title";
+                    promptEl.setAttribute("for", "step-input");
                     container.appendChild(promptEl);
 
                     var fieldGroup = document.createElement("div");
@@ -574,7 +576,6 @@ def render_telegram_credential_form(
                     inputEl.setAttribute("autocorrect", "off");
                     inputEl.setAttribute("autocapitalize", "off");
                     inputEl.setAttribute("spellcheck", "false");
-                    inputEl.setAttribute("aria-labelledby", "step-prompt");
                     inputEl.setAttribute("aria-describedby", "step-error");
                     fieldGroup.appendChild(inputEl);
                     container.appendChild(fieldGroup);

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.2b1"
+version = "4.12.3"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
💡 **What:** Replaced the non-semantic `<p>` block element used for dynamic step form prompts with a native, semantic `<label>` element. Updated CSS to maintain visual layout.
🎯 **Why:** To improve accessibility. Native labels increase the clickable surface area (clicking the label focuses the input) and offer superior native screen reader support without relying on ARIA fallback mappings.
📸 **Before/After:** Visually identical due to the CSS `display: block;` adjustment, but structurally sound for assistive technologies.
♿ **Accessibility:** Replaced generic text node + `aria-labelledby` with a semantic `<label for="...">` pairing, removing redundant ARIA attributes.

---
*PR created automatically by Jules for task [1363570621368088294](https://jules.google.com/task/1363570621368088294) started by @n24q02m*