### PR TITLE
fix: correct docs drift (versions, tool names, links, compose base)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md - better-telegram-mcp
 
 MCP Server cho Telegram. Python 3.13, uv, hatchling, src layout.
-Dual-mode: Bot API (httpx) + MTProto (Telethon). 6 tools: message, chat, media, contact, config, help.
+Dual-mode: Bot API (httpx) + MTProto (Telethon). 7 tools: message, chat, media, contact, config, help, config__open_relay.
 
 ## Commands
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,32 +79,27 @@ We use [Conventional Commits](https://www.conventionalcommits.org/):
 
 ### Types
 
+Only two commit prefixes are accepted; the `commit-msg` hook
+(`scripts/enforce-commit.sh`) rejects any other type:
+
 - `feat`: New feature
-- `fix`: Bug fix
-- `docs`: Documentation changes
-- `style`: Code style changes
-- `refactor`: Code refactoring
-- `perf`: Performance improvements
-- `test`: Adding or updating tests
-- `chore`: Maintenance tasks
-- `ci`: CI/CD changes
-- `build`: Build system changes
+- `fix`: Bug fix (also use for docs, refactors, tests, CI, and chores)
 
 ### Examples
 
 ```text
 feat: add support for inline keyboards
 fix: handle Telethon session expiry
-docs: update configuration examples
+fix: update configuration examples in README
 ```
 
 ### Version Bumps
 
 | Commit Type | Version Bump | Example |
 |---|---|---|
-| `fix:` | PATCH (3.1.0 -> 3.1.1) | `fix: handle session expiry` |
-| `feat:` | MINOR (3.1.0 -> 3.2.0) | `feat: add inline keyboard support` |
-| `feat!:` or `BREAKING CHANGE:` | MAJOR (3.1.0 -> 4.0.0) | `feat!: remove CLI auth` |
+| `fix:` | PATCH (4.1.0 -> 4.1.1) | `fix: handle session expiry` |
+| `feat:` | MINOR (4.1.0 -> 4.2.0) | `feat: add inline keyboard support` |
+| `BREAKING CHANGE:` footer | MAJOR (4.1.0 -> 5.0.0) | `feat: remove CLI auth` + `BREAKING CHANGE: ...` body |
 
 ## Release Process
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ mcp-name: io.github.n24q02m/better-telegram-mcp
 ## Features
 
 - **Dual mode** -- Bot API (httpx) for bots, MTProto (Telethon) for user accounts
-- **6 tools** with action dispatch: `message`, `chat`, `media`, `contact`, `config`, `help`
+- **7 tools** with action dispatch: `message`, `chat`, `media`, `contact`, `config`, `help`, `config__open_relay`
 - **Auto-detect mode** -- Set bot token for bot mode, or API credentials for user mode
 - **Web-based OTP auth** -- Browser-based authentication with remote relay support for headless environments
 - **Tool annotations** -- Each tool declares `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`
@@ -91,7 +91,7 @@ mcp-name: io.github.n24q02m/better-telegram-mcp
 
 ## Documentation
 
-Full docs at **[mcp.n24q02m.com/servers/better-telegram-mcp/](https://mcp.n24q02m.com/servers/better-telegram-mcp/)**:
+Full docs at **[mcp.n24q02m.com/servers/better-telegram-mcp/setup/](https://mcp.n24q02m.com/servers/better-telegram-mcp/setup/)**:
 
 - [Setup](https://mcp.n24q02m.com/servers/better-telegram-mcp/setup/) -- install methods for Claude Code, Codex, Gemini CLI, Cursor, Windsurf, mcp.json
 - [Modes overview](https://mcp.n24q02m.com/get-started/modes-overview/) -- stdio / local-relay / remote-relay / remote-oauth
@@ -112,6 +112,7 @@ Full docs at **[mcp.n24q02m.com/servers/better-telegram-mcp/](https://mcp.n24q02
 | `contact` | `list`, `search`, `add`, `block` | List, search, add contacts. Block/unblock users (user mode only) |
 | `config` | `status`, `set`, `cache_clear`, `setup_status`, `setup_start`, `setup_reset`, `setup_complete` | Server status, runtime settings, cache, credential setup (relay, status, reset, complete) |
 | `help` | -- | Full documentation for any topic |
+| `config__open_relay` | -- | Re-trigger the zero-config relay setup flow (prints a fresh relay URL for the browser form). Registered via `mcp-core`'s `register_open_relay_tool` so an LLM can restart setup without a manual restart |
 
 ### MCP Resources
 
@@ -141,7 +142,7 @@ uv run better-telegram-mcp
 
 ## Trust Model
 
-This plugin implements **TC-NearZK** (in-memory, ephemeral). See [mcp-core/docs/TRUST-MODEL.md](https://github.com/n24q02m/mcp-core/blob/main/docs/TRUST-MODEL.md) for full classification.
+This plugin implements **TC-NearZK** (in-memory, ephemeral). See [mcp-core trust model](https://mcp.n24q02m.com/servers/mcp-core/trust-model/) for full classification.
 
 | Mode | Storage | Encryption | Who can read your data? |
 |---|---|---|---|

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 3.x.x   | :white_check_mark: |
-| < 3.0   | :x:                |
+| 4.x.x   | :white_check_mark: |
+| < 4.0   | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+# Base compose file — stdio mode (default).
+# For HTTP mode, layer the overlay:
+#   docker compose -f docker-compose.yml -f docker-compose.http.yml up
+services:
+  better-telegram-mcp:
+    image: n24q02m/better-telegram-mcp:latest
+    environment:
+      - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN}
+      - TELEGRAM_DATA_DIR=/data
+    volumes:
+      - telegram-data:/data
+volumes:
+  telegram-data:

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.n24q02m/better-telegram-mcp",
   "title": "Better Telegram MCP",
-  "description": "Telegram MCP server — dual-mode Bot API + MTProto, 6 composite tools.",
+  "description": "Telegram MCP server — dual-mode Bot API + MTProto, composite tools.",
   "repository": {
     "url": "https://github.com/n24q02m/better-telegram-mcp.git",
     "source": "github"

--- a/skills/channel-post/SKILL.md
+++ b/skills/channel-post/SKILL.md
@@ -11,7 +11,7 @@ Compose and post formatted content to a Telegram channel with correct formatting
 ## Steps
 
 1. **Identify target channel**:
-   - `chats(action="list")` to find the channel
+   - `chat(action="list")` to find the channel
    - Channel chat_id is a negative number (e.g., -1001234567890) or @username
 
 2. **Compose content** with the user:
@@ -20,8 +20,8 @@ Compose and post formatted content to a Telegram channel with correct formatting
    - Determine if media attachments are needed
 
 3. **Handle media attachments** (if any):
-   - Photo with caption: `media(action="send_photo", chat_id="...", file_path="...", caption="...")` -- caption goes WITH the photo, not as a separate message
-   - Document: `media(action="send_document", chat_id="...", file_path="...")`
+   - Photo with caption: `media(action="send_photo", chat_id="...", file_path_or_url="...", caption="...")` -- caption goes WITH the photo, not as a separate message
+   - Document: `media(action="send_file", chat_id="...", file_path_or_url="...")`
    - Multiple photos: send as media group, first photo carries the caption
 
 4. **Split long messages** if content exceeds 4096 characters:
@@ -30,7 +30,7 @@ Compose and post formatted content to a Telegram channel with correct formatting
    - Send chunks sequentially with the same parse_mode
 
 5. **Send and verify**:
-   - `messages(action="send", chat_id="<channel>", text="<content>", parse_mode="MarkdownV2")`
+   - `message(action="send", chat_id="<channel>", text="<content>", parse_mode="MarkdownV2")`
    - Verify the message appears correctly in the channel
    - If formatting breaks, check the escaping rules below
 

--- a/skills/setup-bot/SKILL.md
+++ b/skills/setup-bot/SKILL.md
@@ -15,9 +15,9 @@ Diagnose and fix Telegram bot connectivity issues. This skill assumes the bot al
    - If status shows "not configured", the user needs to set `TELEGRAM_BOT_TOKEN` env var and restart the MCP server (token is NOT runtime-configurable)
 
 2. **Test send to obtain chat_id**:
-   - `chats(action="list")` to see known chats
+   - `chat(action="list")` to see known chats
    - If no chats appear, instruct user to send any message to the bot first (the bot must receive at least one message to discover chat_id)
-   - Send test: `messages(action="send", chat_id="<id>", text="Connection test")`
+   - Send test: `message(action="send", chat_id="<id>", text="Connection test")`
 
 3. **Diagnose errors** using the flowchart below
 

--- a/src/better_telegram_mcp/server.py
+++ b/src/better_telegram_mcp/server.py
@@ -622,7 +622,7 @@ def main() -> None:
                 "  2. Switch to HTTP mode for user mode auth "
                 "(see https://mcp.n24q02m.com/servers/better-telegram-mcp/setup/)\n"
                 "\n"
-                "Documentation: https://mcp.n24q02m.com/servers/better-telegram-mcp/\n"
+                "Documentation: https://mcp.n24q02m.com/servers/better-telegram-mcp/setup/\n"
             )
             sys.stderr.write(msg)
             sys.exit(1)


### PR DESCRIPTION
Documentation-drift audit for the public release repo. Every finding verified against actual source before editing.

## Findings + status

1. **SECURITY.md supported-versions (DRIFT, fixed)** — table listed major `3.x` but current released major is `4.x` (latest stable `v4.12.6`, per `gh release list`). Updated to `4.x.x` / `< 4.0`.

2. **Skills wrong tool/param names (DRIFT, fixed)** — verified against the FastMCP registry in `src/better_telegram_mcp/server.py`. Actual tools are `message`/`chat`/`media`/`contact` (singular), media uses action `send_file` and param `file_path_or_url`. Corrected every stale reference in `skills/channel-post/SKILL.md` + `skills/setup-bot/SKILL.md` (`chats`->`chat`, `messages`->`message`, `send_document`->`send_file`, `file_path`->`file_path_or_url`). The `src/.../docs/*.md` resources contain no tool-call examples, so no drift there.

3. **Missing base `docker-compose.yml` (DRIFT, fixed by adding file)** — `docker-compose.http.yml` is an overlay whose header documents `docker compose -f docker-compose.yml -f docker-compose.http.yml up`, but the base `docker-compose.yml` was **never committed** (confirmed via git history; PR #77 added only the overlay). `.dockerignore` even reserved the name. The overlay defines no image, so the documented command fails. Added a canonical base (stdio default, `image: n24q02m/better-telegram-mcp:latest`, `/data` volume the overlay reuses) derived from the Dockerfile. Validated both `docker compose config` (base alone) and the merged base+overlay.

4. **Tool count (DRIFT, fixed)** — actual registered count is **7**: `message, chat, media, contact, config, help, config__open_relay` (asserted in `tests/test_server.py`). Canonical sibling convention (email-mcp) counts `config__open_relay` in. Bumped README/CLAUDE.md to 7 and added a `config__open_relay` row to the README Tools table. Dropped the hard "6 composite tools" count from `server.json` description (mirrors email-mcp). Left `tools/  # 6 mega-tools` in AGENTS.md/CONTRIBUTING.md — those correctly describe the 6 source modules (config__open_relay is registered externally from mcp-core, not a module).

5. **Dead links (DRIFT, fixed)** — curl-verified:
   - `mcp-core/docs/TRUST-MODEL.md` blob -> 404 (mcp-core/docs only has README). Replaced with the live `https://mcp.n24q02m.com/servers/mcp-core/trust-model/` (200, where mcp-core's own README points).
   - bare server-root `.../servers/better-telegram-mcp/` -> 404 (all bare roots 404). Repointed README "Full docs" link and the stdio error-message "Documentation:" URL in `server.py` to the live `/setup/` leaf (200).

6. **CONTRIBUTING.md commit-type list (DRIFT, fixed)** — advertised `feat/fix/docs/style/refactor/perf/test/chore/ci/build`, but the enforced `commit-msg` hook (`scripts/enforce-commit.sh`) blocks everything except `feat:`/`fix:`. Contributors following the old list would have commits rejected. Aligned Types to feat/fix-only, removed the `docs:` example, and replaced the `feat!:` MAJOR row with the `BREAKING CHANGE:` footer (the hook also rejects `!`).

## Verification
- `uv run ruff check .` — all checks passed
- `uv run ruff format --check` — clean
- `uv run pytest tests/test_server.py tests/test_config_open_relay_registered.py` — 52 passed (7-tool assertion holds)
- `docker compose config` — base + overlay merge validated
- pre-commit hooks passed on commit
- uv.lock pre-existing working-tree drift kept out of this PR (scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)