### PR TITLE
fix: accept cross-stack MCP_DCR_SERVER_SECRET (legacy DCR_SERVER_SECRET still works)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,8 @@ collects bot_token OR phone, posts to `/save`, and chains OTP / 2FA via
 
 - **Single-user**: writes to `config.enc`, hot-reloads the global Telethon
   backend in `server.py`.
-- **Multi-user remote** (`PUBLIC_URL` + `DCR_SERVER_SECRET` set): per-sub
+- **Multi-user remote** (`PUBLIC_URL` + `MCP_DCR_SERVER_SECRET` set; legacy
+  `DCR_SERVER_SECRET` still accepted): per-sub
   Telethon backends managed by `TelegramAuthProvider`; the auth_scope
   middleware (`_per_request_sub_scope`) pins the JWT sub + per-user
   backend into contextvars before each MCP tool call.
@@ -64,6 +65,7 @@ Session persist: `~/.better-telegram-mcp/<name>.session`, permission 600.
 - `TELEGRAM_PHONE` -- phone (required for auth web UI)
 - `TELEGRAM_AUTH_URL` -- `local` | remote URL (default: remote)
 - `TELEGRAM_SESSION_NAME`, `TELEGRAM_DATA_DIR` -- optional
+- `MCP_DCR_SERVER_SECRET` -- multi-user remote OAuth shared secret (with `PUBLIC_URL`); legacy `DCR_SERVER_SECRET` still accepted
 
 NO `TELEGRAM_PASSWORD` -- 2FA nhap qua web UI, KHONG luu env.
 
@@ -129,6 +131,6 @@ Tier policy:
 - **T2 non-interaction** (`make e2e-config CONFIG=<id>` locally) - driver pre-fills relay form from skret AWS SSM `/better-telegram-mcp/prod` (`ap-southeast-1`). No user gate.
 - **T2 interaction** - driver fills relay form, then prints upstream user-gate URL; user signs in / types OTP at provider. Driver enforces per-flow timeouts (device-code 900s, oauth-redirect 300s, browser-form 600s) and emits `[poll] elapsed=Xs remaining=Ys status=<body>` every 30s. On timeout, container logs + last `setup-status` are saved to `<tmp>/e2e-diag/` BEFORE teardown for post-mortem.
 
-Multi-user remote mode (deployment property; not a separate config) requires `DCR_SERVER_SECRET` in the same skret namespace - driver refuses to start the container without it when `PUBLIC_URL` is set.
+Multi-user remote mode (deployment property; not a separate config) requires `MCP_DCR_SERVER_SECRET` (legacy `DCR_SERVER_SECRET` still accepted) in the same skret namespace - driver refuses to start the container without it when `PUBLIC_URL` is set.
 
 References: `mcp-core/scripts/e2e/matrix.yaml`, `~/.claude/skills/mcp-dev/references/e2e-full-matrix.md` (harness-readiness gate), `~/.claude/skills/mcp-dev/references/secrets-skret.md` (per-server credential layout), `~/.claude/skills/mcp-dev/references/multi-user-pattern.md` (per-JWT-sub isolation).

--- a/src/better_telegram_mcp/config.py
+++ b/src/better_telegram_mcp/config.py
@@ -113,6 +113,7 @@ class Settings(BaseSettings):
         # 1. Check explicit env vars (prioritize CREDENTIAL_SECRET)
         secret = (
             os.environ.get("CREDENTIAL_SECRET")
+            or os.environ.get("MCP_DCR_SERVER_SECRET")
             or os.environ.get("DCR_SERVER_SECRET")
             or os.environ.get("MASTER_SECRET")
         )

--- a/src/better_telegram_mcp/transports/http.py
+++ b/src/better_telegram_mcp/transports/http.py
@@ -2,7 +2,8 @@
 
 Two outcomes (both via mcp-core ``run_http_server``):
 
-- **Multi-user remote** when ``DCR_SERVER_SECRET`` + ``PUBLIC_URL`` + a
+- **Multi-user remote** when ``MCP_DCR_SERVER_SECRET`` (legacy
+  ``DCR_SERVER_SECRET`` still accepted) + ``PUBLIC_URL`` + a
   Telegram ``api_id``/``api_hash`` pair are present. mcp-core's local OAuth
   AS issues a per-authorize ``sub`` UUID, and the ``auth_scope`` middleware
   pins that sub into a contextvar so per-tool-call handlers resolve the
