### PR TITLE
[FIX] Glama display name documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,3 +148,4 @@ Conventional Commits: `type(scope): message`. Automated semantic release.
 - **Mega-tool pattern**: 6 tools x N actions = full API coverage with minimal tool registration overhead
 - **Session persistence**: `~/.better-telegram-mcp/<name>.session` for Telethon (MTProto)
 - **Auth flow**: OTP sent to Telegram app -> terminal input or `config(action='auth', code='...')` for headless
+- **Glama integration**: The display name is programmatically set using the 'title' property in 'server.json'. The 'glama.json' file is used for ownership claiming via the 'maintainers' array and does not support the display name.

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.4b1"
+version = "4.12.4"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
This PR updates the `AGENTS.md` file to correctly document how the Glama display name is configured. 

The previous documentation (or backlog) suggested that the display name could only be updated manually via the Glama admin page. However, it is actually programmatically set using the `title` property in the root `server.json` file. 

Changes:
- Added a bullet point to the `Architecture` section in `AGENTS.md` explaining the Glama integration.
- Clarified the roles of `server.json` (display name) and `glama.json` (maintainers/ownership).
- Verified that all linters and tests pass project-wide.

---
*PR created automatically by Jules for task [15434322145758667623](https://jules.google.com/task/15434322145758667623) started by @n24q02m*