### PR TITLE
[FIX] Unused Import in tools/__init__.py

### DIFF
--- a/src/better_telegram_mcp/tools/__init__.py
+++ b/src/better_telegram_mcp/tools/__init__.py
@@ -1,16 +1,1 @@
-from .chats import handle_chats
-from .config_tool import handle_config
-from .contacts import handle_contacts
-from .help_tool import handle_help
-from .media import handle_media
-from .messages import MessagesArgs, handle_messages
-
-__all__ = [
-    "MessagesArgs",
-    "handle_chats",
-    "handle_config",
-    "handle_contacts",
-    "handle_help",
-    "handle_media",
-    "handle_messages",
-]
+"""Tool implementations for better-telegram-mcp."""

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.4b1"
+version = "4.12.4"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
Removed redundant re-exports in `src/better_telegram_mcp/tools/__init__.py`. All internal consumers and tests import directly from the specific tool submodules (e.g., `better_telegram_mcp.tools.chats`). Verified that the project builds and all tests pass after removing these unused imports.

---
*PR created automatically by Jules for task [2610557432068984385](https://jules.google.com/task/2610557432068984385) started by @n24q02m*