### PR TITLE
[FIX] Unused Import in security.py

### DIFF
--- a/src/better_telegram_mcp/backends/security.py
+++ b/src/better_telegram_mcp/backends/security.py
@@ -1,6 +1,5 @@
 """Input validation for security-sensitive operations."""
 
-from __future__ import annotations
 
 import ipaddress
 import socket

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.4b1"
+version = "4.12.4"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
This PR removes the redundant `from __future__ import annotations` import from `src/better_telegram_mcp/backends/security.py`. 

In Python 3.13, this import is unnecessary for files that do not utilize self-referential type hints or forward references that require runtime evaluation of strings. Removing it cleans up the codebase without impacting functionality or type safety.

Verification performed:
- `uv run ruff check` passed.
- `uv run ty check` passed.
- `uv run pytest tests/test_backends/test_security.py` passed (49 tests).

---
*PR created automatically by Jules for task [14489924954515404924](https://jules.google.com/task/14489924954515404924) started by @n24q02m*