### PR TITLE
⚡ Bolt: Concurrent session cleanup to prevent network blocking

### DIFF
--- a/src/better_telegram_mcp/auth/telegram_auth_provider.py
+++ b/src/better_telegram_mcp/auth/telegram_auth_provider.py
@@ -390,7 +390,9 @@ class TelegramAuthProvider:
             for bearer, result in zip(disconnect_bearers, results, strict=True):
                 if isinstance(result, Exception):  # pragma: no cover
                     logger.warning(
-                        "Error disconnecting stale OTP backend {}: {}", bearer[:8], result
+                        "Error disconnecting stale OTP backend {}: {}",
+                        bearer[:8],
+                        result,
                     )
 
         return removed

--- a/src/better_telegram_mcp/auth/telegram_auth_provider.py
+++ b/src/better_telegram_mcp/auth/telegram_auth_provider.py
@@ -356,27 +356,42 @@ class TelegramAuthProvider:
         removed = 0
         now = time.time()
 
+        revoke_tasks = []
+        revoke_bearers = []
         for bearer, info in sessions.items():
             if now - info.created_at > _SESSION_TTL:
-                await self.revoke_session(bearer)
+                revoke_tasks.append(self.revoke_session(bearer))
+                revoke_bearers.append(bearer)
+
+        if revoke_tasks:
+            results = await asyncio.gather(*revoke_tasks, return_exceptions=True)
+            for bearer, result in zip(revoke_bearers, results, strict=True):
+                if isinstance(result, Exception):
+                    logger.warning("Error revoking session {}: {}", bearer[:8], result)
                 removed += 1
 
         # Clean up stale pending OTPs (5 min TTL) using chronological insertion order.
         # Since start_user_auth pops-then-reinserts each bearer, the oldest entries
         # are always at the front, so we can stop at the first non-stale entry instead
         # of scanning the full dict on every cleanup tick.
+        disconnect_tasks = []
+        disconnect_bearers = []
         while self._pending_otps:
             bearer, pending = next(iter(self._pending_otps.items()))
             if now - pending["created_at"] <= 300:
                 break
             self._pending_otps.pop(bearer)
-            try:
-                await pending["backend"].disconnect()
-            except Exception as exc:  # pragma: no cover - best-effort cleanup
-                logger.warning(
-                    "Error disconnecting stale OTP backend {}: {}", bearer[:8], exc
-                )
+            disconnect_tasks.append(pending["backend"].disconnect())
+            disconnect_bearers.append(bearer)
             removed += 1
+
+        if disconnect_tasks:
+            results = await asyncio.gather(*disconnect_tasks, return_exceptions=True)
+            for bearer, result in zip(disconnect_bearers, results, strict=True):
+                if isinstance(result, Exception):  # pragma: no cover
+                    logger.warning(
+                        "Error disconnecting stale OTP backend {}: {}", bearer[:8], result
+                    )
 
         return removed
 


### PR DESCRIPTION
💡 What: Refactored `TelegramAuthProvider.cleanup_expired` to use `asyncio.gather(..., return_exceptions=True)` for revoking sessions and disconnecting stale OTP backends concurrently.

🎯 Why: The original implementation sequentially awaited each disconnect operation. Since each disconnect involves an MTProto roundtrip, doing this sequentially for multiple expired sessions created an O(N) blocking operation that stalled the async event loop and affected server responsiveness.

📊 Impact: Reduces cleanup network latency from O(N * RTT) to O(RTT), preventing the server from blocking during periodic sweeps of multiple expired or stale items.

🔬 Measurement: Verified by running the test suite (`tests/test_telegram_auth_provider_cleanup.py` and `tests/test_telegram_auth_provider.py`), which confirmed that multiple items are still correctly identified and removed, with individual exceptions correctly trapped and logged without aborting the batch.

---
*PR created automatically by Jules for task [10793297908091787940](https://jules.google.com/task/10793297908091787940) started by @n24q02m*