### PR TITLE
[FIX] Actionable Comment in server.py: Implement robust backend lifecycle

### DIFF
--- a/src/better_telegram_mcp/credential_state.py
+++ b/src/better_telegram_mcp/credential_state.py
@@ -281,7 +281,7 @@ async def save_credentials(
     return None
 
 
-def set_on_configured(callback: Callable[[], Awaitable[None]]) -> None:
+def set_on_configured(callback: Callable[[], Awaitable[None]] | None) -> None:
     """Register callback invoked after relay credentials are applied.
 
     ``server.py`` uses this to reinitialize the Telegram backend (hot-reload)

--- a/src/better_telegram_mcp/server.py
+++ b/src/better_telegram_mcp/server.py
@@ -124,6 +124,11 @@ def _register_hot_reload() -> None:
         _settings = _ensure_settings()
         if not _settings.is_configured:
             return
+
+        if _backend is not None:
+            logger.info("Disconnecting old backend before hot-reload")
+            await _backend.disconnect()
+
         logger.info("Hot-reloading backend from relay config ({})", _settings.mode)
         _backend = _create_backend_instance(_settings)
         await _backend.connect()
@@ -163,10 +168,17 @@ async def _lifespan(server: FastMCP) -> AsyncIterator[None]:
             yield
         finally:
             _unconfigured = False
+            # Unregister hot-reload to avoid leaks and re-init on dead server
+            from .credential_state import set_on_configured
+
+            set_on_configured(None)
             # Disconnect backend if it was created via hot-reload
             if _backend is not None:
                 await _backend.disconnect()
+                _backend = None
                 logger.info("Disconnected from Telegram")
+            _settings = None
+            _pending_auth = False
         return
 
     logger.info("Mode: {}", _settings.mode)
@@ -186,6 +198,9 @@ async def _lifespan(server: FastMCP) -> AsyncIterator[None]:
         yield
     finally:
         await _backend.disconnect()
+        _backend = None
+        _settings = None
+        _pending_auth = False
         logger.info("Disconnected from Telegram")
 
 


### PR DESCRIPTION
This PR addresses the "Actionable Comment" in `src/better_telegram_mcp/server.py` by implementing comprehensive cleanup and state management for the Telegram backend, especially concerning the hot-reload functionality.

Key changes:
- **Hot-Reload Leak Fix:** In `_reinit_backend_from_relay`, the existing backend is now disconnected before a new one is created and connected. This prevents multiple concurrent connections and potential resource leaks.
- **Shutdown Cleanup:** In the `_lifespan` function, the hot-reload callback is now unregistered (`set_on_configured(None)`) and global state variables (`_backend`, `_settings`, `_pending_auth`, `_unconfigured`) are reset. This ensures the server can be safely shut down or restarted within the same process without side effects from stale state.
- **Typing Update:** `credential_state.py` is updated to allow `None` in `set_on_configured` to support unregistering.
- **Dependency Safety:** Fixed a `NameError` in the `_lifespan` cleanup block by using a local import for `set_on_configured`.

All tests passed successfully.

---
*PR created automatically by Jules for task [5617540238212844707](https://jules.google.com/task/5617540238212844707) started by @n24q02m*