### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF Bypass Vulnerability via Whitespace in URLs

### DIFF
--- a/src/better_telegram_mcp/backends/bot_backend.py
+++ b/src/better_telegram_mcp/backends/bot_backend.py
@@ -261,10 +261,10 @@ class BotBackend(TelegramBackend):
         }
         method = method_map.get(media_type, "sendDocument")
 
-        if file_path_or_url.lower().startswith(("http://", "https://")):
-            content = await fetch_url_safely(file_path_or_url)
+        if file_path_or_url.strip().lower().startswith(("http://", "https://")):
+            content = await fetch_url_safely(file_path_or_url.strip())
             field = media_type if media_type != "document" else "document"
-            filename = file_path_or_url.split("/")[-1] or "file"
+            filename = file_path_or_url.strip().split("/")[-1] or "file"
             return await self._call_form(
                 method,
                 files={field: (filename, content)},

--- a/src/better_telegram_mcp/backends/user_backend.py
+++ b/src/better_telegram_mcp/backends/user_backend.py
@@ -454,8 +454,8 @@ class UserBackend(TelegramBackend):
         elif media_type == "video":
             kwargs["video_note"] = False
 
-        if file_path_or_url.lower().startswith(("http://", "https://")):
-            file_to_send = await fetch_url_safely(file_path_or_url)
+        if file_path_or_url.strip().lower().startswith(("http://", "https://")):
+            file_to_send = await fetch_url_safely(file_path_or_url.strip())
         else:
             file_to_send = validate_file_path(file_path_or_url)
         msg = await client.send_file(chat_id, file_to_send, **kwargs)

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.2b1"
+version = "4.12.3"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
**Vulnerability:** URLs could bypass the `startswith(("http://", "https://"))` check if they contained leading whitespace (e.g. `" http://malicious.com"`). This could allow malicious URLs to bypass the `fetch_url_safely` SSRF protection.

**Fix:** Appended `.strip()` before validating URLs in both `bot_backend.py` and `user_backend.py`. The stripped URL is passed into `fetch_url_safely` preventing the bypass.

**Testing:** Evaluated via standalone test scripts to verify the fix works as intended.

**Learnings:** Recorded memory context around proper URL stripping before checking and routing to telethon to prevent SSRF bypasses.

---
*PR created automatically by Jules for task [4325951422924044249](https://jules.google.com/task/4325951422924044249) started by @n24q02m*