### PR TITLE
[FIX] Predictable Salt Used for PBKDF2 Key Derivation

### DIFF
--- a/src/better_telegram_mcp/auth/per_user_session_store.py
+++ b/src/better_telegram_mcp/auth/per_user_session_store.py
@@ -72,8 +72,8 @@ class PerUserSessionStore:
         if self._salt_path.exists():
             return self._salt_path.read_bytes()
 
-        # Backward compatibility: existing sessions use legacy hardcoded salt
-        if self._path.exists():
+        # Fallback only if the file exists and is non-empty (sturdier check).
+        if self._path.is_file() and self._path.stat().st_size > 0:
             return _LEGACY_SALT
 
         # New installation: generate random salt and persist atomically

--- a/src/better_telegram_mcp/transports/credential_store.py
+++ b/src/better_telegram_mcp/transports/credential_store.py
@@ -93,8 +93,9 @@ class CredentialStore:
         if self._salt_path.exists():
             return self._salt_path.read_bytes()
 
-        # Backward compatibility: existing credentials use legacy hardcoded salt
-        if self._path.exists():
+        # Backward compatibility: existing credentials use legacy hardcoded salt.
+        # Fallback only if the file exists and is non-empty (sturdier check).
+        if self._path.is_file() and self._path.stat().st_size > 0:
             return _LEGACY_SALT
 
         # New installation: generate random salt and persist atomically

--- a/tests/test_salt_fallback.py
+++ b/tests/test_salt_fallback.py
@@ -1,0 +1,46 @@
+from better_telegram_mcp.auth.per_user_session_store import (
+    _LEGACY_SALT as PER_USER_LEGACY_SALT,
+)
+from better_telegram_mcp.auth.per_user_session_store import PerUserSessionStore
+from better_telegram_mcp.transports.credential_store import (
+    _LEGACY_SALT as CRED_STORE_LEGACY_SALT,
+)
+from better_telegram_mcp.transports.credential_store import CredentialStore
+
+
+def test_per_user_session_store_salt_tightened(tmp_path):
+    data_dir = tmp_path / "per_user"
+    data_dir.mkdir()
+    session_file = data_dir / "sessions.enc"
+
+    # Empty file
+    session_file.touch()
+    store = PerUserSessionStore(data_dir, secret="test")
+    assert store._salt != PER_USER_LEGACY_SALT
+
+    # Non-empty file (legacy)
+    data_dir_legacy = tmp_path / "per_user_legacy"
+    data_dir_legacy.mkdir()
+    session_file_legacy = data_dir_legacy / "sessions.enc"
+    session_file_legacy.write_bytes(b"legacy-data")
+    store_legacy = PerUserSessionStore(data_dir_legacy, secret="test")
+    assert store_legacy._salt == PER_USER_LEGACY_SALT
+
+
+def test_credential_store_salt_tightened(tmp_path):
+    data_dir = tmp_path / "cred_store"
+    data_dir.mkdir()
+    session_file = data_dir / "credentials.enc"
+
+    # Empty file
+    session_file.touch()
+    store = CredentialStore(data_dir, secret="test")
+    assert store._salt != CRED_STORE_LEGACY_SALT
+
+    # Non-empty file (legacy)
+    data_dir_legacy = tmp_path / "cred_store_legacy"
+    data_dir_legacy.mkdir()
+    session_file_legacy = data_dir_legacy / "credentials.enc"
+    session_file_legacy.write_bytes(b"legacy-data")
+    store_legacy = CredentialStore(data_dir_legacy, secret="test")
+    assert store_legacy._salt == CRED_STORE_LEGACY_SALT

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.4b1"
+version = "4.12.4"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
The fallback to legacy salt should only be allowed if a valid legacy encrypted file exists. If it's a new installation and salt generation fails, it should fail securely rather than falling back. This PR tightens the condition for using the legacy salt in both PerUserSessionStore and CredentialStore by checking if the path is a file and has a size greater than zero.

---
*PR created automatically by Jules for task [15108249055340446050](https://jules.google.com/task/15108249055340446050) started by @n24q02m*