### PR TITLE
[PERF] Optimize key preview string allocation and slicing in HTTP transport

### DIFF
--- a/src/better_telegram_mcp/transports/http.py
+++ b/src/better_telegram_mcp/transports/http.py
@@ -27,6 +27,7 @@ Per spec ``2026-05-01-stdio-pure-http-multiuser.md``: there is no
 is handled in ``server.main()`` and never reaches this module.
 """
 
+import itertools
 import os
 from contextvars import ContextVar
 from typing import Any
@@ -214,13 +215,13 @@ async def _per_request_sub_scope(
         provider = get_global_provider()
         if provider is not None:
             backend = provider.resolve_backend(sub)
-            keys_preview = list(provider.active_clients.keys())
             keys_short = [
-                k[:12] + "..." if len(k) > 12 else k for k in keys_preview[:5]
+                f"{k[:12]}..." if len(k) > 12 else k
+                for k in itertools.islice(provider.active_clients.keys(), 5)
             ]
             logger.info(
                 "auth_scope: sub={} found_backend={} active_keys_count={} keys={}",
-                (sub or "")[:12] + "...",
+                f"{(sub or '')[:12]}...",
                 type(backend).__name__ if backend else "None",
                 len(provider.active_clients),
                 keys_short,


### PR DESCRIPTION
This PR addresses a minor performance inefficiency in the HTTP transport's authentication middleware.

### Changes:
1.  **Avoid Full List Creation:** Replaced `list(provider.active_clients.keys())[:5]` with `itertools.islice(provider.active_clients.keys(), 5)`. This prevents creating a potentially large list of all active client keys in memory when only the first 5 are needed for logging.
2.  **Efficient String Formatting:** Replaced string concatenation (`+ "..."`) with f-strings (`f"{k[:12]}..."`) in the key preview loop and the `sub` truncation. F-strings are generally more efficient in Python for this type of operation.
3.  **Import Optimization:** Added `import itertools` and ensured imports are sorted using `ruff`.

### Verification:
- Ran `pytest tests/test_transports/test_http.py` and all 18 tests passed.
- Ran `ruff check` and `ruff format` to ensure code quality.
- Ran `ty check` for type consistency.
- Manually verified the logic change preserves the intended logging output.

---
*PR created automatically by Jules for task [17564835341563808586](https://jules.google.com/task/17564835341563808586) started by @n24q02m*