### PR TITLE
[FIX] Unused Import in relay_setup.py

### DIFF
--- a/src/better_telegram_mcp/relay_setup.py
+++ b/src/better_telegram_mcp/relay_setup.py
@@ -11,8 +11,6 @@ verified through the ``/otp`` endpoint (see ``credential_state.save_credentials`
 and ``credential_state.on_step_submitted``).
 """
 
-from __future__ import annotations
-
 import re
 from pathlib import Path
 


### PR DESCRIPTION
This PR removes the redundant `from __future__ import annotations` from `src/better_telegram_mcp/relay_setup.py`.

In Python 3.13+, this import is often unnecessary unless there are self-referential type hints or forward references that aren't otherwise handled. In this specific file, none of those conditions are met, so the import was correctly identified as unused.

Changes:
- Removed `from __future__ import annotations` from `src/better_telegram_mcp/relay_setup.py`.
- Reformatted the file using `ruff` to ensure proper spacing.

Verification:
- `uv run ruff check src/better_telegram_mcp/relay_setup.py` passes.
- `uv run ty check src/better_telegram_mcp/relay_setup.py` passes.
- `uv run pytest tests/test_relay_setup.py` passes (43 tests).

---
*PR created automatically by Jules for task [9952725772160457597](https://jules.google.com/task/9952725772160457597) started by @n24q02m*