### PR TITLE
🎨 Palette: Clear validation error state on input

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,7 @@
 ## 2024-07-28 - Contrast Requirements for Dark Themes
 **Learning:** Text using color `#666` fails WCAG AA 4.5:1 contrast requirements when placed against dark-themed backgrounds such as `#1a1a1a`.
 **Action:** When designing dark themes, ensure that subtle or secondary text elements (like `.server-id` and `.help-text`) are upgraded to at least `#888` or `#999` to maintain readability and accessibility standards.
+
+## 2024-08-01 - Clear Validation Errors on Input
+**Learning:** Leaving error states (like `aria-invalid="true"` or visible error banners) active after the user has begun to correct their input creates a hostile UX and cognitive friction. Forms feel much more responsive and forgiving when validation feedback resets the moment the user types a new character.
+**Action:** Always attach `input` event listeners to form fields to actively strip validation styling and hide inline error messages when the user resumes typing.

--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -605,6 +605,10 @@ def render_telegram_credential_form(
                             submitStep();
                         }}
                     }});
+                    inputEl.addEventListener("input", function () {{
+                        inputEl.removeAttribute("aria-invalid");
+                        errorEl.style.display = "none";
+                    }});
                 }}
 
                 promptEl.textContent = ns.text || "";
@@ -703,6 +707,16 @@ def render_telegram_credential_form(
                         inputEl.focus();
                     }});
             }}
+
+            // Clear validation errors on typing
+            form.querySelectorAll(".field-input").forEach(function (input) {{
+                input.addEventListener("input", function () {{
+                    input.removeAttribute("aria-invalid");
+                    if (statusBox.classList.contains("error")) {{
+                        statusBox.style.display = "none";
+                    }}
+                }});
+            }});
 
             // --- Form submit ---------------------------------------------------
             form.addEventListener("submit", function (event) {{

--- a/tests/test_credential_form.py
+++ b/tests/test_credential_form.py
@@ -78,6 +78,14 @@ def test_escapes_submit_url() -> None:
     assert "&lt;script&gt;" in html or "&quot;&gt;&lt;script&gt;" in html
 
 
+def test_form_clears_validation_errors_on_input() -> None:
+    html = render_telegram_credential_form(SCHEMA, "/auth")
+    assert 'input.addEventListener("input"' in html
+    assert 'inputEl.addEventListener("input"' in html
+    assert 'input.removeAttribute("aria-invalid")' in html
+    assert 'statusBox.style.display = "none"' in html
+
+
 def test_renders_with_minimal_schema() -> None:
     html = render_telegram_credential_form({}, "/auth")
     # Falls back to generic defaults without raising.

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.5"
+version = "4.12.6"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
### 🎨 Palette: Clear validation error state on input

**💡 What:** Added JavaScript event listeners to the credential form inputs (`.field-input` and dynamically created `#step-input`) that listen for the `input` event. When the user starts typing, any existing `aria-invalid` attributes are stripped from the input field, and associated error alert banners (`.status-box.error` or `#step-error`) are hidden.
**🎯 Why:** Leaving error states visible after the user has begun to correct their input creates cognitive friction and makes the form feel hostile. Resetting the validation state as soon as the user takes corrective action (typing) makes the UI feel much more responsive and forgiving.
**♿ Accessibility:** Improves screen reader and visual experience by not maintaining an invalid state once the user is actively working on correcting it.
**📸 Before/After:** Before this change, if you submitted an empty field, it would turn red and stay red, with a visible error banner, even as you typed the correct value. Now, the red styling and banner disappear instantly upon the first keystroke.

Also added a new test to verify this behavior and updated `.jules/palette.md` to document this reusable UX pattern.

---
*PR created automatically by Jules for task [1044942847865067676](https://jules.google.com/task/1044942847865067676) started by @n24q02m*