### PR TITLE
fix: gitignore bot/merge junk artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,11 @@ docs/superpowers/
 coverage.xml
 htmlcov/
 .coverage
+
+# Bot/merge junk artifacts (prevent accidental commits) — 2026-06-07
+*.orig
+*.rej
+*.cover
+*.bak
+/*.patch
+/*.diff


### PR DESCRIPTION
Prevents accidental commits of merge/patch junk (*.orig, *.rej, *.patch, *.diff, *.cover, *.bak) that bot PRs occasionally introduced. gitignore-only, inert.