### PR TITLE
[FIX] Unused Import in per_user_session_store.py

### DIFF
--- a/src/better_telegram_mcp/auth/per_user_session_store.py
+++ b/src/better_telegram_mcp/auth/per_user_session_store.py
@@ -9,7 +9,6 @@ Uses AES-256-GCM, key derived from CREDENTIAL_SECRET env var or auto-generated.
 Reuses the key derivation pattern from transports/credential_store.py.
 """
 
-from __future__ import annotations
 
 import copy
 import json
@@ -46,7 +45,7 @@ class SessionInfo:
         return asdict(self)
 
     @classmethod
-    def from_dict(cls, data: dict) -> SessionInfo:
+    def from_dict(cls, data: dict) -> "SessionInfo":
         return cls(**data)
 
 

--- a/src/better_telegram_mcp/auth/per_user_session_store.py
+++ b/src/better_telegram_mcp/auth/per_user_session_store.py
@@ -9,7 +9,6 @@ Uses AES-256-GCM, key derived from CREDENTIAL_SECRET env var or auto-generated.
 Reuses the key derivation pattern from transports/credential_store.py.
 """
 
-
 import copy
 import json
 import os

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.4b1"
+version = "4.12.4"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
Removed the redundant \`from __future__ import annotations\` from \`src/better_telegram_mcp/auth/per_user_session_store.py\` and updated the self-referential type hint in \`SessionInfo.from_dict\` to use a string forward reference. This aligns with the repository's preference for minimal future imports in the Python 3.13 codebase while maintaining type safety.

---
*PR created automatically by Jules for task [14628865853456978757](https://jules.google.com/task/14628865853456978757) started by @n24q02m*