### PR TITLE
🎨 Palette: Native Label for step inputs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,6 @@
 ## 2024-07-28 - Contrast Requirements for Dark Themes
 **Learning:** Text using color `#666` fails WCAG AA 4.5:1 contrast requirements when placed against dark-themed backgrounds such as `#1a1a1a`.
 **Action:** When designing dark themes, ensure that subtle or secondary text elements (like `.server-id` and `.help-text`) are upgraded to at least `#888` or `#999` to maintain readability and accessibility standards.
+## 2024-05-18 - [Accessibility: Native Labels over ARIA in Form Inputs]
+**Learning:** When constructing HTML form inputs dynamically (e.g., in `credential_form.py`), using native semantic `<label for="...">` elements is superior to visual block elements like `<p>` paired with `aria-labelledby`. Native labels provide better screen reader support and inherently increase the clickable area without requiring extra ARIA attributes.
+**Action:** When creating form inputs, always use native `<label>` elements connected via the `for` attribute instead of non-semantic elements with `aria-labelledby`. If a block-level display is required, use CSS `display: block;` on the label rather than a block element like `<p>`.

--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -142,6 +142,7 @@ def render_telegram_credential_form(
         }}
 
         .form-title {{
+            display: block;
             font-size: 0.875rem;
             font-weight: 500;
             color: #aaa;
@@ -560,7 +561,8 @@ def render_telegram_credential_form(
                     container = document.createElement("div");
                     container.id = "step-container";
 
-                    promptEl = document.createElement("p");
+                    promptEl = document.createElement("label");
+                    promptEl.htmlFor = "step-input";
                     promptEl.id = "step-prompt";
                     promptEl.className = "form-title";
                     container.appendChild(promptEl);
@@ -574,7 +576,6 @@ def render_telegram_credential_form(
                     inputEl.setAttribute("autocorrect", "off");
                     inputEl.setAttribute("autocapitalize", "off");
                     inputEl.setAttribute("spellcheck", "false");
-                    inputEl.setAttribute("aria-labelledby", "step-prompt");
                     inputEl.setAttribute("aria-describedby", "step-error");
                     fieldGroup.appendChild(inputEl);
                     container.appendChild(fieldGroup);


### PR DESCRIPTION
💡 **What**: Refactored `showStepInput` to use a semantic `<label>` element mapped to its input via `for` instead of a non-semantic `<p>` tag mapped via `aria-labelledby`.
🎯 **Why**: Native labels are structurally robust, widely supported by screen readers out-of-the-box, and increase the clickable target area without relying on redundant ARIA mapping.
♿ **Accessibility**: Enhanced screen reader support and general accessibility for the multi-step auth form inputs by using correct semantic HTML instead of `aria-labelledby` workarounds.

---
*PR created automatically by Jules for task [11383160496962946420](https://jules.google.com/task/11383160496962946420) started by @n24q02m*