### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix URL parsing for IPv6 to prevent SSRF bypass

### DIFF
--- a/src/better_telegram_mcp/backends/security.py
+++ b/src/better_telegram_mcp/backends/security.py
@@ -206,9 +206,12 @@ async def fetch_url_safely(url: str, timeout: float = 30.0) -> bytes:
 
     # Construct a new URL using the IP address
     # We must preserve the original scheme, path, query, etc.
-    # parsed.netloc might contain port, so we handle that
-    netloc_parts = parsed.netloc.split("@")[-1].split(":")
-    port = f":{netloc_parts[1]}" if len(netloc_parts) > 1 else ""
+    # parsed.netloc might contain port, so we handle that.
+    # To prevent IPv6 parsing issues, we use urlparse's built-in port handling
+    # and wrap IPv6 addresses in brackets.
+    if ":" in ip_addr and not ip_addr.startswith("["):
+        ip_addr = f"[{ip_addr}]"
+    port = f":{parsed.port}" if parsed.port is not None else ""
 
     new_netloc = f"{ip_addr}{port}"
     new_url = urlunparse(parsed._replace(netloc=new_netloc))

--- a/tests/test_backends/test_security.py
+++ b/tests/test_backends/test_security.py
@@ -161,6 +161,35 @@ class TestValidateUrl:
             validate_url("http://resolves-to-nothing.com/")
 
     @pytest.mark.asyncio
+    async def test_fetch_url_safely_ipv6(self, monkeypatch):
+        """Test that fetch_url_safely correctly constructs URLs for IPv6 addresses."""
+        from unittest.mock import AsyncMock, patch
+        import httpx
+        from better_telegram_mcp.backends.security import fetch_url_safely
+
+        target_hostname = "ipv6.example.com"
+        ipv6_addr = "2001:db8::1"
+        target_url = f"http://{target_hostname}:8080/path?query=1"
+
+        def mock_getaddrinfo(host, port, *args, **kwargs):
+            return [(socket.AF_INET6, 1, 6, "", (ipv6_addr, 8080, 0, 0))]
+
+        monkeypatch.setattr("socket.getaddrinfo", mock_getaddrinfo)
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+            resp = httpx.Response(200, content=b"ipv6-content")
+            resp._request = httpx.Request("GET", f"http://[{ipv6_addr}]:8080/path?query=1")
+            mock_get.return_value = resp
+
+            content = await fetch_url_safely(target_url)
+
+            assert content == b"ipv6-content"
+            args, kwargs = mock_get.call_args
+            requested_url = str(args[0])
+            assert requested_url == f"http://[{ipv6_addr}]:8080/path?query=1"
+            assert kwargs["headers"]["Host"] == target_hostname
+
+    @pytest.mark.asyncio
     async def test_fetch_url_safely_prevents_rebinding(self, monkeypatch):
         """Test that fetch_url_safely uses the validated IP and ignores subsequent DNS changes."""
         from unittest.mock import AsyncMock, patch

--- a/tests/test_backends/test_security.py
+++ b/tests/test_backends/test_security.py
@@ -180,7 +180,9 @@ class TestValidateUrl:
 
         with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
             resp = httpx.Response(200, content=b"ipv6-content")
-            resp._request = httpx.Request("GET", f"http://[{ipv6_addr}]:8080/path?query=1")
+            resp._request = httpx.Request(
+                "GET", f"http://[{ipv6_addr}]:8080/path?query=1"
+            )
             mock_get.return_value = resp
 
             content = await fetch_url_safely(target_url)

--- a/tests/test_backends/test_security.py
+++ b/tests/test_backends/test_security.py
@@ -164,7 +164,9 @@ class TestValidateUrl:
     async def test_fetch_url_safely_ipv6(self, monkeypatch):
         """Test that fetch_url_safely correctly constructs URLs for IPv6 addresses."""
         from unittest.mock import AsyncMock, patch
+
         import httpx
+
         from better_telegram_mcp.backends.security import fetch_url_safely
 
         target_hostname = "ipv6.example.com"

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.4"
+version = "4.12.4b1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.4b1"
+version = "4.12.4"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
This PR resolves a CRITICAL vulnerability where URL rebuilding in `fetch_url_safely` used string splitting (`.split(":")`) to extract ports, which corrupted IPv6 addresses and left them unbracketed in the rebuilt URL.

Manual string splitting is unsafe for IPv6 addresses as they contain colons natively. Rebuilding a URL without wrapping bare IPv6 addresses in brackets `[]` causes HTTP clients to malform the request or fail to connect to the pinned IP, potentially allowing for SSRF bypasses.

The fix relies on standard `urllib.parse` properties like `parsed.port` and correctly enforces bracket wrapping for IPv6 addresses when dynamically modifying the `netloc`.

A unit test was also added to enforce correct parsing on IPv6 targets.

---
*PR created automatically by Jules for task [7174090883520282670](https://jules.google.com/task/7174090883520282670) started by @n24q02m*