### PR TITLE
[FIX] Actionable Comment in config.py

### DIFF
--- a/src/better_telegram_mcp/config.py
+++ b/src/better_telegram_mcp/config.py
@@ -92,15 +92,28 @@ class Settings(BaseSettings):
         Returns:
             A configured Settings instance.
         """
-        kwargs: dict[str, object] = {
-            "bot_token": config.get("TELEGRAM_BOT_TOKEN"),
-            "phone": config.get("TELEGRAM_PHONE"),
+        # Mapping of relay config keys to Settings field names
+        mapping = {
+            "TELEGRAM_BOT_TOKEN": "bot_token",
+            "TELEGRAM_PHONE": "phone",
+            "TELEGRAM_API_ID": "api_id",
+            "TELEGRAM_API_HASH": "api_hash",
+            "TELEGRAM_SESSION_NAME": "session_name",
+            "TELEGRAM_AUTH_URL": "auth_url",
+            "TELEGRAM_DATA_DIR": "data_dir",
+            "TELEGRAM_TRUSTED_PROXIES": "trusted_proxies",
         }
-        # Only override defaults if relay explicitly provides values
-        if config.get("TELEGRAM_API_ID"):
-            kwargs["api_id"] = int(config["TELEGRAM_API_ID"])
-        if config.get("TELEGRAM_API_HASH"):
-            kwargs["api_hash"] = config["TELEGRAM_API_HASH"]
+
+        kwargs: dict[str, object] = {}
+        for config_key, field_name in mapping.items():
+            val = _empty_to_none(config.get(config_key))
+            if val is not None:
+                kwargs[field_name] = val
+            elif field_name in ("bot_token", "phone"):
+                # bot_token and phone are primary credentials; if relay lacks them,
+                # we explicitly pass None to override env vars (relay is the source of truth).
+                kwargs[field_name] = None
+
         return cls(**kwargs)
 
     @property

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -184,3 +184,30 @@ def test_from_relay_config():
     s2 = Settings.from_relay_config({})
     assert s2.api_id == 37984984
     assert s2.api_hash == "2f5f4c76c4de7c07302380c788390100"
+
+def test_from_relay_config_robustness():
+    # Whitespace should be treated as None
+    config = {
+        "TELEGRAM_BOT_TOKEN": "   ",
+        "TELEGRAM_PHONE": "",
+        "TELEGRAM_API_ID": " 12345 ",
+    }
+    s = Settings.from_relay_config(config)
+    assert s.bot_token is None
+    assert s.phone is None
+    assert s.api_id == 12345
+
+
+def test_from_relay_config_extended(tmp_path):
+    config = {
+        "TELEGRAM_SESSION_NAME": "custom_session",
+        "TELEGRAM_AUTH_URL": "https://example.com/auth",
+        "TELEGRAM_DATA_DIR": str(tmp_path),
+        "TELEGRAM_TRUSTED_PROXIES": "1.1.1.1,2.2.2.2",
+    }
+    s = Settings.from_relay_config(config)
+    assert s.session_name == "custom_session"
+    assert s.auth_url == "https://example.com/auth"
+    assert s.data_dir == tmp_path
+    assert s.trusted_proxies == "1.1.1.1,2.2.2.2"
+    assert s.trusted_proxy_list == frozenset({"1.1.1.1", "2.2.2.2"})

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -185,6 +185,7 @@ def test_from_relay_config():
     assert s2.api_id == 37984984
     assert s2.api_hash == "2f5f4c76c4de7c07302380c788390100"
 
+
 def test_from_relay_config_robustness():
     # Whitespace should be treated as None
     config = {

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.4b1"
+version = "4.12.4"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
Refactored `Settings.from_relay_config` in `src/better_telegram_mcp/config.py` to address the actionable comment. The new implementation is more robust and complete, handling all relevant settings fields and normalizing inputs to treat whitespace-only strings as `None`. Core credentials (`bot_token`, `phone`) are handled as primary fields to maintain consistency with the relay mode, while secondary fields use a safer override-only-if-set logic. Added comprehensive unit tests in `tests/test_config.py` to verify the improvements.

---
*PR created automatically by Jules for task [11883298040316968176](https://jules.google.com/task/11883298040316968176) started by @n24q02m*