### PR TITLE
🎨 Palette: Improve credential form contrast

### DIFF
--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -130,14 +130,14 @@ def render_telegram_credential_form(
 
         .server-id {{
             font-size: 0.8125rem;
-            color: #999;
+            color: #aaaaaa;
             font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
             margin-bottom: 0.5rem;
         }}
 
         .server-description {{
             font-size: 0.9rem;
-            color: #999;
+            color: #aaaaaa;
             margin-top: 0.5rem;
         }}
 
@@ -263,7 +263,7 @@ def render_telegram_credential_form(
 
         .help-text {{
             font-size: 0.8125rem;
-            color: #999;
+            color: #aaaaaa;
             margin-top: 0.375rem;
         }}
 


### PR DESCRIPTION
🎨 Palette: Improve text contrast on dark theme elements in credential form

**💡 What:**
Updated the CSS color property for `.server-id`, `.server-description`, and `.help-text` from `#999` to `#aaaaaa`.

**🎯 Why:**
To improve readability and WCAG contrast ratio on dark-themed backgrounds (`#1a1a1a`), making the interface more accessible for all users. 

**♿ Accessibility:**
Improves contrast ratio.

---
*PR created automatically by Jules for task [16874752516497277363](https://jules.google.com/task/16874752516497277363) started by @n24q02m*