### PR TITLE
fix: report package version in serverInfo and honor MCP_PORT in HTTP mode

### DIFF
--- a/src/better_telegram_mcp/server.py
+++ b/src/better_telegram_mcp/server.py
@@ -194,6 +194,13 @@ mcp = FastMCP(
     lifespan=_lifespan,
 )
 
+# FastMCP (the SDK class) has no ``version=`` kwarg, so it defaults the
+# advertised serverInfo.version to the mcp SDK's own version. Pin it to this
+# package's version so initialize responses report the right value.
+from better_telegram_mcp import __version__  # noqa: E402
+
+mcp._mcp_server.version = __version__
+
 # Register the standard `config__open_relay` MCP tool so the LLM can re-trigger
 # the relay form via tool call when credentials are missing or expired. In
 # stdio mode (PUBLIC_URL unset), the tool returns ``stdio_unsupported`` so

--- a/src/better_telegram_mcp/transports/http.py
+++ b/src/better_telegram_mcp/transports/http.py
@@ -58,6 +58,16 @@ def get_current_backend():
     return _current_backend.get(None)
 
 
+def _resolve_port(default: int) -> int:
+    """Resolve the HTTP bind port, honoring ``MCP_PORT``.
+
+    ``MCP_PORT`` is the cross-stack-standard name (matches imagine-mcp and the
+    other servers); the legacy ``PORT`` var is still accepted for back-compat.
+    Falls back to ``default`` when neither is set.
+    """
+    return int(os.environ.get("MCP_PORT") or os.environ.get("PORT") or default)
+
+
 def _dcr_secret() -> str | None:
     """Resolve the multi-user OAuth shared secret from env.
 
@@ -152,7 +162,7 @@ def _start_single_user_http(settings: Settings) -> None:
     from ..credential_state import on_step_submitted, save_credentials
     from ..server import mcp
 
-    port = int(os.environ.get("PORT", "0"))
+    port = _resolve_port(0)
     host = os.environ.get("HOST")
 
     # MCP_AUTH_DISABLE=1 skips Bearer JWT verification on /mcp -- for
@@ -284,7 +294,7 @@ def _start_multi_user_http(settings: Settings) -> None:
     )
     set_global_provider(auth_provider)
 
-    port = int(os.environ.get("PORT", "8080"))
+    port = _resolve_port(8080)
     host = os.environ.get("HOST", "0.0.0.0")
     public_url = os.environ.get("PUBLIC_URL", "")
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -31,6 +31,17 @@ def test_mcp_has_7_tools():
     assert set(tools.keys()) == expected
 
 
+def test_serverinfo_version_matches_package():
+    """serverInfo.version must report the package version, not the mcp SDK
+    version. FastMCP (SDK class) has no version kwarg, so server.py pins
+    _mcp_server.version = __version__; verify it propagates to the
+    initialization options advertised to clients."""
+    from better_telegram_mcp import __version__
+
+    opts = mcp._mcp_server.create_initialization_options()
+    assert opts.server_version == __version__
+
+
 def test_main_exists():
     assert callable(main)
 

--- a/tests/test_transports/test_http.py
+++ b/tests/test_transports/test_http.py
@@ -12,6 +12,7 @@ from better_telegram_mcp.transports.http import (
     _current_backend,
     _is_multi_user_mode,
     _per_request_sub_scope,
+    _resolve_port,
     get_current_backend,
     start_http,
 )
@@ -52,6 +53,31 @@ class TestGetCurrentBackend:
             assert get_current_backend() == mock_backend
         finally:
             _current_backend.reset(token)
+
+
+class TestResolvePort:
+    def test_resolve_port_honors_mcp_port(self) -> None:
+        """MCP_PORT overrides the default (imagine-mcp parity)."""
+        with patch.dict("os.environ", {"MCP_PORT": "12345"}, clear=True):
+            assert _resolve_port(8080) == 12345
+
+    def test_resolve_port_default_when_unset(self) -> None:
+        """Falls back to the supplied default when no env var is set."""
+        with patch.dict("os.environ", {}, clear=True):
+            assert _resolve_port(8080) == 8080
+            assert _resolve_port(0) == 0
+
+    def test_resolve_port_legacy_port_back_compat(self) -> None:
+        """Legacy PORT var is still honored when MCP_PORT is absent."""
+        with patch.dict("os.environ", {"PORT": "7070"}, clear=True):
+            assert _resolve_port(8080) == 7070
+
+    def test_resolve_port_mcp_port_wins_over_legacy(self) -> None:
+        """MCP_PORT takes precedence over the legacy PORT var."""
+        with patch.dict(
+            "os.environ", {"MCP_PORT": "12345", "PORT": "7070"}, clear=True
+        ):
+            assert _resolve_port(8080) == 12345
 
 
 class TestIsMultiUserMode:
@@ -215,6 +241,41 @@ class TestStartHttp:
         kwargs = mock_run.call_args.kwargs
         assert kwargs["port"] == 8080
         assert kwargs["host"] == "0.0.0.0"
+
+    def test_start_http_multi_user_honors_mcp_port(
+        self, settings: Settings, tmp_path: Path
+    ) -> None:
+        """MCP_PORT is forwarded to run_http_server (imagine-mcp parity)."""
+        env = {
+            "DCR_SERVER_SECRET": "secret",
+            "PUBLIC_URL": "https://mcp.example.com",
+            "TELEGRAM_API_ID": "12345",
+            "TELEGRAM_API_HASH": "hash",
+            "MCP_PORT": "12345",
+        }
+
+        with (
+            patch.dict("os.environ", env, clear=True),
+            patch(
+                "mcp_core.transport.local_server.run_http_server",
+                new_callable=AsyncMock,
+            ) as mock_run,
+            patch(
+                "better_telegram_mcp.auth.telegram_auth_provider.TelegramAuthProvider"
+            ) as mock_provider_cls,
+        ):
+            mock_provider = mock_provider_cls.return_value
+            mock_provider.restore_sessions = AsyncMock(return_value=0)
+            mock_provider.shutdown = AsyncMock()
+
+            settings_with_api = Settings(
+                data_dir=tmp_path / "d",
+                api_id=12345,
+                api_hash="hash",
+            )
+            start_http(settings_with_api)
+
+        assert mock_run.call_args.kwargs["port"] == 12345
 
     def test_start_http_multi_user_mcp_prefixed_secret_no_runtimeerror(
         self, tmp_path: Path


### PR DESCRIPTION
## Summary

Two small fixes.

### Fix A - serverInfo.version
`FastMCP` (the mcp SDK class) has no `version=` kwarg, so `serverInfo.version` defaulted to the mcp SDK's own version. Pin `mcp._mcp_server.version = __version__` right after the constructor so `initialize` responses advertise the package version. Verified it propagates to `create_initialization_options().server_version`.

### Fix B - honor MCP_PORT in HTTP mode
The HTTP transport bound the port from `PORT` only. Both the single-user and multi-user start paths now route through a small `_resolve_port(default)` helper that honors `MCP_PORT` (cross-stack standard, imagine-mcp parity), with `PORT` kept as a back-compat fallback. Single-user keeps its ephemeral default (0); multi-user keeps 8080.

## Tests
- Fix A: assert `mcp._mcp_server.create_initialization_options().server_version == __version__`.
- Fix B: `_resolve_port` unit tests (MCP_PORT override, default, legacy PORT fallback, MCP_PORT precedence) + multi-user start path forwards MCP_PORT to `run_http_server`.

Full suite green (588 passed, 19 skipped), ruff check + format + ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)