### PR TITLE
[FIX] Unused Import in tools/__init__.py

### DIFF
--- a/src/better_telegram_mcp/tools/__init__.py
+++ b/src/better_telegram_mcp/tools/__init__.py
@@ -1,16 +1,1 @@
-from .chats import handle_chats
-from .config_tool import handle_config
-from .contacts import handle_contacts
-from .help_tool import handle_help
-from .media import handle_media
-from .messages import MessagesArgs, handle_messages
 
-__all__ = [
-    "MessagesArgs",
-    "handle_chats",
-    "handle_config",
-    "handle_contacts",
-    "handle_help",
-    "handle_media",
-    "handle_messages",
-]

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.4b1"
+version = "4.12.4"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
The `src/better_telegram_mcp/tools/__init__.py` file contained several re-exports that were not utilized by the rest of the codebase, which prefers deep imports. This change empties the file to remove these unused imports and minimize the package's public API surface.

Verified with unit tests and ruff linting.

---
*PR created automatically by Jules for task [13226162788767206673](https://jules.google.com/task/13226162788767206673) started by @n24q02m*