### PR TITLE
[FIX] Unused Import in tools/__init__.py

### DIFF
--- a/src/better_telegram_mcp/tools/__init__.py
+++ b/src/better_telegram_mcp/tools/__init__.py
@@ -3,10 +3,9 @@ from .config_tool import handle_config
 from .contacts import handle_contacts
 from .help_tool import handle_help
 from .media import handle_media
-from .messages import MessagesArgs, handle_messages
+from .messages import handle_messages
 
 __all__ = [
-    "MessagesArgs",
     "handle_chats",
     "handle_config",
     "handle_contacts",


### PR DESCRIPTION
This PR removes the unused `MessagesArgs` import and its corresponding entry in `__all__` from `src/better_telegram_mcp/tools/__init__.py`. 

**Reasoning:**
- `MessagesArgs` is defined in `src/better_telegram_mcp/tools/messages.py`.
- Consumers of `MessagesArgs` (such as `src/better_telegram_mcp/server.py` and various tests) already import it directly from the `messages` submodule rather than the `tools` package root.
- Unused imports should be removed to maintain a clean codebase and avoid unnecessary overhead or potential circular dependencies.

**Verification:**
- Verified that no other modules in `src` or `tests` were importing `MessagesArgs` from `better_telegram_mcp.tools`.
- Ran the full test suite (`pytest tests -m "not integration and not live"`); all 601 relevant tests passed.
- Ran `ruff check` on the modified file; no issues found.

---
*PR created automatically by Jules for task [11353795310926016999](https://jules.google.com/task/11353795310926016999) started by @n24q02m*