### PR TITLE
🎨 Palette: Improve form accessibility with native labels

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,7 @@
 ## 2024-07-28 - Contrast Requirements for Dark Themes
 **Learning:** Text using color `#666` fails WCAG AA 4.5:1 contrast requirements when placed against dark-themed backgrounds such as `#1a1a1a`.
 **Action:** When designing dark themes, ensure that subtle or secondary text elements (like `.server-id` and `.help-text`) are upgraded to at least `#888` or `#999` to maintain readability and accessibility standards.
+
+## 2024-08-01 - Prefer Native `<label>` Elements Over `aria-labelledby`
+**Learning:** When constructing HTML form inputs dynamically in JS (e.g., in `credential_form.py`'s `step-input` builder), it is always best to use semantic native `<label>` elements connected via `htmlFor = "input-id"` rather than structural elements like `<p>` paired with `aria-labelledby`. This avoids over-reliance on ARIA, improves native screen reader support, and naturally increases the clickable area for inputs without additional code.
+**Action:** Default to `<label for="id">` instead of ARIA associations for primary input labels. To prevent visual regressions when transitioning elements from block types (like `<p>` or `<div>`) to inline `<label>` elements, explicitly add `display: block;` to the corresponding CSS class.

--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -142,6 +142,7 @@ def render_telegram_credential_form(
         }}
 
         .form-title {{
+            display: block;
             font-size: 0.875rem;
             font-weight: 500;
             color: #aaa;
@@ -560,8 +561,9 @@ def render_telegram_credential_form(
                     container = document.createElement("div");
                     container.id = "step-container";
 
-                    promptEl = document.createElement("p");
+                    promptEl = document.createElement("label");
                     promptEl.id = "step-prompt";
+                    promptEl.htmlFor = "step-input";
                     promptEl.className = "form-title";
                     container.appendChild(promptEl);
 
@@ -574,7 +576,6 @@ def render_telegram_credential_form(
                     inputEl.setAttribute("autocorrect", "off");
                     inputEl.setAttribute("autocapitalize", "off");
                     inputEl.setAttribute("spellcheck", "false");
-                    inputEl.setAttribute("aria-labelledby", "step-prompt");
                     inputEl.setAttribute("aria-describedby", "step-error");
                     fieldGroup.appendChild(inputEl);
                     container.appendChild(fieldGroup);


### PR DESCRIPTION
💡 **What:** Replaced the structural `<p>` pseudo-label with a semantic `<label>` connected via `htmlFor`. Added `display: block;` to maintain visual compatibility.
🎯 **Why:** To improve accessibility by favoring native HTML semantics over ARIA attributes. This enhances screen reader support and naturally increases the clickable target area without extra scripting.
♿ **Accessibility:** Replaced `aria-labelledby` relying on a `<p>` tag with a native HTML `<label for="...">` connection.

---
*PR created automatically by Jules for task [12388611924439248223](https://jules.google.com/task/12388611924439248223) started by @n24q02m*