### PR TITLE
[FIX] Unused Import in config.py

### DIFF
--- a/src/better_telegram_mcp/config.py
+++ b/src/better_telegram_mcp/config.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import functools
 import os
 from functools import cached_property
 from pathlib import Path
@@ -41,7 +40,7 @@ class Settings(BaseSettings):
     # Runtime (derived)
     mode: Literal["bot", "user"] = "bot"
 
-    @functools.cached_property
+    @cached_property
     def trusted_proxy_list(self) -> frozenset[str]:
         """⚡ Bolt: Memoize proxy parsing and convert to frozenset for O(1) lookups."""
         if not self.trusted_proxies:


### PR DESCRIPTION
This PR removes a redundant import in `src/better_telegram_mcp/config.py`. 

The file had both `import functools` and `from functools import cached_property`, while using both `@functools.cached_property` and `@cached_property`. I unified the usage to `@cached_property` and removed the top-level `import functools`. 

Verified with:
- `uv run ruff check`
- `uv run ty check`
- `uv run pytest` (all 601 tests passed)

---
*PR created automatically by Jules for task [17452648878281803385](https://jules.google.com/task/17452648878281803385) started by @n24q02m*