### PR TITLE
[FIX] Unused Import in __init__.py

### DIFF
--- a/src/better_telegram_mcp/__init__.py
+++ b/src/better_telegram_mcp/__init__.py
@@ -1,10 +1,8 @@
 from importlib.metadata import PackageNotFoundError, version
 
-from .__main__ import _cli as main
-
 try:
     __version__ = version("better-telegram-mcp")
 except PackageNotFoundError:
     __version__ = "unknown"
 
-__all__ = ["main", "__version__"]
+__all__ = ["__version__"]

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.4b1"
+version = "4.12.4"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
Removed the redundant re-export of the CLI entry point from 'src/better_telegram_mcp/__init__.py'. The CLI entry point is already correctly defined in 'pyproject.toml' pointing to 'better_telegram_mcp.__main__:_cli'. This reduces the public API surface and eliminates an unused import warning.

---
*PR created automatically by Jules for task [332407046066059919](https://jules.google.com/task/332407046066059919) started by @n24q02m*