### PR TITLE
[FIX] Unused Import in tools/__init__.py

### DIFF
--- a/src/better_telegram_mcp/tools/__init__.py
+++ b/src/better_telegram_mcp/tools/__init__.py
@@ -1,16 +1,1 @@
-from .chats import handle_chats
-from .config_tool import handle_config
-from .contacts import handle_contacts
-from .help_tool import handle_help
-from .media import handle_media
-from .messages import MessagesArgs, handle_messages
 
-__all__ = [
-    "MessagesArgs",
-    "handle_chats",
-    "handle_config",
-    "handle_contacts",
-    "handle_help",
-    "handle_media",
-    "handle_messages",
-]

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.4b1"
+version = "4.12.4"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
Removed unused imports and the `__all__` block from `src/better_telegram_mcp/tools/__init__.py`. All consumers and tests in the codebase import tool handlers directly from their respective submodules (e.g., `src/better_telegram_mcp/server.py` uses `from .tools.media import MediaOptions, handle_media`), making these package-level re-exports redundant. This cleanup follows the project's minimal public API pattern and resolves the reported unused import issue.

---
*PR created automatically by Jules for task [4197393542190608623](https://jules.google.com/task/4197393542190608623) started by @n24q02m*