### PR TITLE
[FIX] Hardcoded Telegram API ID and Hash

### DIFF
--- a/src/better_telegram_mcp/config.py
+++ b/src/better_telegram_mcp/config.py
@@ -23,9 +23,9 @@ class Settings(BaseSettings):
     # Bot mode
     bot_token: str | None = None
 
-    # User mode (app-level credentials with built-in defaults, like Google Drive client_id/secret)
-    api_id: int | None = 37984984
-    api_hash: str | None = "2f5f4c76c4de7c07302380c788390100"
+    # User mode (app-level credentials)
+    api_id: int | None = None
+    api_hash: str | None = None
     phone: str | None = None
     session_name: str = "default"
 
@@ -87,7 +87,6 @@ class Settings(BaseSettings):
 
         Args:
             config: Dict with keys like TELEGRAM_BOT_TOKEN, TELEGRAM_API_ID, etc.
-            API_ID and API_HASH use built-in defaults if not provided.
 
         Returns:
             A configured Settings instance.

--- a/src/better_telegram_mcp/transports/http.py
+++ b/src/better_telegram_mcp/transports/http.py
@@ -17,8 +17,8 @@ Two outcomes (both via mcp-core ``run_http_server``):
   OTP/2FA flow runs against ``/otp``, and the global single backend in
   ``server.py`` is hot-reloaded once credentials land.
 
-The ``api_id``/``api_hash`` pair has built-in defaults in ``config.py``
-(public Telegram app registration) so a deployed container only needs
+The ``api_id``/``api_hash`` pair must be provided via environment variables
+so a deployed container needs ``TELEGRAM_API_ID``, ``TELEGRAM_API_HASH``,
 ``MCP_DCR_SERVER_SECRET`` (legacy ``DCR_SERVER_SECRET`` still accepted) +
 ``PUBLIC_URL`` set to flip on multi-user.
 
@@ -85,10 +85,8 @@ def _is_multi_user_mode(settings: Settings | None = None) -> bool:
     Multi-user requires: ``MCP_DCR_SERVER_SECRET`` (OAuth shared secret;
     legacy ``DCR_SERVER_SECRET`` still accepted) + ``PUBLIC_URL`` (deployed
     hostname) + a Telegram ``api_id`` / ``api_hash`` pair. The
-    api_id/api_hash pair is satisfied either by the corresponding env vars
-    OR by the built-in Settings defaults (the code ships a public app
-    registration — see ``config.py``), so a deployed container only needs
-    to set the two "secret" variables to flip on multi-user mode.
+    api_id/api_hash pair must be provided via env vars (TELEGRAM_API_ID and
+    TELEGRAM_API_HASH).
     """
     has_dcr = bool(_dcr_secret())
     has_public_url = bool(os.environ.get("PUBLIC_URL"))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -54,19 +54,12 @@ def test_is_configured_user(monkeypatch):
 
 
 def test_api_id_api_hash_without_phone_not_configured(monkeypatch):
-    """api_id + api_hash without phone should NOT be configured (defaults exist)."""
+    """api_id + api_hash without phone should NOT be configured (now None by default)."""
     monkeypatch.setenv("TELEGRAM_API_ID", "12345")
     monkeypatch.setenv("TELEGRAM_API_HASH", "abcdef123456")
     s = Settings()
     assert s.is_configured is False
     assert s.mode == "bot"
-
-
-def test_default_api_credentials():
-    """api_id and api_hash have built-in defaults."""
-    s = Settings()
-    assert s.api_id == 37984984
-    assert s.api_hash == "2f5f4c76c4de7c07302380c788390100"
 
 
 def test_default_data_dir(monkeypatch):
@@ -185,5 +178,5 @@ def test_from_relay_config():
 
     # Defaults
     s2 = Settings.from_relay_config({})
-    assert s2.api_id == 37984984
-    assert s2.api_hash == "2f5f4c76c4de7c07302380c788390100"
+    assert s2.api_id is None
+    assert s2.api_hash is None

--- a/tests/test_relay_setup.py
+++ b/tests/test_relay_setup.py
@@ -83,8 +83,8 @@ def test_from_relay_config_missing_keys():
     config = {}
     s = Settings.from_relay_config(config)
     assert s.bot_token is None
-    assert s.api_id == 37984984  # built-in default
-    assert s.api_hash == "2f5f4c76c4de7c07302380c788390100"  # built-in default
+    assert s.api_id is None
+    assert s.api_hash is None
     assert s.is_configured is False  # no phone, no bot_token
 
 

--- a/tests/test_transports/test_http.py
+++ b/tests/test_transports/test_http.py
@@ -88,7 +88,9 @@ class TestIsMultiUserMode:
             "PUBLIC_URL": "https://mcp.example.com",
         }
         with patch.dict("os.environ", env, clear=True):
-            # settings has api_id/api_hash by default
+            # settings needs api_id/api_hash to be set for multi-user
+            settings.api_id = 123
+            settings.api_hash = "abc"
             assert _is_multi_user_mode(settings) is True
 
     def test_is_multi_user_mode_true_mcp_prefixed_secret(
@@ -101,6 +103,8 @@ class TestIsMultiUserMode:
             "PUBLIC_URL": "https://mcp.example.com",
         }
         with patch.dict("os.environ", env, clear=True):
+            settings.api_id = 123
+            settings.api_hash = "abc"
             assert _is_multi_user_mode(settings) is True
 
     def test_is_multi_user_mode_true_legacy_secret(self, settings: Settings) -> None:
@@ -111,6 +115,8 @@ class TestIsMultiUserMode:
             "PUBLIC_URL": "https://mcp.example.com",
         }
         with patch.dict("os.environ", env, clear=True):
+            settings.api_id = 123
+            settings.api_hash = "abc"
             assert _is_multi_user_mode(settings) is True
 
     def test_is_multi_user_mode_false_missing_dcr(self, settings: Settings) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.6"
+version = "4.12.7b2"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
This PR removes the hardcoded Telegram API ID and Hash from the configuration. These values are now required to be provided via environment variables (TELEGRAM_API_ID and TELEGRAM_API_HASH), improving security and flexibility.

Key changes:
- `api_id` and `api_hash` defaults in `Settings` are now `None`.
- `from_relay_config` and `_is_multi_user_mode` documentation updated to reflect that these credentials are no longer built-in.
- Test suite updated to remove assertions on specific default values and to ensure multi-user mode is tested with explicit credentials.
- All unit and integration tests (relevant to config) are passing.

---
*PR created automatically by Jules for task [17705192411536068478](https://jules.google.com/task/17705192411536068478) started by @n24q02m*