### PR TITLE
[FIX] Unused Import in backends/__init__.py

### DIFF
--- a/src/better_telegram_mcp/backends/__init__.py
+++ b/src/better_telegram_mcp/backends/__init__.py
@@ -1,3 +1,1 @@
-from .base import ModeError, TelegramBackend
-
-__all__ = ["ModeError", "TelegramBackend"]
+"""Telegram backends."""

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.4b1"
+version = "4.12.4"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
This PR removes unused imports in `src/better_telegram_mcp/backends/__init__.py`.

The `ModeError` and `TelegramBackend` classes were being imported and exported via `__all__`, but they are not used by any internal consumers that import from the package root. All existing consumers (in `server.py`, `tools/`, and `tests/`) already import these classes directly from `better_telegram_mcp.backends.base`.

Removing these redundant re-exports cleans up the codebase and ensures the `backends` module has a minimal API surface.

Changes:
- Replaced re-exports in `src/better_telegram_mcp/backends/__init__.py` with a module docstring.

Verification:
- Ran `uv run ruff check src/better_telegram_mcp/backends/__init__.py` (Passed)
- Ran `uv run pytest` for backends, server, and tools (Passed)

---
*PR created automatically by Jules for task [864834876359160411](https://jules.google.com/task/864834876359160411) started by @n24q02m*