### PR TITLE
🛡️ Sentinel: [HIGH] Fix IPv6 parsing in fetch_url_safely

### DIFF
--- a/src/better_telegram_mcp/backends/security.py
+++ b/src/better_telegram_mcp/backends/security.py
@@ -206,9 +206,12 @@ async def fetch_url_safely(url: str, timeout: float = 30.0) -> bytes:
 
     # Construct a new URL using the IP address
     # We must preserve the original scheme, path, query, etc.
-    # parsed.netloc might contain port, so we handle that
-    netloc_parts = parsed.netloc.split("@")[-1].split(":")
-    port = f":{netloc_parts[1]}" if len(netloc_parts) > 1 else ""
+    # parsed.netloc might contain port, so we handle that.
+    # If the resolved IP is an IPv6 address, format it in brackets.
+    if ":" in ip_addr:
+        ip_addr = f"[{ip_addr}]"
+
+    port = f":{parsed.port}" if parsed.port else ""
 
     new_netloc = f"{ip_addr}{port}"
     new_url = urlunparse(parsed._replace(netloc=new_netloc))

--- a/tests/test_backends/test_security.py
+++ b/tests/test_backends/test_security.py
@@ -205,6 +205,38 @@ class TestValidateUrl:
             assert kwargs["headers"]["Host"] == target_hostname
             assert kwargs["extensions"]["sni_hostname"] == target_hostname
 
+    @pytest.mark.asyncio
+    async def test_fetch_url_safely_ipv6_port(self, monkeypatch):
+        """Test that fetch_url_safely correctly constructs the URL with IPv6 and port."""
+        from unittest.mock import AsyncMock, patch
+
+        import httpx
+
+        from better_telegram_mcp.backends.security import fetch_url_safely
+
+        target_hostname = "ipv6.example.com"
+        safe_ip = "2606:4700:4700::1111"
+        port = "8080"
+
+        def mock_getaddrinfo(host, port_val, *args, **kwargs):
+            return [(socket.AF_INET6, 1, 6, "", (safe_ip, int(port), 0, 0))]
+
+        monkeypatch.setattr("socket.getaddrinfo", mock_getaddrinfo)
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+            resp = httpx.Response(200, content=b"content")
+            resp._request = httpx.Request("GET", f"http://[{safe_ip}]:{port}/data")
+            mock_get.return_value = resp
+
+            await fetch_url_safely(f"http://{target_hostname}:{port}/data")
+
+            args, _ = mock_get.call_args
+            requested_url = str(args[0])
+
+            # The requested URL must properly wrap the IPv6 address in brackets and append the port.
+            assert f"[{safe_ip}]:{port}" in requested_url
+            assert requested_url.startswith("http://")
+
 
 class TestValidateFilePath:
     def test_normal_path_allowed(self, tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.4b1"
+version = "4.12.4"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The DNS rebinding protection in `fetch_url_safely` failed to correctly parse ports for IPv6 addresses because it relied on manual string splitting (`url.split(":")`). This breaks the mechanism that safely fetches from external URLs when fetching from an IPv6 source, resulting in `httpx.InvalidURL` exceptions.
🎯 **Impact:** Denial of Service (DoS) / functional failure when attempting to securely fetch media from valid IPv6 sources, breaking the robustness of SSRF mitigation.
🔧 **Fix:** Changed the port extraction to use the built-in and robust `parsed.port` from `urllib.parse.urlparse`. Formatted the IP address with brackets if it is an IPv6 address (i.e. contains a colon) when constructing the safe URL.
✅ **Verification:** Added `test_fetch_url_safely_ipv6_port` to `tests/test_backends/test_security.py` to ensure correct handling. Ran full test suite and lint checks.

---
*PR created automatically by Jules for task [10040677357602123803](https://jules.google.com/task/10040677357602123803) started by @n24q02m*