### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF bypass via URL whitespace padding

### DIFF
--- a/src/better_telegram_mcp/backends/bot_backend.py
+++ b/src/better_telegram_mcp/backends/bot_backend.py
@@ -261,10 +261,10 @@ class BotBackend(TelegramBackend):
         }
         method = method_map.get(media_type, "sendDocument")
 
-        if file_path_or_url.lower().startswith(("http://", "https://")):
-            content = await fetch_url_safely(file_path_or_url)
+        if file_path_or_url.strip().lower().startswith(("http://", "https://")):
+            content = await fetch_url_safely(file_path_or_url.strip())
             field = media_type if media_type != "document" else "document"
-            filename = file_path_or_url.split("/")[-1] or "file"
+            filename = file_path_or_url.strip().split("/")[-1] or "file"
             return await self._call_form(
                 method,
                 files={field: (filename, content)},

--- a/src/better_telegram_mcp/backends/user_backend.py
+++ b/src/better_telegram_mcp/backends/user_backend.py
@@ -454,8 +454,8 @@ class UserBackend(TelegramBackend):
         elif media_type == "video":
             kwargs["video_note"] = False
 
-        if file_path_or_url.lower().startswith(("http://", "https://")):
-            file_to_send = await fetch_url_safely(file_path_or_url)
+        if file_path_or_url.strip().lower().startswith(("http://", "https://")):
+            file_to_send = await fetch_url_safely(file_path_or_url.strip())
         else:
             file_to_send = validate_file_path(file_path_or_url)
         msg = await client.send_file(chat_id, file_to_send, **kwargs)

--- a/tests/test_backends/test_ssrf_whitespace.py
+++ b/tests/test_backends/test_ssrf_whitespace.py
@@ -1,10 +1,10 @@
-import pytest
 from unittest.mock import AsyncMock, patch
-from pathlib import Path
+
+import pytest
 
 from better_telegram_mcp.backends.bot_backend import BotBackend
 from better_telegram_mcp.backends.user_backend import UserBackend
-from better_telegram_mcp.backends.security import SecurityError
+
 
 @pytest.mark.asyncio
 async def test_bot_backend_ssrf_whitespace_url():

--- a/tests/test_backends/test_ssrf_whitespace.py
+++ b/tests/test_backends/test_ssrf_whitespace.py
@@ -9,7 +9,10 @@ from better_telegram_mcp.backends.user_backend import UserBackend
 @pytest.mark.asyncio
 async def test_bot_backend_ssrf_whitespace_url():
     backend = BotBackend("12345:ABCDEF")
-    with patch("better_telegram_mcp.backends.bot_backend.fetch_url_safely", new_callable=AsyncMock) as mock_fetch:
+    with patch(
+        "better_telegram_mcp.backends.bot_backend.fetch_url_safely",
+        new_callable=AsyncMock,
+    ) as mock_fetch:
         mock_fetch.return_value = b"test"
 
         backend._call_form = AsyncMock()
@@ -17,12 +20,16 @@ async def test_bot_backend_ssrf_whitespace_url():
 
         mock_fetch.assert_called_once_with("http://127.0.0.1")
 
+
 @pytest.mark.asyncio
 async def test_user_backend_ssrf_whitespace_url():
     backend = UserBackend({})
     backend._client = AsyncMock()
     backend._connected = True
-    with patch("better_telegram_mcp.backends.user_backend.fetch_url_safely", new_callable=AsyncMock) as mock_fetch:
+    with patch(
+        "better_telegram_mcp.backends.user_backend.fetch_url_safely",
+        new_callable=AsyncMock,
+    ) as mock_fetch:
         mock_fetch.return_value = b"test"
 
         backend._serialize_message = lambda x: {}

--- a/tests/test_backends/test_ssrf_whitespace.py
+++ b/tests/test_backends/test_ssrf_whitespace.py
@@ -1,0 +1,31 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+from pathlib import Path
+
+from better_telegram_mcp.backends.bot_backend import BotBackend
+from better_telegram_mcp.backends.user_backend import UserBackend
+from better_telegram_mcp.backends.security import SecurityError
+
+@pytest.mark.asyncio
+async def test_bot_backend_ssrf_whitespace_url():
+    backend = BotBackend("12345:ABCDEF")
+    with patch("better_telegram_mcp.backends.bot_backend.fetch_url_safely", new_callable=AsyncMock) as mock_fetch:
+        mock_fetch.return_value = b"test"
+
+        backend._call_form = AsyncMock()
+        await backend.send_media(123, "photo", "   http://127.0.0.1")
+
+        mock_fetch.assert_called_once_with("http://127.0.0.1")
+
+@pytest.mark.asyncio
+async def test_user_backend_ssrf_whitespace_url():
+    backend = UserBackend({})
+    backend._client = AsyncMock()
+    backend._connected = True
+    with patch("better_telegram_mcp.backends.user_backend.fetch_url_safely", new_callable=AsyncMock) as mock_fetch:
+        mock_fetch.return_value = b"test"
+
+        backend._serialize_message = lambda x: {}
+        await backend.send_media(123, "photo", "   http://127.0.0.1")
+
+        mock_fetch.assert_called_once_with("http://127.0.0.1")

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.2b1"
+version = "4.12.3"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.3"
+version = "4.12.2b1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** SSRF vulnerability due to application-level routing using case-sensitive prefix checks bypassing URL validation using leading whitespace characters. By providing an URL like `"  http://malicious.com"`, it was previously possible to bypass the `.startswith` verification to avoid safety restrictions while still being automatically executed correctly by the underlying Telethon API client.
🎯 **Impact:** An attacker could trick the server to make unauthorized requests or expose local configuration.
🔧 **Fix:** `.strip()` the value from white space characters before doing prefix checks and before passing them to the validation layer.
✅ **Verification:** Verified by unit tests to ensure that `fetch_url_safely` is correctly executed for inputs including leading whitespaces in bot_backend and user_backend.

---
*PR created automatically by Jules for task [17478965936686366326](https://jules.google.com/task/17478965936686366326) started by @n24q02m*