### PR TITLE
[PERF] Sequential async calls in session cleanup loop

### DIFF
--- a/src/better_telegram_mcp/auth/telegram_auth_provider.py
+++ b/src/better_telegram_mcp/auth/telegram_auth_provider.py
@@ -356,27 +356,51 @@ class TelegramAuthProvider:
         removed = 0
         now = time.time()
 
-        for bearer, info in sessions.items():
-            if now - info.created_at > _SESSION_TTL:
-                await self.revoke_session(bearer)
-                removed += 1
+        # 1. Revoke expired active sessions concurrently
+        to_revoke = [
+            bearer
+            for bearer, info in sessions.items()
+            if now - info.created_at > _SESSION_TTL
+        ]
+        if to_revoke:
+            # We use return_exceptions=True to ensure one failure doesn't stop the rest.
+            # revoke_session returns True if the session was found and deleted in store.
+            results = await asyncio.gather(
+                *[self.revoke_session(b) for b in to_revoke], return_exceptions=True
+            )
+            for res in results:
+                if isinstance(res, Exception):
+                    logger.error("Unexpected error during session revocation: {}", res)
+                elif res is True:
+                    removed += 1
 
-        # Clean up stale pending OTPs (5 min TTL) using chronological insertion order.
+        # 2. Clean up stale pending OTPs (5 min TTL) concurrently using chronological order.
         # Since start_user_auth pops-then-reinserts each bearer, the oldest entries
         # are always at the front, so we can stop at the first non-stale entry instead
         # of scanning the full dict on every cleanup tick.
+        stale_otps = []
         while self._pending_otps:
             bearer, pending = next(iter(self._pending_otps.items()))
             if now - pending["created_at"] <= 300:
                 break
             self._pending_otps.pop(bearer)
-            try:
-                await pending["backend"].disconnect()
-            except Exception as exc:  # pragma: no cover - best-effort cleanup
-                logger.warning(
-                    "Error disconnecting stale OTP backend {}: {}", bearer[:8], exc
-                )
-            removed += 1
+            stale_otps.append((bearer, pending))
+
+        if stale_otps:
+
+            async def _disconnect_stale(b: str, p: dict) -> None:
+                try:
+                    await p["backend"].disconnect()
+                except Exception as exc:  # pragma: no cover - best-effort cleanup
+                    logger.warning(
+                        "Error disconnecting stale OTP backend {}: {}", b[:8], exc
+                    )
+
+            await asyncio.gather(
+                *[_disconnect_stale(b, p) for b, p in stale_otps],
+                return_exceptions=True,
+            )
+            removed += len(stale_otps)
 
         return removed
 

--- a/tests/test_telegram_auth_provider.py
+++ b/tests/test_telegram_auth_provider.py
@@ -424,6 +424,54 @@ class TestCleanupExpired:
         assert "stale" not in provider._pending_otps
         mock_backend.disconnect.assert_called_once()
 
+    async def test_cleanup_expired_concurrently(
+        self, provider: TelegramAuthProvider
+    ) -> None:
+        """Cleanup should run disconnects in parallel."""
+        import asyncio
+        from unittest.mock import patch
+
+        N = 3
+        delay = 0.1
+        # Use a very large TTL so our manual created_at is definitely expired
+        from better_telegram_mcp.auth.telegram_auth_provider import _SESSION_TTL
+
+        with patch(
+            "better_telegram_mcp.auth.telegram_auth_provider.BotBackend"
+        ) as MockBot:
+            disconnects: list[AsyncMock] = []
+
+            def make_backend(*_args, **_kwargs):
+                inst = MockBot.return_value.__class__()
+                inst.connect = AsyncMock()
+
+                async def slow_disconnect() -> None:
+                    await asyncio.sleep(delay)
+
+                inst.disconnect = AsyncMock(side_effect=slow_disconnect)
+                disconnects.append(inst.disconnect)
+                return inst
+
+            MockBot.side_effect = make_backend
+            for i in range(N):
+                bearer = await provider.register_bot(f"b{i}", f"token{i}")
+                # Manually expire it in store
+                info = provider._store.load(bearer)
+                info.created_at = time.time() - _SESSION_TTL - 1
+                provider._store.store(bearer, info)
+                # Ensure it's NOT in active_clients yet (register_bot adds it)
+                # but we want to test revoke_session which handles active_clients.
+                # Actually, register_bot ALREADY added it to active_clients.
+
+        start = time.perf_counter()
+        removed = await provider.cleanup_expired()
+        elapsed = time.perf_counter() - start
+
+        assert removed == N
+        assert all(d.called for d in disconnects)
+        # If sequential, it would be N * delay. If concurrent, ~delay.
+        assert elapsed < N * delay * 0.8
+
 
 class TestShutdown:
     async def test_shutdown_disconnects_all(

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.6"
+version = "4.12.7b2"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
Refactored `cleanup_expired` in `TelegramAuthProvider` to use `asyncio.gather` for concurrent revocation of expired sessions and disconnection of stale OTP backends. This reduces total wait time for I/O operations from O(N) to O(1) RTTs.

- Revoke expired sessions concurrently with `return_exceptions=True`.
- Clean up stale pending OTP backends concurrently.
- Added `test_cleanup_expired_concurrently` to verify parallel execution.

---
*PR created automatically by Jules for task [10430482532936581853](https://jules.google.com/task/10430482532936581853) started by @n24q02m*