### PR TITLE
[FIX] Unused Import in bot_backend.py

### DIFF
--- a/src/better_telegram_mcp/backends/bot_backend.py
+++ b/src/better_telegram_mcp/backends/bot_backend.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import asyncio
 from typing import Any
 


### PR DESCRIPTION
Removed redundant `from __future__ import annotations` from `src/better_telegram_mcp/backends/bot_backend.py`. This import is not required in Python 3.13 for the type hints used in this module and was identified as an unused import at line 1. All tests and lint checks passed.

---
*PR created automatically by Jules for task [17461587171066463673](https://jules.google.com/task/17461587171066463673) started by @n24q02m*