### PR TITLE
🎨 Palette: Use semantic `<label>` for step prompt

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,6 @@
 ## 2024-07-28 - Contrast Requirements for Dark Themes
 **Learning:** Text using color `#666` fails WCAG AA 4.5:1 contrast requirements when placed against dark-themed backgrounds such as `#1a1a1a`.
 **Action:** When designing dark themes, ensure that subtle or secondary text elements (like `.server-id` and `.help-text`) are upgraded to at least `#888` or `#999` to maintain readability and accessibility standards.
+## 2026-05-30 - Semantic <label> over <p> with aria-labelledby
+**Learning:** When constructing HTML form inputs dynamically (e.g., in `credential_form.py`), using native semantic `<label for="...">` elements is vastly superior to visual block elements like `<p>` paired with `aria-labelledby`. Native labels improve screen reader support out-of-the-box, but more importantly, they increase the clickable area, allowing users to click the text to focus the input field. The ARIA attribute becomes redundant and can be removed.
+**Action:** Always prefer native `<label for="inputId">` elements for form fields. To prevent visual regressions when switching from a block element (like `<p>`) to an inline `<label>`, explicitly add `display: block;` to the associated CSS class.

--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -148,6 +148,7 @@ def render_telegram_credential_form(
             text-transform: uppercase;
             letter-spacing: 0.05em;
             margin-bottom: 1.25rem;
+            display: block;
         }}
 
         .tabs {{
@@ -560,7 +561,8 @@ def render_telegram_credential_form(
                     container = document.createElement("div");
                     container.id = "step-container";
 
-                    promptEl = document.createElement("p");
+                    promptEl = document.createElement("label");
+                    promptEl.setAttribute("for", "step-input");
                     promptEl.id = "step-prompt";
                     promptEl.className = "form-title";
                     container.appendChild(promptEl);
@@ -574,7 +576,6 @@ def render_telegram_credential_form(
                     inputEl.setAttribute("autocorrect", "off");
                     inputEl.setAttribute("autocapitalize", "off");
                     inputEl.setAttribute("spellcheck", "false");
-                    inputEl.setAttribute("aria-labelledby", "step-prompt");
                     inputEl.setAttribute("aria-describedby", "step-error");
                     fieldGroup.appendChild(inputEl);
                     container.appendChild(fieldGroup);


### PR DESCRIPTION
This PR implements a micro-UX and accessibility enhancement.

By changing the prompt element from a generic `<p>` tag to a semantic `<label>` tag, it improves screen reader compatibility and increases the clickable hit area for the input field.

The element is now correctly associated using `for="step-input"`, and the now-redundant `aria-labelledby` attribute on the input has been removed. Visual layout is maintained by adding `display: block` to the prompt's CSS class.

---
*PR created automatically by Jules for task [1753572194853195870](https://jules.google.com/task/1753572194853195870) started by @n24q02m*