### PR TITLE
[FIX] Unused Import in tools/__init__.py

### DIFF
--- a/src/better_telegram_mcp/tools/__init__.py
+++ b/src/better_telegram_mcp/tools/__init__.py
@@ -1,16 +1,1 @@
-from .chats import handle_chats
-from .config_tool import handle_config
-from .contacts import handle_contacts
-from .help_tool import handle_help
-from .media import handle_media
-from .messages import MessagesArgs, handle_messages
-
-__all__ = [
-    "MessagesArgs",
-    "handle_chats",
-    "handle_config",
-    "handle_contacts",
-    "handle_help",
-    "handle_media",
-    "handle_messages",
-]
+"""Tool handlers for better-telegram-mcp."""


### PR DESCRIPTION
This PR removes unused tool handler imports and the \`__all__\` list from \`src/better_telegram_mcp/tools/__init__.py\`. These re-exports are redundant as the server and other consumers import directly from the tool submodules. A module docstring has been added for clarity.

---
*PR created automatically by Jules for task [10651259357432645965](https://jules.google.com/task/10651259357432645965) started by @n24q02m*