### PR TITLE
[TEST] Missing tests for contacts tool

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -166,6 +166,70 @@ async def test_contact_list(mock_backend):
 
 
 @pytest.mark.asyncio
+async def test_contact_search(mock_backend):
+    import better_telegram_mcp.server as srv
+    from better_telegram_mcp.server import contact
+
+    old_backend = srv._backend
+    old_pending = srv._pending_auth
+    try:
+        srv._backend = mock_backend
+        srv._pending_auth = False
+        result = json.loads(await contact(action="search", query="John"))
+        assert "error" not in result
+        mock_backend.search_contacts.assert_awaited_once_with("John")
+    finally:
+        srv._backend = old_backend
+        srv._pending_auth = old_pending
+
+
+@pytest.mark.asyncio
+async def test_contact_add(mock_backend):
+    import better_telegram_mcp.server as srv
+    from better_telegram_mcp.server import contact
+
+    old_backend = srv._backend
+    old_pending = srv._pending_auth
+    try:
+        srv._backend = mock_backend
+        srv._pending_auth = False
+        result = json.loads(
+            await contact(
+                action="add",
+                phone="+12345",
+                first_name="John",
+                last_name="Doe",
+            )
+        )
+        assert "error" not in result
+        mock_backend.add_contact.assert_awaited_once_with(
+            "+12345", "John", last_name="Doe"
+        )
+    finally:
+        srv._backend = old_backend
+        srv._pending_auth = old_pending
+
+
+@pytest.mark.asyncio
+async def test_contact_block(mock_backend):
+    import better_telegram_mcp.server as srv
+    from better_telegram_mcp.server import contact
+
+    old_backend = srv._backend
+    old_pending = srv._pending_auth
+    try:
+        srv._backend = mock_backend
+        srv._pending_auth = False
+        result = json.loads(await contact(action="block", user_id=123))
+        assert "error" not in result
+        assert result["blocked"] is True
+        mock_backend.block_user.assert_awaited_once_with(123, unblock=False)
+    finally:
+        srv._backend = old_backend
+        srv._pending_auth = old_pending
+
+
+@pytest.mark.asyncio
 async def test_message_unknown_action(mock_backend):
     import better_telegram_mcp.server as srv
     from better_telegram_mcp.server import message

--- a/tests/test_tools/test_contacts.py
+++ b/tests/test_tools/test_contacts.py
@@ -14,6 +14,7 @@ async def test_list(mock_backend):
     result = json.loads(await handle_contacts(mock_backend, "list"))
     assert result["contacts"] == []
     assert result["count"] == 0
+    mock_backend.list_contacts.assert_awaited_once_with()
 
 
 @pytest.mark.asyncio
@@ -23,6 +24,7 @@ async def test_search(mock_backend):
     )
     assert result["contacts"] == []
     assert result["count"] == 0
+    mock_backend.search_contacts.assert_awaited_once_with("John")
 
 
 @pytest.mark.asyncio
@@ -69,6 +71,7 @@ async def test_block(mock_backend):
         await handle_contacts(mock_backend, "block", ContactsOptions(user_id=123))
     )
     assert result["blocked"] is True
+    mock_backend.block_user.assert_awaited_once_with(123, unblock=False)
 
 
 @pytest.mark.asyncio
@@ -79,6 +82,7 @@ async def test_unblock(mock_backend):
         )
     )
     assert result["unblocked"] is True
+    mock_backend.block_user.assert_awaited_once_with(123, unblock=True)
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.4"
+version = "4.12.5"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
Improved unit tests for the contacts tool by adding backend call verification and added integration tests for the `contact` tool in `server.py` to ensure correct argument mapping from flat entry-point arguments to internal Pydantic models. Reached 100% coverage for `contacts.py`.

---
*PR created automatically by Jules for task [3685178370845650314](https://jules.google.com/task/3685178370845650314) started by @n24q02m*