### PR TITLE
[FIX] Unused Import in telegram_auth_provider.py

### DIFF
--- a/src/better_telegram_mcp/auth/telegram_auth_provider.py
+++ b/src/better_telegram_mcp/auth/telegram_auth_provider.py
@@ -13,7 +13,6 @@ isolating concurrent users). The argument names retain the historical
 value is the ``sub`` in the new wiring.
 """
 
-from __future__ import annotations
 
 import asyncio
 import hashlib
@@ -29,24 +28,6 @@ from ..backends.user_backend import UserBackend
 from ..config import Settings
 from .in_memory_session_store import InMemorySessionStore
 from .per_user_session_store import SessionInfo
-
-# Module-level singleton for cross-component access from save_credentials,
-# on_step_submitted, and the auth_scope middleware. Set at HTTP-server
-# startup in ``_start_multi_user_http``; left as ``None`` in stdio /
-# single-user HTTP modes (which use the global ``_backend`` in server.py).
-_global_provider: TelegramAuthProvider | None = None
-
-
-def set_global_provider(provider: TelegramAuthProvider | None) -> None:
-    """Register the process-global TelegramAuthProvider for multi-user HTTP."""
-    global _global_provider
-    _global_provider = provider
-
-
-def get_global_provider() -> TelegramAuthProvider | None:
-    """Return the process-global provider, or ``None`` outside multi-user HTTP."""
-    return _global_provider
-
 
 # Session expiry: 30 days
 _SESSION_TTL = 30 * 24 * 60 * 60
@@ -92,7 +73,6 @@ class TelegramAuthProvider:
 
         Returns the number of successfully restored sessions.
         """
-        import asyncio
 
         sessions = self._store.load_all()
         now = time.time()
@@ -422,3 +402,20 @@ class TelegramAuthProvider:
                 return_exceptions=True,
             )
         self._pending_otps.clear()
+
+# Module-level singleton for cross-component access from save_credentials,
+# on_step_submitted, and the auth_scope middleware. Set at HTTP-server
+# startup in ``_start_multi_user_http``; left as ``None`` in stdio /
+# single-user HTTP modes (which use the global ``_backend`` in server.py).
+_global_provider: TelegramAuthProvider | None = None
+
+
+def set_global_provider(provider: TelegramAuthProvider | None) -> None:
+    """Register the process-global TelegramAuthProvider for multi-user HTTP."""
+    global _global_provider
+    _global_provider = provider
+
+
+def get_global_provider() -> TelegramAuthProvider | None:
+    """Return the process-global provider, or ``None`` outside multi-user HTTP."""
+    return _global_provider

--- a/src/better_telegram_mcp/auth/telegram_auth_provider.py
+++ b/src/better_telegram_mcp/auth/telegram_auth_provider.py
@@ -13,7 +13,6 @@ isolating concurrent users). The argument names retain the historical
 value is the ``sub`` in the new wiring.
 """
 
-
 import asyncio
 import hashlib
 import secrets
@@ -402,6 +401,7 @@ class TelegramAuthProvider:
                 return_exceptions=True,
             )
         self._pending_otps.clear()
+
 
 # Module-level singleton for cross-component access from save_credentials,
 # on_step_submitted, and the auth_scope middleware. Set at HTTP-server

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.4b1"
+version = "4.12.4"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
Removed redundant `from __future__ import annotations` and a local `import asyncio` in `telegram_auth_provider.py`. To allow the removal of the future import while maintaining valid type hints, the global provider variable and its associated getter/setter functions were relocated to the end of the file, ensuring the `TelegramAuthProvider` class is defined before it is referenced.

---
*PR created automatically by Jules for task [15892724023488236038](https://jules.google.com/task/15892724023488236038) started by @n24q02m*