### PR TITLE
[FIX] Unused Import in tools/__init__.py

### DIFF
--- a/src/better_telegram_mcp/tools/__init__.py
+++ b/src/better_telegram_mcp/tools/__init__.py
@@ -3,10 +3,9 @@ from .config_tool import handle_config
 from .contacts import handle_contacts
 from .help_tool import handle_help
 from .media import handle_media
-from .messages import MessagesArgs, handle_messages
+from .messages import handle_messages
 
 __all__ = [
-    "MessagesArgs",
     "handle_chats",
     "handle_config",
     "handle_contacts",


### PR DESCRIPTION
Remove unused MessagesArgs import from src/better_telegram_mcp/tools/__init__.py to improve code quality and maintain consistency across tool option models.

---
*PR created automatically by Jules for task [756951384376264502](https://jules.google.com/task/756951384376264502) started by @n24q02m*