### PR TITLE
[FIX] Unused Import in security.py

### DIFF
--- a/src/better_telegram_mcp/backends/security.py
+++ b/src/better_telegram_mcp/backends/security.py
@@ -1,7 +1,5 @@
 """Input validation for security-sensitive operations."""
 
-from __future__ import annotations
-
 import ipaddress
 import socket
 from pathlib import Path


### PR DESCRIPTION
Removed the redundant `from __future__ import annotations` import from `src/better_telegram_mcp/backends/security.py`. In Python 3.13, this directive is unnecessary for modules that do not contain self-referential type hints or forward references. All other imports in the file are verified to be in use.

---
*PR created automatically by Jules for task [12196899432704909290](https://jules.google.com/task/12196899432704909290) started by @n24q02m*