### PR TITLE
[PERF] Sequential async calls in session cleanup loop

### DIFF
--- a/src/better_telegram_mcp/auth/telegram_auth_provider.py
+++ b/src/better_telegram_mcp/auth/telegram_auth_provider.py
@@ -351,32 +351,63 @@ class TelegramAuthProvider:
         return self._store.delete(bearer)
 
     async def cleanup_expired(self) -> int:
-        """Remove expired sessions. Returns count of removed sessions."""
+        """Remove expired sessions and stale OTPs concurrently.
+
+        Each Telethon ``disconnect()`` waits for an MTProto roundtrip; running
+        them sequentially turns cleanup into ``len(expired) * RTT``.
+        ``asyncio.gather(..., return_exceptions=True)`` parallelises them.
+        """
         sessions = self._store.load_all()
         removed = 0
         now = time.time()
 
-        for bearer, info in sessions.items():
-            if now - info.created_at > _SESSION_TTL:
-                await self.revoke_session(bearer)
-                removed += 1
+        # 1. Identify and revoke expired sessions concurrently
+        expired_bearers = [
+            bearer
+            for bearer, info in sessions.items()
+            if now - info.created_at > _SESSION_TTL
+        ]
+        if expired_bearers:
+            results = await asyncio.gather(
+                *(self.revoke_session(b) for b in expired_bearers),
+                return_exceptions=True,
+            )
+            for r in results:
+                if isinstance(r, Exception):
+                    logger.warning("Error during session revocation: {}", r)
+                elif r is True:
+                    removed += 1
 
-        # Clean up stale pending OTPs (5 min TTL) using chronological insertion order.
+        # 2. Clean up stale pending OTPs (5 min TTL) concurrently
         # Since start_user_auth pops-then-reinserts each bearer, the oldest entries
-        # are always at the front, so we can stop at the first non-stale entry instead
-        # of scanning the full dict on every cleanup tick.
+        # are at the front, so we can stop at the first non-stale entry.
+        stale_otps = []
         while self._pending_otps:
             bearer, pending = next(iter(self._pending_otps.items()))
             if now - pending["created_at"] <= 300:
                 break
-            self._pending_otps.pop(bearer)
-            try:
-                await pending["backend"].disconnect()
-            except Exception as exc:  # pragma: no cover - best-effort cleanup
-                logger.warning(
-                    "Error disconnecting stale OTP backend {}: {}", bearer[:8], exc
-                )
-            removed += 1
+            stale_otps.append(self._pending_otps.pop(bearer))
+
+        if stale_otps:
+
+            async def _disconnect(p: dict) -> bool:
+                try:
+                    await p["backend"].disconnect()
+                    return True
+                except Exception as exc:
+                    logger.warning(
+                        "Error disconnecting stale OTP backend {}: {}",
+                        p["bearer"][:8],
+                        exc,
+                    )
+                    return False
+
+            await asyncio.gather(
+                *(_disconnect(p) for p in stale_otps),
+                return_exceptions=True,
+            )
+            # Both True and False from _disconnect mean it was "removed" from pending
+            removed += len(stale_otps)
 
         return removed
 

