### PR TITLE
[FIX] Actionable Comment in telegram_auth_provider.py

### DIFF
--- a/src/better_telegram_mcp/auth/telegram_auth_provider.py
+++ b/src/better_telegram_mcp/auth/telegram_auth_provider.py
@@ -334,21 +334,35 @@ class TelegramAuthProvider:
 
         Returns True if the session existed.
         """
+        existed = False
+
         backend = self.active_clients.pop(bearer, None)
         if backend is not None:
-            await backend.disconnect()
+            existed = True
+            try:
+                await backend.disconnect()
+            except Exception as exc:
+                logger.warning("Error disconnecting backend during revocation: {}", exc)
 
         # Remove pending OTP if any
         pending = self._pending_otps.pop(bearer, None)
         if pending is not None:
-            await pending["backend"].disconnect()
+            existed = True
+            try:
+                await pending["backend"].disconnect()
+            except Exception as exc:
+                logger.warning(
+                    "Error disconnecting pending OTP backend during revocation: {}", exc
+                )
 
         # Remove from ownership map
         to_remove = [sid for sid, b in self.session_owners.items() if b == bearer]
         for sid in to_remove:
+            existed = True
             del self.session_owners[sid]
 
-        return self._store.delete(bearer)
+        deleted_from_store = self._store.delete(bearer)
+        return existed or deleted_from_store
 
     async def cleanup_expired(self) -> int:
         """Remove expired sessions. Returns count of removed sessions."""

--- a/tests/test_telegram_auth_provider.py
+++ b/tests/test_telegram_auth_provider.py
@@ -254,6 +254,49 @@ class TestRevokeSession:
         result = await provider.revoke_session("nonexistent")
         assert result is False
 
+    async def test_revoke_pending_otp_returns_true(
+        self, provider: TelegramAuthProvider
+    ) -> None:
+        """Should return True when revoking a pending OTP session."""
+        mock_backend = AsyncMock()
+        provider._pending_otps["pending-bearer"] = {
+            "bearer": "pending-bearer",
+            "backend": mock_backend,
+            "phone": "+123456789",
+            "phone_code_hash": "hash",
+            "session_name": "session",
+            "created_at": time.time(),
+        }
+
+        result = await provider.revoke_session("pending-bearer")
+        assert result is True
+        assert "pending-bearer" not in provider._pending_otps
+        mock_backend.disconnect.assert_called_once()
+
+    async def test_revoke_session_continues_on_disconnect_error(
+        self, provider: TelegramAuthProvider, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Should continue cleanup even if disconnect fails."""
+        from loguru import logger
+
+        handler_id = logger.add(caplog.handler, format="{message}", level="WARNING")
+
+        try:
+            mock_backend = AsyncMock()
+            mock_backend.disconnect.side_effect = Exception("Disconnect failed")
+
+            provider.active_clients["bad-bearer"] = mock_backend
+            provider.session_owners["sid"] = "bad-bearer"
+
+            result = await provider.revoke_session("bad-bearer")
+
+            assert result is True
+            assert "bad-bearer" not in provider.active_clients
+            assert "sid" not in provider.session_owners
+            assert "Error disconnecting backend during revocation" in caplog.text
+        finally:
+            logger.remove(handler_id)
+
     async def test_revoke_cleans_session_owners(
         self, provider: TelegramAuthProvider
     ) -> None:


### PR DESCRIPTION
This PR improves the robustness of the `revoke_session` method in `TelegramAuthProvider`. 

Changes:
1.  **Existence Tracking**: Updated `revoke_session` to return `True` if the session existed in any of the following states: active client, pending OTP, session ownership map, or persistent store. Previously, it only returned the result of the store deletion, which was misleading for pending OTP sessions.
2.  **Robust Disconnection**: Wrapped `backend.disconnect()` calls in `try...except` blocks with logging. This ensures that a network error during one backend's disconnection does not prevent the cleanup of other session state (like removing it from the ownership map or the store).
3.  **New Tests**: Added unit tests to verify:
    *   `revoke_session` returns `True` for pending OTP sessions.
    *   `revoke_session` continues cleanup even if a backend disconnect fails.

These changes resolve the actionable comment in `telegram_auth_provider.py` and improve the overall reliability of session management.

---
*PR created automatically by Jules for task [5045585192261254074](https://jules.google.com/task/5045585192261254074) started by @n24q02m*