@@ -18,7 +19,8 @@ Two outcomes (both via mcp-core ``run_http_server``):
 
 The ``api_id``/``api_hash`` pair has built-in defaults in ``config.py``
 (public Telegram app registration) so a deployed container only needs
-``DCR_SERVER_SECRET`` + ``PUBLIC_URL`` set to flip on multi-user.
+``MCP_DCR_SERVER_SECRET`` (legacy ``DCR_SERVER_SECRET`` still accepted) +
+``PUBLIC_URL`` set to flip on multi-user.
 
 Per spec ``2026-05-01-stdio-pure-http-multiuser.md``: there is no
 ``MCP_MODE`` env var, no remote-relay client, no daemon-bridge. Stdio mode
@@ -56,17 +58,29 @@ def get_current_backend():
     return _current_backend.get(None)
 
 
+def _dcr_secret() -> str | None:
+    """Resolve the multi-user OAuth shared secret from env.
+
+    ``MCP_DCR_SERVER_SECRET`` is the cross-stack-standard name (wins);
+    legacy ``DCR_SERVER_SECRET`` is still accepted for back-compat.
+    """
+    return os.environ.get("MCP_DCR_SERVER_SECRET") or os.environ.get(
+        "DCR_SERVER_SECRET"
+    )
+
+
 def _is_multi_user_mode(settings: Settings | None = None) -> bool:
     """Check if multi-user HTTP mode is configured.
 
-    Multi-user requires: ``DCR_SERVER_SECRET`` (OAuth shared secret) +
-    ``PUBLIC_URL`` (deployed hostname) + a Telegram ``api_id`` / ``api_hash``
-    pair. The api_id/api_hash pair is satisfied either by the corresponding
-    env vars OR by the built-in Settings defaults (the code ships a public
-    app registration — see ``config.py``), so a deployed container only
-    needs to set the two "secret" variables to flip on multi-user mode.
+    Multi-user requires: ``MCP_DCR_SERVER_SECRET`` (OAuth shared secret;
+    legacy ``DCR_SERVER_SECRET`` still accepted) + ``PUBLIC_URL`` (deployed
+    hostname) + a Telegram ``api_id`` / ``api_hash`` pair. The
+    api_id/api_hash pair is satisfied either by the corresponding env vars
+    OR by the built-in Settings defaults (the code ships a public app
+    registration — see ``config.py``), so a deployed container only needs
+    to set the two "secret" variables to flip on multi-user mode.
     """
-    has_dcr = bool(os.environ.get("DCR_SERVER_SECRET"))
+    has_dcr = bool(_dcr_secret())
     has_public_url = bool(os.environ.get("PUBLIC_URL"))
     if settings is None:
         settings = Settings()
