### PR TITLE
[PERF] Unnecessary string concatenation in loop for key preview

### DIFF
--- a/src/better_telegram_mcp/transports/http.py
+++ b/src/better_telegram_mcp/transports/http.py
@@ -29,6 +29,7 @@ is handled in ``server.main()`` and never reaches this module.
 
 import os
 from contextvars import ContextVar
+from itertools import islice
 from typing import Any
 
 from loguru import logger
@@ -224,13 +225,13 @@ async def _per_request_sub_scope(
         provider = get_global_provider()
         if provider is not None:
             backend = provider.resolve_backend(sub)
-            keys_preview = list(provider.active_clients.keys())
             keys_short = [
-                k[:12] + "..." if len(k) > 12 else k for k in keys_preview[:5]
+                f"{k[:12]}..." if len(k) > 12 else k
+                for k in islice(provider.active_clients.keys(), 5)
             ]
             logger.info(
                 "auth_scope: sub={} found_backend={} active_keys_count={} keys={}",
-                (sub or "")[:12] + "...",
+                f"{(sub or '')[:12]}...",
                 type(backend).__name__ if backend else "None",
                 len(provider.active_clients),
                 keys_short,

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.6"
+version = "4.12.7b2"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
This PR optimizes the `_per_request_sub_scope` middleware in `src/better_telegram_mcp/transports/http.py` to reduce unnecessary string allocations and list creations during logging.

Changes:
- Replaced `list(provider.active_clients.keys())` with `islice(provider.active_clients.keys(), 5)` to avoid creating a full list of all active clients when only the first 5 are needed for the preview.
- Replaced string concatenation (`+ "..."`) with f-strings for both the key previews and the `sub` preview in the log message.

These changes slightly improve performance by reducing memory pressure and CPU cycles spent on intermediate string/list objects in the hot path of the multi-user HTTP transport.

---
*PR created automatically by Jules for task [1253780300487343989](https://jules.google.com/task/1253780300487343989) started by @n24q02m*