### PR TITLE
🛡️ Sentinel: [HIGH] Fix Predictable Salt Vulnerability

### DIFF
--- a/src/better_telegram_mcp/auth/per_user_session_store.py
+++ b/src/better_telegram_mcp/auth/per_user_session_store.py
@@ -73,7 +73,9 @@ class PerUserSessionStore:
             return self._salt_path.read_bytes()
 
         # Backward compatibility: existing sessions use legacy hardcoded salt
-        if self._path.exists():
+        # We only fallback if the storage file exists and has content.
+        # Otherwise an empty file could bypass secure random salt generation.
+        if self._path.is_file() and self._path.stat().st_size > 0:
             return _LEGACY_SALT
 
         # New installation: generate random salt and persist atomically

--- a/src/better_telegram_mcp/transports/credential_store.py
+++ b/src/better_telegram_mcp/transports/credential_store.py
@@ -94,7 +94,9 @@ class CredentialStore:
             return self._salt_path.read_bytes()
 
         # Backward compatibility: existing credentials use legacy hardcoded salt
-        if self._path.exists():
+        # We only fallback if the storage file exists and has content.
+        # Otherwise an empty file could bypass secure random salt generation.
+        if self._path.is_file() and self._path.stat().st_size > 0:
             return _LEGACY_SALT
 
         # New installation: generate random salt and persist atomically

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.4"
+version = "4.12.5"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
Fix predictable salt vulnerability in CredentialStore and PerUserSessionStore

Updated `_resolve_salt` to only fall back to the legacy hardcoded salt `_LEGACY_SALT` if the storage file exists as a regular file and has actual content (`st_size > 0`). This ensures that an inadvertently created empty file does not bypass the secure random salt generation for new installations.

Also added a journal entry in `.jules/sentinel.md` documenting this critical learning.

---
*PR created automatically by Jules for task [8988748484211032879](https://jules.google.com/task/8988748484211032879) started by @n24q02m*