--- a/tests/test_telegram_auth_provider_cleanup.py
+++ b/tests/test_telegram_auth_provider_cleanup.py
@@ -51,3 +51,137 @@ async def test_shutdown_logs_pending_otp_disconnect_error(
         assert "Error disconnecting pending OTP backend test-bea" in caplog.text
     finally:
         logger.remove(handler_id)
+
+
+async def test_cleanup_expired_concurrent(provider: TelegramAuthProvider) -> None:
+    """Should clean up multiple expired sessions and OTPs concurrently."""
+    from better_telegram_mcp.auth.per_user_session_store import SessionInfo
+    from better_telegram_mcp.auth.telegram_auth_provider import _SESSION_TTL
+
+    now = time.time()
+    # 2 expired sessions
+    provider._store.store(
+        "exp1",
+        SessionInfo(
+            session_name="s1",
+            mode="bot",
+            bot_token="t1",
+            created_at=now - _SESSION_TTL - 10,
+        ),
+    )
+    provider._store.store(
+        "exp2",
+        SessionInfo(
+            session_name="s2",
+            mode="bot",
+            bot_token="t2",
+            created_at=now - _SESSION_TTL - 20,
+        ),
+    )
+    # 1 valid session
+    provider._store.store(
+        "valid",
+        SessionInfo(
+            session_name="s3",
+            mode="bot",
+            bot_token="t3",
+            created_at=now,
+        ),
+    )
+
+    # 2 stale OTPs
+    mock_backend1 = AsyncMock()
+    mock_backend2 = AsyncMock()
+    provider._pending_otps["otp1"] = {
+        "bearer": "otp1",
+        "backend": mock_backend1,
+        "phone": "+1",
+        "phone_code_hash": "h1",
+        "session_name": "o1",
+        "created_at": now - 600,
+    }
+    provider._pending_otps["otp2"] = {
+        "bearer": "otp2",
+        "backend": mock_backend2,
+        "phone": "+2",
+        "phone_code_hash": "h2",
+        "session_name": "o2",
+        "created_at": now - 700,
+    }
+
+    removed = await provider.cleanup_expired()
+    assert removed == 4
+    assert provider._store.load("exp1") is None
+    assert provider._store.load("exp2") is None
+    assert provider._store.load("valid") is not None
+    assert "otp1" not in provider._pending_otps
+    assert "otp2" not in provider._pending_otps
+    mock_backend1.disconnect.assert_called_once()
+    mock_backend2.disconnect.assert_called_once()
+
+
+async def test_cleanup_expired_handles_exceptions(
+    provider: TelegramAuthProvider, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Should handle and log exceptions during cleanup without crashing."""
+    from better_telegram_mcp.auth.per_user_session_store import SessionInfo
+    from better_telegram_mcp.auth.telegram_auth_provider import _SESSION_TTL
+
+    handler_id = logger.add(caplog.handler, format="{message}", level="WARNING")
+
+    try:
+        now = time.time()
+        # Mock revoke_session to raise an error for one bearer
+        original_revoke = provider.revoke_session
+
+        async def mock_revoke(bearer: str) -> bool:
+            if bearer == "fail":
+                raise Exception("Revocation failed")
+            return await original_revoke(bearer)
+
+        provider.revoke_session = mock_revoke
+
+        provider._store.store(
+            "fail",
+            SessionInfo(
+                session_name="sf",
+                mode="bot",
+                bot_token="tf",
+                created_at=now - _SESSION_TTL - 10,
+            ),
+        )
+        provider._store.store(
+            "ok",
+            SessionInfo(
+                session_name="so",
+                mode="bot",
+                bot_token="to",
+                created_at=now - _SESSION_TTL - 20,
+            ),
+        )
+
+        # Stale OTP that fails to disconnect
+        mock_backend = AsyncMock()
+        mock_backend.disconnect.side_effect = Exception("Disconnect failed")
+        provider._pending_otps["otp_fail"] = {
+            "bearer": "otp_fail",
+            "backend": mock_backend,
+            "phone": "+1",
+            "phone_code_hash": "h1",
+            "session_name": "of",
+            "created_at": now - 600,
+        }
+
+        removed = await provider.cleanup_expired()
+
+        # 'ok' session removed = 1
+        # 'otp_fail' removed from dict = 1
+        # Total = 2
+        assert removed == 2
+        assert "Error during session revocation: Revocation failed" in caplog.text
+        assert (
+            "Error disconnecting stale OTP backend otp_fail: Disconnect failed"
+            in caplog.text
+        )
+    finally:
+        logger.remove(handler_id)

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.4b1"
+version = "4.12.4"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
### Problem
In `TelegramAuthProvider.cleanup_expired`, the removal of expired sessions and stale OTPs was performed sequentially using `await` in a loop. Since each revocation or disconnection involves network I/O and MTProto round-trips, the total cleanup time scaled linearly with the number of expired items, potentially blocking the server for an extended period.

### Solution
- Refactored `cleanup_expired` to identify all expired sessions first, then revoke them concurrently using `asyncio.gather`.
- Refactored stale OTP cleanup to collect all stale entries and disconnect them concurrently using `asyncio.gather`.
- Used `return_exceptions=True` in `asyncio.gather` to ensure that a failure in one cleanup task doesn't abort the others, matching the "best-effort" cleanup semantics.
- Added comprehensive unit tests in `tests/test_telegram_auth_provider_cleanup.py` to verify:
  - Multiple expired sessions and OTPs are removed.
  - Exceptions during concurrent cleanup are caught and logged as warnings.

### Verification
- Ran `ruff check` and `ruff format` (all passed).
- Ran `ty check` (passed).
- Ran all relevant tests in `tests/test_telegram_auth_provider.py` and `tests/test_telegram_auth_provider_cleanup.py` (all 27 tests passed).

---
*PR created automatically by Jules for task [3057030078908263963](https://jules.google.com/task/3057030078908263963) started by @n24q02m*