### PR TITLE
[PERF] Suboptimal linear scan for session owners removal

### DIFF
--- a/src/better_telegram_mcp/auth/telegram_auth_provider.py
+++ b/src/better_telegram_mcp/auth/telegram_auth_provider.py
@@ -19,9 +19,14 @@ import asyncio
 import hashlib
 import secrets
 import time
+from collections import defaultdict
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 from loguru import logger
+
+if TYPE_CHECKING:
+    pass
 
 from ..backends.base import TelegramBackend
 from ..backends.bot_backend import BotBackend
@@ -55,6 +60,57 @@ _SESSION_TTL = 30 * 24 * 60 * 60
 _PendingOTP = dict  # {bearer, backend, phone, phone_code_hash, created_at}
 
 
+class _SessionOwnersDict(dict[str, str]):
+    """Internal dict that maintains a reverse mapping for O(1) bearer lookup."""
+
+    def __init__(
+        self, reverse_map: defaultdict[str, set[str]], *args: Any, **kwargs: Any
+    ) -> None:
+        self._reverse = reverse_map
+        super().__init__(*args, **kwargs)
+
+    def __setitem__(self, key: str, value: str) -> None:
+        if key in self:
+            old_val = self[key]
+            self._reverse[old_val].discard(key)
+            if not self._reverse[old_val]:
+                del self._reverse[old_val]
+        super().__setitem__(key, value)
+        self._reverse[value].add(key)
+
+    def __delitem__(self, key: str) -> None:
+        if key in self:
+            old_val = self[key]
+            self._reverse[old_val].discard(key)
+            if not self._reverse[old_val]:
+                del self._reverse[old_val]
+        super().__delitem__(key)
+
+    def pop(self, key: str, default: Any = None) -> str:
+        if key in self:
+            val = self[key]
+            self._reverse[val].discard(key)
+            if not self._reverse[val]:
+                del self._reverse[val]
+            return super().pop(key)
+        return default
+
+    def clear(self) -> None:
+        super().clear()
+        self._reverse.clear()
+
+    def update(self, other: Any = None, **kwargs: Any) -> None:
+        if other is not None:
+            if hasattr(other, "keys"):
+                for k in other:
+                    self[k] = other[k]
+            else:
+                for k, v in other:
+                    self[k] = v
+        for k, v in kwargs.items():
+            self[k] = v
+
+
 class TelegramAuthProvider:
     """Manages per-user Telegram authentication and backend lifecycle.
 
@@ -72,7 +128,11 @@ class TelegramAuthProvider:
         self.active_clients: dict[str, TelegramBackend] = {}
 
         # MCP session_id -> bearer (session ownership)
-        self.session_owners: dict[str, str] = {}
+        # ⚡ Bolt: Maintain reverse mapping for O(1) removal of sessions by bearer
+        self._bearer_to_sessions: defaultdict[str, set[str]] = defaultdict(set)
+        self.session_owners: dict[str, str] = _SessionOwnersDict(
+            self._bearer_to_sessions
+        )
 
         # Pending OTP verifications (bearer -> pending state)
         self._pending_otps: dict[str, _PendingOTP] = {}
@@ -344,7 +404,8 @@ class TelegramAuthProvider:
             await pending["backend"].disconnect()
 
         # Remove from ownership map
-        to_remove = [sid for sid, b in self.session_owners.items() if b == bearer]
+        # ⚡ Bolt: Use reverse mapping for O(1) removal
+        to_remove = list(self._bearer_to_sessions.get(bearer, []))
         for sid in to_remove:
             del self.session_owners[sid]
 

--- a/tests/test_session_owners_perf.py
+++ b/tests/test_session_owners_perf.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+
+import pytest
+
+from better_telegram_mcp.auth.telegram_auth_provider import TelegramAuthProvider
+
+
+@pytest.fixture
+def data_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "data"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def provider(data_dir: Path) -> TelegramAuthProvider:
+    return TelegramAuthProvider(data_dir, api_id=12345, api_hash="test_hash")
+
+
+def test_session_owners_reverse_mapping_sync(provider: TelegramAuthProvider):
+    """Verify that _bearer_to_sessions is correctly synchronized with session_owners."""
+    bearer1 = "bearer1"
+    bearer2 = "bearer2"
+
+    # 1. Addition
+    provider.session_owners["sid1"] = bearer1
+    provider.session_owners["sid2"] = bearer1
+    provider.session_owners["sid3"] = bearer2
+
+    assert provider._bearer_to_sessions[bearer1] == {"sid1", "sid2"}
+    assert provider._bearer_to_sessions[bearer2] == {"sid3"}
+
+    # 2. Update (change bearer for a session)
+    provider.session_owners["sid1"] = bearer2
+    assert "sid1" not in provider._bearer_to_sessions[bearer1]
+    assert provider._bearer_to_sessions[bearer1] == {"sid2"}
+    assert provider._bearer_to_sessions[bearer2] == {"sid3", "sid1"}
+
+    # 3. Deletion
+    del provider.session_owners["sid2"]
+    assert bearer1 not in provider._bearer_to_sessions
+    assert provider._bearer_to_sessions[bearer2] == {"sid3", "sid1"}
+
+    # 4. Pop
+    val = provider.session_owners.pop("sid3")
+    assert val == bearer2
+    assert provider._bearer_to_sessions[bearer2] == {"sid1"}
+
+    # 5. Clear
+    provider.session_owners.clear()
+    assert len(provider.session_owners) == 0
+    assert len(provider._bearer_to_sessions) == 0
+
+
+def test_session_owners_update_sync(provider: TelegramAuthProvider):
+    """Verify that update() correctly synchronizes reverse mapping."""
+    bearer1 = "bearer1"
+    provider.session_owners.update({"sid1": bearer1, "sid2": bearer1})
+    assert provider._bearer_to_sessions[bearer1] == {"sid1", "sid2"}
+
+    provider.session_owners.update(sid3="bearer2")
+    assert provider._bearer_to_sessions["bearer2"] == {"sid3"}

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.4"
+version = "4.12.5"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
Optimized the removal of session owners in `TelegramAuthProvider` by introducing a reverse mapping `bearer -> set[session_id]`, allowing O(1) removal instead of O(N) linear scan.

Implemented via a specialized `_SessionOwnersDict` that automatically keeps the reverse mapping in sync with the primary `session_owners` dict.

- Added `_SessionOwnersDict` helper class
- Updated `TelegramAuthProvider.__init__` to initialize reverse mapping
- Updated `TelegramAuthProvider.revoke_session` to use reverse mapping
- Added `tests/test_session_owners_perf.py` to verify synchronization
- Verified with full test suite and linting

---
*PR created automatically by Jules for task [15134843109863194545](https://jules.google.com/task/15134843109863194545) started by @n24q02m*