### PR TITLE
[FIX] Unused Import in config.py

### DIFF
--- a/src/better_telegram_mcp/config.py
+++ b/src/better_telegram_mcp/config.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import functools
 import os
 from functools import cached_property
 from pathlib import Path
@@ -41,7 +40,7 @@ class Settings(BaseSettings):
     # Runtime (derived)
     mode: Literal["bot", "user"] = "bot"
 
-    @functools.cached_property
+    @cached_property
     def trusted_proxy_list(self) -> frozenset[str]:
         """⚡ Bolt: Memoize proxy parsing and convert to frozenset for O(1) lookups."""
         if not self.trusted_proxies:

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.4b1"
+version = "4.12.4"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
This PR removes a redundant `import functools` in `src/better_telegram_mcp/config.py`.

### Changes
- Changed `@functools.cached_property` to `@cached_property` on line 44 (now 43).
- Removed `import functools` from line 3.
- Verified that `from __future__ import annotations` is still necessary for self-referential type hints in the `Settings` class.

### Verification
- Ran `ruff check` (passed).
- Ran `ty check src/better_telegram_mcp/config.py` (passed).
- Ran `uv run pytest tests/test_config.py` (all 22 tests passed).

---
*PR created automatically by Jules for task [16533750406964752610](https://jules.google.com/task/16533750406964752610) started by @n24q02m*