### PR TITLE
[SECURITY] Hardcoded Authentication URL

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,6 @@
 ## 2024-07-28 - Contrast Requirements for Dark Themes
 **Learning:** Text using color `#666` fails WCAG AA 4.5:1 contrast requirements when placed against dark-themed backgrounds such as `#1a1a1a`.
 **Action:** When designing dark themes, ensure that subtle or secondary text elements (like `.server-id` and `.help-text`) are upgraded to at least `#888` or `#999` to maintain readability and accessibility standards.
+## 2026-06-05 - Security Configuration UX
+**Learning:** When making a previously default configuration field required, providing a clear error message that explains *why* it is required (e.g., "required for public deployments") helps users understand the security context and fix the issue quickly.
+**Pattern:** Conditional validation in Pydantic Settings allows for a flexible UX that stays simple for local/stdio users while enforcing security for public deployments.

--- a/src/better_telegram_mcp/config.py
+++ b/src/better_telegram_mcp/config.py
@@ -30,7 +30,7 @@ class Settings(BaseSettings):
     session_name: str = "default"
 
     # Auth
-    auth_url: str = "https://better-telegram-mcp.n24q02m.com"
+    auth_url: str | None = None
 
     # Data
     data_dir: Path = Path.home() / ".better-telegram-mcp"
@@ -56,6 +56,12 @@ class Settings(BaseSettings):
         self.bot_token = _empty_to_none(self.bot_token)
         self.api_hash = _empty_to_none(self.api_hash)
         self.phone = _empty_to_none(self.phone)
+        self.auth_url = _empty_to_none(self.auth_url)
+
+        if os.environ.get("PUBLIC_URL") and not self.auth_url:
+            raise ValueError(
+                "TELEGRAM_AUTH_URL is required for public deployments (PUBLIC_URL is set)"
+            )
 
         has_bot = self.bot_token is not None
         # User mode requires phone (api_id/api_hash have built-in defaults)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -187,3 +187,26 @@ def test_from_relay_config():
     s2 = Settings.from_relay_config({})
     assert s2.api_id == 37984984
     assert s2.api_hash == "2f5f4c76c4de7c07302380c788390100"
+
+
+def test_auth_url_required_for_public_url(monkeypatch):
+    monkeypatch.setenv("PUBLIC_URL", "https://example.com")
+    monkeypatch.delenv("TELEGRAM_AUTH_URL", raising=False)
+    with pytest.raises(
+        ValueError, match="TELEGRAM_AUTH_URL is required for public deployments"
+    ):
+        Settings()
+
+
+def test_auth_url_success_with_public_url(monkeypatch):
+    monkeypatch.setenv("PUBLIC_URL", "https://example.com")
+    monkeypatch.setenv("TELEGRAM_AUTH_URL", "https://auth.example.com")
+    s = Settings()
+    assert s.auth_url == "https://auth.example.com"
+
+
+def test_auth_url_none_without_public_url(monkeypatch):
+    monkeypatch.delenv("PUBLIC_URL", raising=False)
+    monkeypatch.delenv("TELEGRAM_AUTH_URL", raising=False)
+    s = Settings()
+    assert s.auth_url is None

--- a/tests/test_transports/test_http.py
+++ b/tests/test_transports/test_http.py
@@ -86,6 +86,7 @@ class TestIsMultiUserMode:
         env = {
             "DCR_SERVER_SECRET": "secret",
             "PUBLIC_URL": "https://mcp.example.com",
+            "TELEGRAM_AUTH_URL": "https://auth.example.com",
         }
         with patch.dict("os.environ", env, clear=True):
             # settings has api_id/api_hash by default
@@ -99,6 +100,7 @@ class TestIsMultiUserMode:
         env = {
             "MCP_DCR_SERVER_SECRET": "secret",
             "PUBLIC_URL": "https://mcp.example.com",
+            "TELEGRAM_AUTH_URL": "https://auth.example.com",
         }
         with patch.dict("os.environ", env, clear=True):
             assert _is_multi_user_mode(settings) is True
@@ -109,6 +111,7 @@ class TestIsMultiUserMode:
         env = {
             "DCR_SERVER_SECRET": "secret",
             "PUBLIC_URL": "https://mcp.example.com",
+            "TELEGRAM_AUTH_URL": "https://auth.example.com",
         }
         with patch.dict("os.environ", env, clear=True):
             assert _is_multi_user_mode(settings) is True