@@ -78,14 +92,16 @@ def start_http(settings: Settings) -> None:
     """Start MCP server in HTTP mode.
 
     Three outcomes:
-    - Full multi-user OAuth 2.1 when ``DCR_SERVER_SECRET`` + ``PUBLIC_URL``
+    - Full multi-user OAuth 2.1 when ``MCP_DCR_SERVER_SECRET`` (legacy
+      ``DCR_SERVER_SECRET`` still accepted) + ``PUBLIC_URL``
       are set and a ``api_id``/``api_hash`` pair is available (via env var
       or the built-in Settings defaults). Per-JWT-sub Telethon clients,
       isolated credentials, the intended public-deploy mode.
     - Single-user relay fallback when ``PUBLIC_URL`` is absent — that's
       self-host / localhost ``uvx`` usage and a single shared config is
       correct there.
-    - ``RuntimeError`` when ``PUBLIC_URL`` is set but ``DCR_SERVER_SECRET``
+    - ``RuntimeError`` when ``PUBLIC_URL`` is set but
+      ``MCP_DCR_SERVER_SECRET`` / ``DCR_SERVER_SECRET``
       or the api_id/api_hash pair is missing. Without all three, the
       fallback would serve a shared ``default.session`` + ``TELEGRAM_PHONE``
       across every visitor, which leaks credentials (the 2026-04-21
@@ -101,8 +117,8 @@ def start_http(settings: Settings) -> None:
     override = os.environ.get("TELEGRAM_ACCEPT_SHARED_SINGLE_USER") == "1"
     if public_url and not override:
         missing = []
-        if not os.environ.get("DCR_SERVER_SECRET"):
-            missing.append("DCR_SERVER_SECRET")
+        if not _dcr_secret():
+            missing.append("MCP_DCR_SERVER_SECRET (legacy DCR_SERVER_SECRET)")
         if not (settings.api_id and settings.api_hash):
             missing.append("TELEGRAM_API_ID and TELEGRAM_API_HASH")
         msg = (
@@ -239,8 +255,9 @@ def _start_multi_user_http(settings: Settings) -> None:
     ``TelegramAuthProvider`` so concurrent users do not share Telethon
     sessions.
 
-    The ``DCR_SERVER_SECRET`` env var is required by the upstream check
-    in :func:`_is_multi_user_mode`; mcp-core's local OAuth AS reuses it
+    The ``MCP_DCR_SERVER_SECRET`` env var (legacy ``DCR_SERVER_SECRET``
+    still accepted) is required by the upstream check in
+    :func:`_is_multi_user_mode`; mcp-core's local OAuth AS reuses it
     to mint per-user JWTs.
     """
     import asyncio

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -112,8 +112,20 @@ def test_secret_priority_env_credential(monkeypatch):
     assert s.secret == "env-cred"
 
 
-def test_secret_priority_env_dcr(monkeypatch):
+def test_secret_priority_env_mcp_dcr(monkeypatch):
+    """MCP_DCR_SERVER_SECRET (cross-stack name) wins over legacy DCR_SERVER_SECRET."""
     monkeypatch.delenv("CREDENTIAL_SECRET", raising=False)
+    monkeypatch.setenv("MCP_DCR_SERVER_SECRET", "env-mcp-dcr")
+    monkeypatch.setenv("DCR_SERVER_SECRET", "env-dcr")
+    monkeypatch.setenv("MASTER_SECRET", "env-master")
+    s = Settings()
+    assert s.secret == "env-mcp-dcr"
+
+
+def test_secret_priority_env_dcr(monkeypatch):
+    """Back-compat: legacy DCR_SERVER_SECRET still resolves when MCP_ name absent."""
+    monkeypatch.delenv("CREDENTIAL_SECRET", raising=False)
+    monkeypatch.delenv("MCP_DCR_SERVER_SECRET", raising=False)
     monkeypatch.setenv("DCR_SERVER_SECRET", "env-dcr")
     monkeypatch.setenv("MASTER_SECRET", "env-master")
     s = Settings()
@@ -124,7 +136,12 @@ def test_secret_persistence(tmp_path):
     # Test that it generates and persists a secret when no env vars are set
     import os
 
-    for env in ["CREDENTIAL_SECRET", "DCR_SERVER_SECRET", "MASTER_SECRET"]:
+    for env in [
+        "CREDENTIAL_SECRET",
+        "MCP_DCR_SERVER_SECRET",
+        "DCR_SERVER_SECRET",
+        "MASTER_SECRET",
+    ]:
         if env in os.environ:
             del os.environ[env]
 

--- a/tests/test_transports/test_http.py
+++ b/tests/test_transports/test_http.py
@@ -65,8 +65,32 @@ class TestIsMultiUserMode:
             # settings has api_id/api_hash by default
             assert _is_multi_user_mode(settings) is True
 
