### PR TITLE
[PERF] Sequential async calls in session cleanup loop

### DIFF
--- a/src/better_telegram_mcp/auth/telegram_auth_provider.py
+++ b/src/better_telegram_mcp/auth/telegram_auth_provider.py
@@ -356,10 +356,22 @@ class TelegramAuthProvider:
         removed = 0
         now = time.time()
 
-        for bearer, info in sessions.items():
-            if now - info.created_at > _SESSION_TTL:
-                await self.revoke_session(bearer)
-                removed += 1
+        to_revoke = [
+            bearer
+            for bearer, info in sessions.items()
+            if now - info.created_at > _SESSION_TTL
+        ]
+        if to_revoke:
+            results = await asyncio.gather(
+                *[self.revoke_session(b) for b in to_revoke], return_exceptions=True
+            )
+            for bearer, res in zip(to_revoke, results, strict=True):
+                if isinstance(res, Exception):
+                    logger.error(
+                        "Error revoking expired session {}: {}", bearer[:8], res
+                    )
+                elif res:
+                    removed += 1
 
         # Clean up stale pending OTPs (5 min TTL) using chronological insertion order.
         # Since start_user_auth pops-then-reinserts each bearer, the oldest entries

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.4"
+version = "4.12.5"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
Replaced the sequential loop in `TelegramAuthProvider.cleanup_expired` with `asyncio.gather` to execute session revocations concurrently. This reduces the total wait time for I/O operations (backend disconnection and session deletion) when multiple sessions expire at once.

- Identified expired sessions first to avoid modifying the dictionary during iteration.
- Used `asyncio.gather` with `return_exceptions=True` for robust parallel execution.
- Added error logging for failed revocations.
- Incremented the removed count only for successfully revoked sessions.
- Ensured compliance with Ruff B905 by using `strict=True` in `zip()`.
- Updated performance journal in `.jules/bolt.md`.

---
*PR created automatically by Jules for task [11175172234742894735](https://jules.google.com/task/11175172234742894735) started by @n24q02m*