### PR TITLE
[FIX] Unused Import in __init__.py

### DIFF
--- a/src/better_telegram_mcp/__init__.py
+++ b/src/better_telegram_mcp/__init__.py
@@ -1,10 +1,8 @@
 from importlib.metadata import PackageNotFoundError, version
 
-from .__main__ import _cli as main
-
 try:
     __version__ = version("better-telegram-mcp")
 except PackageNotFoundError:
     __version__ = "unknown"
 
-__all__ = ["main", "__version__"]
+__all__ = ["__version__"]

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.4b1"
+version = "4.12.4"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
Removed the unused import of `main` (aliased from `_cli` in `.__main__`) and its corresponding entry in `__all__` from `src/better_telegram_mcp/__init__.py`. This re-export was not used anywhere in the repository, and the entry point in `pyproject.toml` correctly points to the source in `__main__.py`.

---
*PR created automatically by Jules for task [10368275406170547413](https://jules.google.com/task/10368275406170547413) started by @n24q02m*