### PR TITLE
⚡ Bolt: Optimize memory usage in get_members

### DIFF
--- a/src/better_telegram_mcp/backends/user_backend.py
+++ b/src/better_telegram_mcp/backends/user_backend.py
@@ -343,8 +343,13 @@ class UserBackend(TelegramBackend):
         self, chat_id: str | int, *, limit: int = 50
     ) -> list[dict[str, Any]]:
         client = self._ensure_client()
-        users = await client.get_participants(chat_id, limit=limit)
-        return [self._serialize_user(user) for user in users]
+        # Bolt: Avoid the get_participants() anti-pattern, which just calls
+        # iter_participants(...).collect(). Using async comprehensions improves
+        # memory efficiency without worsening network latency.
+        return [
+            self._serialize_user(user)
+            async for user in client.iter_participants(chat_id, limit=limit)
+        ]
 
     async def promote_admin(
         self, chat_id: str | int, user_id: int, *, demote: bool = False

--- a/tests/test_backends/test_user_backend.py
+++ b/tests/test_backends/test_user_backend.py
@@ -653,7 +653,11 @@ class TestGetMembers:
 
         users = [_mock_user(user_id=i) for i in range(3)]
 
-        mock_client.get_participants = AsyncMock(return_value=users)
+        async def _mock_iter_participants(*args, **kwargs):
+            for u in users:
+                yield u
+
+        mock_client.iter_participants = MagicMock(side_effect=_mock_iter_participants)
 
         settings = _make_settings(tmp_path)
         backend = UserBackend(settings)
@@ -661,7 +665,7 @@ class TestGetMembers:
 
         result = await backend.get_members(123, limit=10)
 
-        mock_client.get_participants.assert_awaited_once_with(123, limit=10)
+        mock_client.iter_participants.assert_called_once_with(123, limit=10)
         assert len(result) == 3
         assert result[0]["first_name"] == "Test"
 


### PR DESCRIPTION
💡 What: Replaced `get_participants` with `iter_participants` and an async comprehension in `UserBackend.get_members`.
🎯 Why: `get_participants` eagerly loads all entities into memory before returning them as a list, which can cause unnecessary memory pressure for large groups. Using the async generator streams them directly into the serializer.
📊 Impact: Reduces memory footprint when serializing large lists of chat members by avoiding an intermediate full-size list allocation.
🔬 Measurement: Verify tests pass and there is no regression in member fetching. Memory profiling would show fewer list allocations.

---
*PR created automatically by Jules for task [8002370963421042073](https://jules.google.com/task/8002370963421042073) started by @n24q02m*