### PR TITLE
[FIX] Simplify complex function config in server.py

### DIFF
--- a/src/better_telegram_mcp/server.py
+++ b/src/better_telegram_mcp/server.py
@@ -432,107 +432,17 @@ async def config(
     - setup_reset: Clear saved credentials
     - setup_complete: Re-resolve credentials after relay config
     """
-    # Setup actions work regardless of configured state
-    match action:
-        case "setup_status":
-            from .credential_state import get_setup_url, get_state
+    backend = None
+    try:
+        backend = get_backend()
+    except RuntimeError:
+        pass
 
-            state = get_state()
-            return ok(
-                {
-                    "state": state.value,
-                    "setup_url": get_setup_url(),
-                    "configured": not _unconfigured,
-                    "pending_auth": _pending_auth,
-                    "env_keys": [
-                        k
-                        for k in {"TELEGRAM_BOT_TOKEN", "TELEGRAM_PHONE"}
-                        if os.environ.get(k)
-                    ],
-                }
-            )
-
-        case "setup_start":
-            from .credential_state import CredentialState, get_state
-
-            if get_state() == CredentialState.CONFIGURED and not (
-                key and key.lower() == "force"
-            ):
-                return ok(
-                    {
-                        "status": "already_configured",
-                        "message": "Already configured. Use key='force' to reconfigure.",
-                    }
-                )
-            # Per spec 2026-05-01-stdio-pure-http-multiuser.md: stdio mode does
-            # not spawn an in-process credential form. Browser-based setup is
-            # the responsibility of HTTP mode; this branch tells the user how
-            # to switch.
-            return ok(
-                {
-                    "status": "stdio_unsupported",
-                    "message": (
-                        "Browser-based setup is HTTP-mode only. "
-                        "For stdio mode, set TELEGRAM_BOT_TOKEN in your "
-                        "plugin/server config (get from @BotFather). "
-                        "For user-mode auth (phone+OTP), switch to HTTP mode "
-                        "(see https://mcp.n24q02m.com/servers/better-telegram-mcp/setup/)."
-                    ),
-                }
-            )
-
-        case "setup_reset":
-            from .credential_state import reset_state
-
-            reset_state()
-            return ok(
-                {
-                    "status": "ok",
-                    "message": "Credentials cleared. Use setup_start to reconfigure.",
-                }
-            )
-
-        case "setup_complete":
-            from .credential_state import (
-                CredentialState,
-                get_state,
-                resolve_credential_state,
-            )
-
-            resolve_credential_state()
-            state = get_state()
-            return ok(
-                {
-                    "status": "ok",
-                    "state": state.value,
-                    "message": "Credential state refreshed.",
-                }
-            )
-
-    if _unconfigured:
-        if action == "status":
-            return ok(
-                {
-                    "mode": None,
-                    "connected": False,
-                    "authorized": False,
-                    "configured": False,
-                    "config": _runtime_config,
-                    "setup": {
-                        "bot_mode": "Set TELEGRAM_BOT_TOKEN (get from @BotFather)",
-                        "user_mode": (
-                            "Set TELEGRAM_PHONE"
-                            " (API credentials have built-in defaults)"
-                        ),
-                    },
-                    "hint": "Use action='setup_start' to configure via browser relay.",
-                }
-            )
-        return _not_ready_response()
     return await handle_config(
-        get_backend(),
+        backend,
         action,
         message_limit=message_limit,
+        key=key,
         timeout=timeout,
     )
 

--- a/src/better_telegram_mcp/tools/config_tool.py
+++ b/src/better_telegram_mcp/tools/config_tool.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import os
 from collections.abc import Awaitable, Callable
 from typing import Any
 
@@ -5,8 +8,26 @@ from ..backends.base import TelegramBackend
 from ..utils.formatting import err, ok, safe_error
 
 
-async def _handle_status(backend: TelegramBackend, **kwargs: Any) -> str:
+async def _handle_status(backend: TelegramBackend | None, **kwargs: Any) -> str:
     from ..server import _pending_auth, _runtime_config
+
+    if backend is None:
+        return ok(
+            {
+                "mode": None,
+                "connected": False,
+                "authorized": False,
+                "configured": False,
+                "config": _runtime_config,
+                "setup": {
+                    "bot_mode": "Set TELEGRAM_BOT_TOKEN (get from @BotFather)",
+                    "user_mode": (
+                        "Set TELEGRAM_PHONE (API credentials have built-in defaults)"
+                    ),
+                },
+                "hint": "Use action='setup_start' to configure via browser relay.",
+            }
+        )
 
     connected = await backend.is_connected()
     authorized = await backend.is_authorized()
@@ -20,7 +41,7 @@ async def _handle_status(backend: TelegramBackend, **kwargs: Any) -> str:
     return ok(result)
 
 
-async def _handle_set(backend: TelegramBackend, **kwargs: Any) -> str:
+async def _handle_set(backend: TelegramBackend | None, **kwargs: Any) -> str:
     from ..server import _runtime_config
 
     updated: dict[str, int] = {}
@@ -33,24 +54,121 @@ async def _handle_set(backend: TelegramBackend, **kwargs: Any) -> str:
     return ok({"updated": updated, "current": _runtime_config})
 
 
-async def _handle_cache_clear(backend: TelegramBackend, **kwargs: Any) -> str:
+async def _handle_cache_clear(backend: TelegramBackend | None, **kwargs: Any) -> str:
+    if backend is None:
+        return err("Backend not initialized.")
     await backend.clear_cache()
     return ok({"message": "Cache cleared."})
+
+
+async def _handle_setup_status(backend: TelegramBackend | None, **kwargs: Any) -> str:
+    from ..credential_state import get_setup_url, get_state
+    from ..server import _pending_auth, _unconfigured
+
+    state = get_state()
+    return ok(
+        {
+            "state": state.value,
+            "setup_url": get_setup_url(),
+            "configured": not _unconfigured,
+            "pending_auth": _pending_auth,
+            "env_keys": [
+                k for k in {"TELEGRAM_BOT_TOKEN", "TELEGRAM_PHONE"} if os.environ.get(k)
+            ],
+        }
+    )
+
+
+async def _handle_setup_start(backend: TelegramBackend | None, **kwargs: Any) -> str:
+    from ..credential_state import CredentialState, get_state
+
+    key = kwargs.get("key")
+    if get_state() == CredentialState.CONFIGURED and not (
+        key and str(key).lower() == "force"
+    ):
+        return ok(
+            {
+                "status": "already_configured",
+                "message": "Already configured. Use key='force' to reconfigure.",
+            }
+        )
+    # Per spec 2026-05-01-stdio-pure-http-multiuser.md: stdio mode does
+    # not spawn an in-process credential form. Browser-based setup is
+    # the responsibility of HTTP mode; this branch tells the user how
+    # to switch.
+    return ok(
+        {
+            "status": "stdio_unsupported",
+            "message": (
+                "Browser-based setup is HTTP-mode only. "
+                "For stdio mode, set TELEGRAM_BOT_TOKEN in your "
+                "plugin/server config (get from @BotFather). "
+                "For user-mode auth (phone+OTP), switch to HTTP mode "
+                "(see https://mcp.n24q02m.com/servers/better-telegram-mcp/setup/)."
+            ),
+        }
+    )
+
+
+async def _handle_setup_reset(backend: TelegramBackend | None, **kwargs: Any) -> str:
+    from ..credential_state import reset_state
+
+    reset_state()
+    return ok(
+        {
+            "status": "ok",
+            "message": "Credentials cleared. Use setup_start to reconfigure.",
+        }
+    )
+
+
+async def _handle_setup_complete(backend: TelegramBackend | None, **kwargs: Any) -> str:
+    from ..credential_state import get_state, resolve_credential_state
+
+    resolve_credential_state()
+    state = get_state()
+    return ok(
+        {
+            "status": "ok",
+            "state": state.value,
+            "message": "Credential state refreshed.",
+        }
+    )
 
 
 _HANDLERS: dict[str, Callable[..., Awaitable[str]]] = {
     "status": _handle_status,
     "set": _handle_set,
     "cache_clear": _handle_cache_clear,
+    "setup_status": _handle_setup_status,
+    "setup_start": _handle_setup_start,
+    "setup_reset": _handle_setup_reset,
+    "setup_complete": _handle_setup_complete,
 }
 
 
 async def handle_config(
-    backend: TelegramBackend,
+    backend: TelegramBackend | None,
     action: str,
     **kwargs: Any,
 ) -> str:
+    from ..server import _not_ready_response, _unconfigured
+
     try:
+        # Setup actions work regardless of configured state
+        if action.startswith("setup_"):
+            handler = _HANDLERS.get(action)
+            if handler:
+                return await handler(backend=backend, **kwargs)
+
+        if _unconfigured:
+            if action == "status":
+                return await _handle_status(backend=None, **kwargs)
+            return _not_ready_response()
+
+        if backend is None:
+            return _not_ready_response()
+
         handler = _HANDLERS.get(action)
         if not handler:
             import difflib

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.6"
+version = "4.12.7b2"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
Refactored the config tool in src/better_telegram_mcp/server.py to reduce its complexity. 
The logic for setup-related actions (setup_status, setup_start, setup_reset, setup_complete) 
and the unconfigured status handling has been moved to src/better_telegram_mcp/tools/config_tool.py.
The config function in server.py now primarily delegates to handle_config, 
ensuring a cleaner separation of concerns and improved maintainability.

Key changes:
- Added setup handlers to config_tool.py.
- Updated _handle_status to support unconfigured state (backend is None).
- Simplified handle_config to manage setup actions and unconfigured guards.
- Refactored config in server.py to safely delegate to handle_config.

---
*PR created automatically by Jules for task [1669712296492815147](https://jules.google.com/task/1669712296492815147) started by @n24q02m*