### PR TITLE
[PERF] Sequential async calls in session cleanup loop

### DIFF
--- a/src/better_telegram_mcp/auth/telegram_auth_provider.py
+++ b/src/better_telegram_mcp/auth/telegram_auth_provider.py
@@ -355,12 +355,18 @@ class TelegramAuthProvider:
         sessions = self._store.load_all()
         removed = 0
         now = time.time()
-
-        for bearer, info in sessions.items():
-            if now - info.created_at > _SESSION_TTL:
-                await self.revoke_session(bearer)
-                removed += 1
-
+        to_revoke = [
+            bearer
+            for bearer, info in sessions.items()
+            if now - info.created_at > _SESSION_TTL
+        ]
+        if to_revoke:
+            results = await asyncio.gather(*(self.revoke_session(b) for b in to_revoke), return_exceptions=True)
+            for b, res in zip(to_revoke, results, strict=True):
+                if isinstance(res, Exception):
+                    logger.warning("Error revoking session {}: {}", b[:8], res)
+                else:
+                    removed += 1
         # Clean up stale pending OTPs (5 min TTL) using chronological insertion order.
         # Since start_user_auth pops-then-reinserts each bearer, the oldest entries
         # are always at the front, so we can stop at the first non-stale entry instead

--- a/src/better_telegram_mcp/auth/telegram_auth_provider.py
+++ b/src/better_telegram_mcp/auth/telegram_auth_provider.py
@@ -361,7 +361,9 @@ class TelegramAuthProvider:
             if now - info.created_at > _SESSION_TTL
         ]
         if to_revoke:
-            results = await asyncio.gather(*(self.revoke_session(b) for b in to_revoke), return_exceptions=True)
+            results = await asyncio.gather(
+                *(self.revoke_session(b) for b in to_revoke), return_exceptions=True
+            )
             for b, res in zip(to_revoke, results, strict=True):
                 if isinstance(res, Exception):
                     logger.warning("Error revoking session {}: {}", b[:8], res)

--- a/tests/test_telegram_auth_provider_cleanup.py
+++ b/tests/test_telegram_auth_provider_cleanup.py
@@ -53,6 +53,7 @@ async def test_shutdown_logs_pending_otp_disconnect_error(
     finally:
         logger.remove(handler_id)
 
+
 async def test_cleanup_expired_sessions_concurrently(
     provider: TelegramAuthProvider,
 ) -> None:
@@ -89,6 +90,7 @@ async def test_cleanup_expired_sessions_concurrently(
     for i in range(5):
         assert provider._store.load(f"expired-{i}") is None
     assert provider._store.load("valid") is not None
+
 
 async def test_cleanup_expired_sessions_gather_called(
     provider: TelegramAuthProvider,

--- a/tests/test_telegram_auth_provider_cleanup.py
+++ b/tests/test_telegram_auth_provider_cleanup.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import time
 from pathlib import Path
 from unittest.mock import AsyncMock
@@ -51,3 +52,66 @@ async def test_shutdown_logs_pending_otp_disconnect_error(
         assert "Error disconnecting pending OTP backend test-bea" in caplog.text
     finally:
         logger.remove(handler_id)
+
+async def test_cleanup_expired_sessions_concurrently(
+    provider: TelegramAuthProvider,
+) -> None:
+    """Should remove multiple expired sessions concurrently."""
+    from better_telegram_mcp.auth.per_user_session_store import SessionInfo
+    from better_telegram_mcp.auth.telegram_auth_provider import _SESSION_TTL
+
+    # Store multiple expired sessions
+    now = time.time()
+    for i in range(5):
+        provider._store.store(
+            f"expired-{i}",
+            SessionInfo(
+                session_name=f"old-{i}",
+                mode="bot",
+                bot_token=f"t{i}",
+                created_at=now - _SESSION_TTL - 1,
+            ),
+        )
+
+    # Store a valid session
+    provider._store.store(
+        "valid",
+        SessionInfo(
+            session_name="new",
+            mode="bot",
+            bot_token="t-valid",
+            created_at=now,
+        ),
+    )
+
+    removed = await provider.cleanup_expired()
+    assert removed == 5
+    for i in range(5):
+        assert provider._store.load(f"expired-{i}") is None
+    assert provider._store.load("valid") is not None
+
+async def test_cleanup_expired_sessions_gather_called(
+    provider: TelegramAuthProvider,
+) -> None:
+    """Verify that asyncio.gather is used for revoking sessions."""
+    from unittest.mock import patch
+
+    from better_telegram_mcp.auth.per_user_session_store import SessionInfo
+    from better_telegram_mcp.auth.telegram_auth_provider import _SESSION_TTL
+
+    now = time.time()
+    for i in range(3):
+        provider._store.store(
+            f"expired-{i}",
+            SessionInfo(
+                session_name=f"old-{i}",
+                mode="bot",
+                bot_token=f"t{i}",
+                created_at=now - _SESSION_TTL - 1,
+            ),
+        )
+
+    with patch("asyncio.gather", wraps=asyncio.gather) as mock_gather:
+        removed = await provider.cleanup_expired()
+        assert removed == 3
+        assert mock_gather.called

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.4b1"
+version = "4.12.4"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
This PR optimizes the `cleanup_expired` method in `TelegramAuthProvider` by revoking expired sessions concurrently using `asyncio.gather`. Previously, sessions were revoked sequentially, which could be slow if multiple sessions needed I/O-intensive disconnection.

Key changes:
- Collected all expired sessions before revocation.
- Used `asyncio.gather(..., return_exceptions=True)` to process all revocations in parallel.
- Added explicit error logging for any individual revocation failures while ensuring the count of successfully removed sessions remains accurate.
- Added targeted unit tests in `tests/test_telegram_auth_provider_cleanup.py` to verify the concurrent logic and ensure `asyncio.gather` is correctly invoked.
- Fixed a minor linting issue (B905) by adding `strict=True` to `zip()`.

---
*PR created automatically by Jules for task [17992912024934954658](https://jules.google.com/task/17992912024934954658) started by @n24q02m*