### PR TITLE
[FIX] Glama display name

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,4 +148,9 @@ Conventional Commits: `type(scope): message`. Automated semantic release.
 - **Mega-tool pattern**: 6 tools x N actions = full API coverage with minimal tool registration overhead
 - **Session persistence**: `~/.better-telegram-mcp/<name>.session` for Telethon (MTProto)
 - **Auth flow**: OTP sent to Telegram app -> terminal input or `config(action='auth', code='...')` for headless
-- **Glama integration**: The display name is programmatically set using the 'title' property in 'server.json'. The 'glama.json' file is used for ownership claiming via the 'maintainers' array and does not support the display name.
+
+- **Glama integration**: The display name cannot be set programmatically and must be updated manually via the Glama admin page. The 'glama.json' file is used for ownership claiming via the 'maintainers' array and does not support the display name.
+
+## TODO / Backlog
+
+- [ ] **Glama display name**: Cannot set programmatically. Update manually via Glama admin page.

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.4"
+version = "4.12.5"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
Updated AGENTS.md to clarify that the Glama display name cannot be set programmatically and must be updated manually via the Glama admin page. Added the task to the TODO / Backlog section as requested.

---
*PR created automatically by Jules for task [5167771748301572562](https://jules.google.com/task/5167771748301572562) started by @n24q02m*