### PR TITLE
[TEST] Untested helper _empty_to_none

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -92,6 +92,9 @@ def test_session_path(monkeypatch):
     "input_val, expected",
     [
         (None, None),
+        ("\t", None),
+        ("\n", None),
+        ("\r\n", None),
         ("", None),
         ("   ", None),
         ("valid", "valid"),

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.4b1"
+version = "4.12.4"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
This PR enhances the test coverage for the `_empty_to_none` helper function in `src/better_telegram_mcp/config.py`. 

The function was already partially tested, but I added more explicit edge cases to the `test_empty_to_none` parameterized test in `tests/test_config.py`, including:
- Tabs (`\t`)
- Newlines (`\n`)
- Carriage returns (`\r\n`)

These additions ensure that any whitespace-only string is correctly mapped to `None`, which is the intended behavior for environment variables that might be set to empty or whitespace strings by default.

All tests passed, and code style checks (ruff, ty) were verified.

---
*PR created automatically by Jules for task [4706896788059582121](https://jules.google.com/task/4706896788059582121) started by @n24q02m*