### PR TITLE
🎨 Palette: Improve accessibility of credential form step input with semantic label

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,7 @@
 ## 2024-07-28 - Contrast Requirements for Dark Themes
 **Learning:** Text using color `#666` fails WCAG AA 4.5:1 contrast requirements when placed against dark-themed backgrounds such as `#1a1a1a`.
 **Action:** When designing dark themes, ensure that subtle or secondary text elements (like `.server-id` and `.help-text`) are upgraded to at least `#888` or `#999` to maintain readability and accessibility standards.
+
+## 2024-06-01 - Semantic Labels for Dynamically Created Inputs
+**Learning:** When dynamically generating inputs with JavaScript, it's easy to fall into the trap of using visually styled tags (like `<p>`) alongside `aria-labelledby` for screen readers. However, true semantic `<label for="...">` elements are inherently more accessible and provide a larger clickable area.
+**Action:** Always prefer native semantic tags over ARIA attributes where possible. Apply appropriate CSS (like `display: block;`) if replacing a block-level element with an inline label.

--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -148,6 +148,7 @@ def render_telegram_credential_form(
             text-transform: uppercase;
             letter-spacing: 0.05em;
             margin-bottom: 1.25rem;
+            display: block;
         }}
 
         .tabs {{
@@ -560,8 +561,9 @@ def render_telegram_credential_form(
                     container = document.createElement("div");
                     container.id = "step-container";
 
-                    promptEl = document.createElement("p");
+                    promptEl = document.createElement("label");
                     promptEl.id = "step-prompt";
+                    promptEl.setAttribute("for", "step-input");
                     promptEl.className = "form-title";
                     container.appendChild(promptEl);
 
@@ -574,7 +576,6 @@ def render_telegram_credential_form(
                     inputEl.setAttribute("autocorrect", "off");
                     inputEl.setAttribute("autocapitalize", "off");
                     inputEl.setAttribute("spellcheck", "false");
-                    inputEl.setAttribute("aria-labelledby", "step-prompt");
                     inputEl.setAttribute("aria-describedby", "step-error");
                     fieldGroup.appendChild(inputEl);
                     container.appendChild(fieldGroup);


### PR DESCRIPTION
💡 What:
Replaced the dynamically generated `<p>` tag (acting as a label) with a native semantic `<label for="step-input">` element in `credential_form.py`.
Added `display: block;` to the `.form-title` CSS class to prevent any visual layout changes.

🎯 Why:
Native semantic HTML tags are significantly more accessible. Using a true `<label>` provides inherent association with the `<input>` element without relying on ARIA workarounds. It also inherently provides a larger clickable surface area, allowing users to click the label text to focus the input field.

♿ Accessibility:
Removed redundant `aria-labelledby` attribute.
Ensured screen readers process the prompt as a standard input label rather than descriptive text.

---
*PR created automatically by Jules for task [6541251178859405891](https://jules.google.com/task/6541251178859405891) started by @n24q02m*