@@ -130,6 +133,7 @@ class TestIsMultiUserMode:
         env = {
             "DCR_SERVER_SECRET": "secret",
             "PUBLIC_URL": "https://mcp.example.com",
+            "TELEGRAM_AUTH_URL": "https://auth.example.com",
         }
         settings_no_api = Settings(data_dir=tmp_path, api_id=0, api_hash="")
         with patch.dict("os.environ", env, clear=True):
@@ -169,6 +173,7 @@ class TestStartHttp:
         env = {
             "DCR_SERVER_SECRET": "secret",
             "PUBLIC_URL": "https://mcp.example.com",
+            "TELEGRAM_AUTH_URL": "https://auth.example.com",
             "TELEGRAM_API_ID": "12345",
             "TELEGRAM_API_HASH": "hash",
             "PORT": "9090",
@@ -213,6 +218,7 @@ class TestStartHttp:
         env = {
             "DCR_SERVER_SECRET": "secret",
             "PUBLIC_URL": "https://mcp.example.com",
+            "TELEGRAM_AUTH_URL": "https://auth.example.com",
             "TELEGRAM_API_ID": "12345",
             "TELEGRAM_API_HASH": "hash",
         }
@@ -249,6 +255,7 @@ class TestStartHttp:
         env = {
             "DCR_SERVER_SECRET": "secret",
             "PUBLIC_URL": "https://mcp.example.com",
+            "TELEGRAM_AUTH_URL": "https://auth.example.com",
             "TELEGRAM_API_ID": "12345",
             "TELEGRAM_API_HASH": "hash",
             "MCP_PORT": "12345",
@@ -285,6 +292,7 @@ class TestStartHttp:
         env = {
             "MCP_DCR_SERVER_SECRET": "secret",
             "PUBLIC_URL": "https://mcp.example.com",
+            "TELEGRAM_AUTH_URL": "https://auth.example.com",
             "TELEGRAM_API_ID": "12345",
             "TELEGRAM_API_HASH": "hash",
         }
@@ -317,6 +325,7 @@ class TestStartHttp:
         env = {
             "DCR_SERVER_SECRET": "secret",
             "PUBLIC_URL": "https://mcp.example.com",
+            "TELEGRAM_AUTH_URL": "https://auth.example.com",
             "TELEGRAM_API_ID": "12345",
             "TELEGRAM_API_HASH": "hash",
         }
@@ -359,6 +368,7 @@ class TestStartHttp:
         """TELEGRAM_ACCEPT_SHARED_SINGLE_USER=1 opt-in skips the refuse-guard."""
         env = {
             "PUBLIC_URL": "https://mcp.example.com",
+            "TELEGRAM_AUTH_URL": "https://auth.example.com",
             "TELEGRAM_ACCEPT_SHARED_SINGLE_USER": "1",
         }
 

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.4"
+version = "4.12.5"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
### Problem
The `auth_url` was previously hardcoded to `https://better-telegram-mcp.n24q02m.com` in `src/better_telegram_mcp/config.py`. This meant all deployments, including private ones, would default to using this external relay unless explicitly changed, which is a security and privacy risk.

### Solution
- Removed the hardcoded default for `auth_url` in the `Settings` class.
- Added a `model_validator` to enforce that `TELEGRAM_AUTH_URL` is provided if `PUBLIC_URL` is set (indicating a public deployment).
- Updated `tests/test_transports/test_http.py` to include a dummy `TELEGRAM_AUTH_URL` in environment mocks where `PUBLIC_URL` is used.
- Added comprehensive unit tests in `tests/test_config.py` to verify the new validation logic.
- Recorded security and UX learnings in `.jules/sentinel.md` and `.jules/palette.md`.

### Impact
Users deploying the server publicly are now forced to explicitly configure their own authentication relay URL, improving the security posture and privacy of the application. Local and stdio users are unaffected as the field remains optional when `PUBLIC_URL` is not set.

---
*PR created automatically by Jules for task [4071597106193761745](https://jules.google.com/task/4071597106193761745) started by @n24q02m*