### PR TITLE
[PERF] Unnecessary string concatenation in loop for key preview

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,8 @@
+## 2025-05-22 - Optimize key preview loop in http.py
+**Optimization:** Replaced `keys_preview = list(provider.active_clients.keys())` with `itertools.islice(provider.active_clients.keys(), 5)` and string concatenation with f-strings.
+**Learning:** Materializing a full list of dictionary keys just to take the first 5 is inefficient. Direct slicing or islice is preferred. f-strings are generally more efficient and readable than string concatenation in loops.
+**Prevention:** Use `itertools.islice` when working with large dictionary views if only a subset is needed. Favor f-strings over `+` for string building.
+## 2025-05-22 - Optimize key preview loop in http.py
+**Optimization:** Replaced `keys_preview = list(provider.active_clients.keys())` with `itertools.islice(provider.active_clients.keys(), 5)` and string concatenation with f-strings.
+**Learning:** Materializing a full list of dictionary keys just to take the first 5 is inefficient. Direct slicing or islice is preferred. f-strings are generally more efficient and readable than string concatenation in loops.
+**Prevention:** Use `itertools.islice` when working with large dictionary views if only a subset is needed. Favor f-strings over `+` for string building.

--- a/src/better_telegram_mcp/transports/http.py
+++ b/src/better_telegram_mcp/transports/http.py
@@ -27,6 +27,7 @@ Per spec ``2026-05-01-stdio-pure-http-multiuser.md``: there is no
 is handled in ``server.main()`` and never reaches this module.
 """
 
+import itertools
 import os
 from contextvars import ContextVar
 from typing import Any
@@ -224,13 +225,13 @@ async def _per_request_sub_scope(
         provider = get_global_provider()
         if provider is not None:
             backend = provider.resolve_backend(sub)
-            keys_preview = list(provider.active_clients.keys())
             keys_short = [
-                k[:12] + "..." if len(k) > 12 else k for k in keys_preview[:5]
+                f"{k[:12]}..." if len(k) > 12 else k
+                for k in itertools.islice(provider.active_clients.keys(), 5)
             ]
             logger.info(
                 "auth_scope: sub={} found_backend={} active_keys_count={} keys={}",
-                (sub or "")[:12] + "...",
+                f"{(sub or '')[:12]}...",
                 type(backend).__name__ if backend else "None",
                 len(provider.active_clients),
                 keys_short,

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.4"
+version = "4.12.5"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
Optimized the `auth_scope` middleware in `src/better_telegram_mcp/transports/http.py` by removing unnecessary `list()` materialization of dictionary keys and replacing string concatenation with f-strings in the key preview loop. Added `import itertools` for efficient slicing.

---
*PR created automatically by Jules for task [18103337266253756495](https://jules.google.com/task/18103337266253756495) started by @n24q02m*