+    def test_is_multi_user_mode_true_mcp_prefixed_secret(
+        self, settings: Settings
+    ) -> None:
+        """Returns True when only MCP_DCR_SERVER_SECRET (cross-stack name)
+        is set — the primary env var, no legacy var needed."""
+        env = {
+            "MCP_DCR_SERVER_SECRET": "secret",
+            "PUBLIC_URL": "https://mcp.example.com",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            assert _is_multi_user_mode(settings) is True
+
+    def test_is_multi_user_mode_true_legacy_secret(
+        self, settings: Settings
+    ) -> None:
+        """Back-compat: returns True when only the legacy DCR_SERVER_SECRET
+        is set (MCP_DCR_SERVER_SECRET absent)."""
+        env = {
+            "DCR_SERVER_SECRET": "secret",
+            "PUBLIC_URL": "https://mcp.example.com",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            assert _is_multi_user_mode(settings) is True
+
     def test_is_multi_user_mode_false_missing_dcr(self, settings: Settings) -> None:
-        """Returns False when DCR_SERVER_SECRET is missing."""
+        """Returns False when both DCR secret names are missing."""
         env = {"PUBLIC_URL": "https://mcp.example.com"}
         with patch.dict("os.environ", env, clear=True):
             assert _is_multi_user_mode(settings) is False
@@ -193,6 +217,70 @@ class TestStartHttp:
         kwargs = mock_run.call_args.kwargs
         assert kwargs["port"] == 8080
         assert kwargs["host"] == "0.0.0.0"
+
+    def test_start_http_multi_user_mcp_prefixed_secret_no_runtimeerror(
+        self, tmp_path: Path
+    ) -> None:
+        """The gate passes (no RuntimeError, multi-user dispatched) when only
+        MCP_DCR_SERVER_SECRET is set with PUBLIC_URL."""
+        env = {
+            "MCP_DCR_SERVER_SECRET": "secret",
+            "PUBLIC_URL": "https://mcp.example.com",
+            "TELEGRAM_API_ID": "12345",
+            "TELEGRAM_API_HASH": "hash",
+        }
+        with (
+            patch.dict("os.environ", env, clear=True),
+            patch(
+                "mcp_core.transport.local_server.run_http_server",
+                new_callable=AsyncMock,
+            ) as mock_run,
+            patch(
+                "better_telegram_mcp.auth.telegram_auth_provider.TelegramAuthProvider"
+            ) as mock_provider_cls,
+        ):
+            mock_provider = mock_provider_cls.return_value
+            mock_provider.restore_sessions = AsyncMock(return_value=0)
+            mock_provider.shutdown = AsyncMock()
+            settings_with_api = Settings(
+                data_dir=tmp_path / "d", api_id=12345, api_hash="hash"
+            )
+            start_http(settings_with_api)
+
+        mock_run.assert_called_once()
+        assert mock_run.call_args.kwargs["auth_scope"] is _per_request_sub_scope
+
+    def test_start_http_multi_user_legacy_secret_no_runtimeerror(
+        self, tmp_path: Path
+    ) -> None:
+        """Back-compat: gate passes when only the legacy DCR_SERVER_SECRET
+        is set with PUBLIC_URL."""
+        env = {
+            "DCR_SERVER_SECRET": "secret",
+            "PUBLIC_URL": "https://mcp.example.com",
+            "TELEGRAM_API_ID": "12345",
+            "TELEGRAM_API_HASH": "hash",
+        }
+        with (
+            patch.dict("os.environ", env, clear=True),
+            patch(
+                "mcp_core.transport.local_server.run_http_server",
+                new_callable=AsyncMock,
+            ) as mock_run,
+            patch(
+                "better_telegram_mcp.auth.telegram_auth_provider.TelegramAuthProvider"
+            ) as mock_provider_cls,
+        ):
+            mock_provider = mock_provider_cls.return_value
+            mock_provider.restore_sessions = AsyncMock(return_value=0)
+            mock_provider.shutdown = AsyncMock()
+            settings_with_api = Settings(
+                data_dir=tmp_path / "d", api_id=12345, api_hash="hash"
+            )
+            start_http(settings_with_api)
+
+        mock_run.assert_called_once()
+        assert mock_run.call_args.kwargs["auth_scope"] is _per_request_sub_scope
 
     def test_start_http_refuses_public_url_without_multi_user(
         self, settings: Settings

--- a/tests/test_transports/test_http.py
+++ b/tests/test_transports/test_http.py
@@ -77,9 +77,7 @@ class TestIsMultiUserMode:
         with patch.dict("os.environ", env, clear=True):
             assert _is_multi_user_mode(settings) is True
 
-    def test_is_multi_user_mode_true_legacy_secret(
-        self, settings: Settings
-    ) -> None:
+    def test_is_multi_user_mode_true_legacy_secret(self, settings: Settings) -> None:
         """Back-compat: returns True when only the legacy DCR_SERVER_SECRET
         is set (MCP_DCR_SERVER_SECRET absent)."""
         env = {


### PR DESCRIPTION
@-