### PR TITLE
[FIX] Unused Import in bot_backend.py

### DIFF
--- a/src/better_telegram_mcp/backends/bot_backend.py
+++ b/src/better_telegram_mcp/backends/bot_backend.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import asyncio
 from typing import Any
 
@@ -260,7 +258,6 @@ class BotBackend(TelegramBackend):
             "video": "sendVideo",
         }
         method = method_map.get(media_type, "sendDocument")
-
         if file_path_or_url.strip().lower().startswith(("http://", "https://")):
             content = await fetch_url_safely(file_path_or_url.strip())
             field = media_type if media_type != "document" else "document"
@@ -271,7 +268,6 @@ class BotBackend(TelegramBackend):
                 chat_id=chat_id,
                 caption=caption,
             )
-
         path = validate_file_path(file_path_or_url)
         if not path.exists():
             raise FileNotFoundError(f"File not found: {file_path_or_url}")


### PR DESCRIPTION
Removed the redundant `from __future__ import annotations` import from `src/better_telegram_mcp/backends/bot_backend.py`. This import is not needed in Python 3.13 for this specific module as it does not utilize self-referential type hints. Verified that linting, type checking, and all tests pass after the change.

---
*PR created automatically by Jules for task [18434898534336115404](https://jules.google.com/task/18434898534336115404) started by @n24q02m*