### PR TITLE
[FIX] Unused Import in per_user_session_store.py

### DIFF
--- a/src/better_telegram_mcp/auth/per_user_session_store.py
+++ b/src/better_telegram_mcp/auth/per_user_session_store.py
@@ -9,15 +9,13 @@ Uses AES-256-GCM, key derived from CREDENTIAL_SECRET env var or auto-generated.
 Reuses the key derivation pattern from transports/credential_store.py.
 """
 
-from __future__ import annotations
-
 import copy
 import json
 import os
 import time
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Literal
+from typing import Literal, Self
 
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
@@ -46,7 +44,7 @@ class SessionInfo:
         return asdict(self)
 
     @classmethod
-    def from_dict(cls, data: dict) -> SessionInfo:
+    def from_dict(cls, data: dict) -> Self:
         return cls(**data)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.4b1"
+version = "4.12.4"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
This PR removes the redundant `from __future__ import annotations` from `src/better_telegram_mcp/auth/per_user_session_store.py` and refactors `SessionInfo.from_dict` to use `typing.Self` for its return type. This change follows the repository's preference for modern Python 3.13 patterns while maintaining type safety. Verified with existing tests and lint checks.

---
*PR created automatically by Jules for task [16234845288523630472](https://jules.google.com/task/16234845288523630472) started by @n24q02m*