### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix IPv6 parsing in URL reconstruction

### DIFF
--- a/src/better_telegram_mcp/backends/security.py
+++ b/src/better_telegram_mcp/backends/security.py
@@ -206,11 +206,13 @@ async def fetch_url_safely(url: str, timeout: float = 30.0) -> bytes:
 
     # Construct a new URL using the IP address
     # We must preserve the original scheme, path, query, etc.
-    # parsed.netloc might contain port, so we handle that
-    netloc_parts = parsed.netloc.split("@")[-1].split(":")
-    port = f":{netloc_parts[1]}" if len(netloc_parts) > 1 else ""
-
-    new_netloc = f"{ip_addr}{port}"
+    # parsed.netloc might contain port, so we handle that.
+    # For IPv6, we must wrap the IP in brackets.
+    port_suffix = f":{parsed.port}" if parsed.port else ""
+    if ":" in ip_addr:
+        new_netloc = f"[{ip_addr}]{port_suffix}"
+    else:
+        new_netloc = f"{ip_addr}{port_suffix}"
     new_url = urlunparse(parsed._replace(netloc=new_netloc))
 
     headers = {"Host": parsed.hostname}

--- a/tests/test_backends/test_security.py
+++ b/tests/test_backends/test_security.py
@@ -205,6 +205,35 @@ class TestValidateUrl:
             assert kwargs["headers"]["Host"] == target_hostname
             assert kwargs["extensions"]["sni_hostname"] == target_hostname
 
+    async def test_fetch_url_safely_ipv6(self, monkeypatch):
+        """Verify fetch_url_safely correctly constructs URL with IPv6 address."""
+        from unittest.mock import AsyncMock, patch
+
+        import httpx
+
+        from better_telegram_mcp.backends.security import fetch_url_safely
+
+        target_hostname = "ipv6.example.com"
+        safe_ip = "2001:db8::1"
+
+        def mock_getaddrinfo(host, port, *args, **kwargs):
+            return [(socket.AF_INET6, 1, 6, "", (safe_ip, 8080, 0, 0))]
+
+        monkeypatch.setattr("socket.getaddrinfo", mock_getaddrinfo)
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+            resp = httpx.Response(200, content=b"content")
+            resp._request = httpx.Request("GET", f"http://[{safe_ip}]:8080/data")
+            mock_get.return_value = resp
+
+            await fetch_url_safely(f"http://{target_hostname}:8080/data")
+
+            args, kwargs = mock_get.call_args
+            requested_url = str(args[0])
+            assert requested_url == f"http://[{safe_ip}]:8080/data"
+            assert kwargs["headers"]["Host"] == target_hostname
+            assert kwargs["extensions"]["sni_hostname"] == target_hostname
+
 
 class TestValidateFilePath:
     def test_normal_path_allowed(self, tmp_path):


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: When the `fetch_url_safely` utility reconstructed URLs after resolving an IP for SSRF protection, it erroneously used `split(":")` on the original network location to extract the port. This manual string manipulation caused the function to improperly handle valid IPv6 addresses (e.g. `2001:db8::1`), leading to malformed reconstructed URLs which could cause routing failures or potentially bypass SSRF protections by malforming target URLs. 
🎯 Impact: Attempts to fetch resources hosted on IPv6 servers would fail. Alternatively, an attacker might be able to craft specific network locations that exploit the string splitting to bypass DNS rebinding protections or induce SSRF.
🔧 Fix: Updated `fetch_url_safely` to use `urllib.parse`'s `parsed.port` property to accurately extract the port without manual string splitting. Additionally, IPv6 addresses containing colons are now wrapped in brackets (e.g., `[2001:db8::1]`) in the reconstructed URL to ensure RFC 3986 compliance.
✅ Verification: `uv run pytest tests/test_backends/test_security.py` runs successfully, including a new test `test_fetch_url_safely_ipv6` verifying that IPv6 URLs are correctly formatted. No new dependencies were added.

---
*PR created automatically by Jules for task [4422313741982223383](https://jules.google.com/task/4422313741982223383) started by @n24q02m*