### PR TITLE
[FIX] Glama display name

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,4 +148,8 @@ Conventional Commits: `type(scope): message`. Automated semantic release.
 - **Mega-tool pattern**: 6 tools x N actions = full API coverage with minimal tool registration overhead
 - **Session persistence**: `~/.better-telegram-mcp/<name>.session` for Telethon (MTProto)
 - **Auth flow**: OTP sent to Telegram app -> terminal input or `config(action='auth', code='...')` for headless
-- **Glama integration**: The display name is programmatically set using the 'title' property in 'server.json'. The 'glama.json' file is used for ownership claiming via the 'maintainers' array and does not support the display name.
+- **Glama integration**: The display name cannot be set programmatically and must be updated manually via the Glama admin page. Although 'server.json' contains a 'title' property, it does not control the external Glama listing. The 'glama.json' file is used exclusively for ownership claiming via the 'maintainers' array.
+
+## TODO / Backlog
+
+- [ ] **Glama display name**: Cannot set programmatically. Update manually via Glama admin page.

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.6"
+version = "4.12.7b2"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
This PR updates `AGENTS.md` to reflect that the Glama display name cannot be set programmatically. It corrects the existing description in the 'Architecture' section and adds a new 'TODO / Backlog' section with the corresponding task. This ensures maintainers and agents are aware of the manual intervention required on the Glama platform.

---
*PR created automatically by Jules for task [13675088811010157136](https://jules.google.com/task/13675088811010157136) started by @n24q02m*