### PR TITLE
[FIX] Actionable Comment in config.py - Improve from_relay_config robustness

### DIFF
--- a/src/better_telegram_mcp/config.py
+++ b/src/better_telegram_mcp/config.py
@@ -92,15 +92,31 @@ class Settings(BaseSettings):
         Returns:
             A configured Settings instance.
         """
+        # 1. Normalize all inputs
+        norm_config = {k: _empty_to_none(v) for k, v in config.items()}
+
+        # 2. Start with core credentials (always included to override ENV)
         kwargs: dict[str, object] = {
-            "bot_token": config.get("TELEGRAM_BOT_TOKEN"),
-            "phone": config.get("TELEGRAM_PHONE"),
+            "bot_token": norm_config.get("TELEGRAM_BOT_TOKEN"),
+            "phone": norm_config.get("TELEGRAM_PHONE"),
         }
-        # Only override defaults if relay explicitly provides values
-        if config.get("TELEGRAM_API_ID"):
-            kwargs["api_id"] = int(config["TELEGRAM_API_ID"])
-        if config.get("TELEGRAM_API_HASH"):
-            kwargs["api_hash"] = config["TELEGRAM_API_HASH"]
+
+        # 3. Only override secondary defaults if relay explicitly provides values
+        # Mapping of relay keys to Setting fields
+        secondary_map = {
+            "TELEGRAM_API_ID": "api_id",
+            "TELEGRAM_API_HASH": "api_hash",
+            "TELEGRAM_SESSION_NAME": "session_name",
+            "TELEGRAM_AUTH_URL": "auth_url",
+            "TELEGRAM_DATA_DIR": "data_dir",
+            "TELEGRAM_TRUSTED_PROXIES": "trusted_proxies",
+        }
+
+        for relay_key, field_name in secondary_map.items():
+            val = norm_config.get(relay_key)
+            if val is not None:
+                kwargs[field_name] = val
+
         return cls(**kwargs)
 
     @property

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -137,7 +137,6 @@ def test_secret_priority_env_dcr(monkeypatch):
 
 def test_secret_persistence(tmp_path):
     # Test that it generates and persists a secret when no env vars are set
-    import os
 
     for env in [
         "CREDENTIAL_SECRET",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -220,4 +220,4 @@ def test_from_relay_config_core_overrides_env(monkeypatch):
 
     s = Settings.from_relay_config({"TELEGRAM_BOT_TOKEN": " "})
     assert s.bot_token is None  # Overridden by empty/whitespace
-    assert s.phone is None      # Included in kwargs as None, so it overrides env-phone
+    assert s.phone is None  # Included in kwargs as None, so it overrides env-phone

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import os
+from pathlib import Path
+
 import pytest
 
 from better_telegram_mcp.config import Settings
@@ -173,14 +176,49 @@ def test_from_relay_config():
         "TELEGRAM_PHONE": "+123456789",
         "TELEGRAM_API_ID": "98765",
         "TELEGRAM_API_HASH": "hash123",
+        "TELEGRAM_SESSION_NAME": "custom-session",
+        "TELEGRAM_AUTH_URL": "http://test.auth",
+        "TELEGRAM_DATA_DIR": "/tmp/data",
+        "TELEGRAM_TRUSTED_PROXIES": "1.1.1.1",
     }
     s = Settings.from_relay_config(config)
     assert s.bot_token == "123:ABC"
     assert s.phone == "+123456789"
     assert s.api_id == 98765
     assert s.api_hash == "hash123"
+    assert s.session_name == "custom-session"
+    assert s.auth_url == "http://test.auth"
+    assert s.data_dir == Path("/tmp/data")
+    assert s.trusted_proxies == "1.1.1.1"
 
-    # Defaults
-    s2 = Settings.from_relay_config({})
-    assert s2.api_id == 37984984
-    assert s2.api_hash == "2f5f4c76c4de7c07302380c788390100"
+
+def test_from_relay_config_defaults():
+    # Empty config should use built-in defaults for secondary fields
+    s = Settings.from_relay_config({})
+    assert s.api_id == 37984984
+    assert s.api_hash == "2f5f4c76c4de7c07302380c788390100"
+    assert s.session_name == "default"
+    assert s.auth_url == "https://better-telegram-mcp.n24q02m.com"
+
+
+def test_from_relay_config_whitespace_fallbacks():
+    # Whitespace in secondary fields should NOT override defaults
+    config = {
+        "TELEGRAM_API_ID": "  ",
+        "TELEGRAM_API_HASH": " ",
+        "TELEGRAM_SESSION_NAME": " ",
+    }
+    s = Settings.from_relay_config(config)
+    assert s.api_id == 37984984
+    assert s.api_hash == "2f5f4c76c4de7c07302380c788390100"
+    assert s.session_name == "default"
+
+
+def test_from_relay_config_core_overrides_env(monkeypatch):
+    # Core fields in relay config should override ENV even if empty
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "env-token")
+    monkeypatch.setenv("TELEGRAM_PHONE", "env-phone")
+
+    s = Settings.from_relay_config({"TELEGRAM_BOT_TOKEN": " "})
+    assert s.bot_token is None  # Overridden by empty/whitespace
+    assert s.phone is None      # Included in kwargs as None, so it overrides env-phone

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.4b1"
+version = "4.12.4"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
This PR improves the robustness of `Settings.from_relay_config` in `src/better_telegram_mcp/config.py`.

Key changes:
1.  **Whitespace Handling**: All values from the relay configuration are now normalized using `_empty_to_none`. This prevents the `int()` conversion for `TELEGRAM_API_ID` from crashing when the input is whitespace (a common occurrence in some relay setups).
2.  **Credential Priority**: Core credentials (`bot_token` and `phone`) are now always included in the `Settings` constructor. This ensures that if they are cleared or changed in the relay configuration, they correctly override any existing environment variables, maintaining the expected authentication mode.
3.  **Selective Overrides**: Secondary settings (like `api_id`, `api_hash`, `session_name`, `data_dir`, etc.) are now only passed to the constructor if they are explicitly provided and non-empty. This prevents `None` values from accidentally overriding built-in defaults or environment variables for these secondary fields.
4.  **Automatic Type Conversion**: Removed manual `int()` conversion for `api_id`, relying instead on Pydantic's built-in type validation and conversion.
5.  **Expanded Testing**: Added comprehensive tests in `tests/test_config.py` to verify whitespace handling, core vs. secondary override behavior, and fallback to defaults.

---
*PR created automatically by Jules for task [17342156255043890959](https://jules.google.com/task/17342156255043890959) started by @n24q02m*