### PR TITLE
🎨 Palette: Strip validation styling on input

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,7 @@
 ## 2024-07-28 - Contrast Requirements for Dark Themes
 **Learning:** Text using color `#666` fails WCAG AA 4.5:1 contrast requirements when placed against dark-themed backgrounds such as `#1a1a1a`.
 **Action:** When designing dark themes, ensure that subtle or secondary text elements (like `.server-id` and `.help-text`) are upgraded to at least `#888` or `#999` to maintain readability and accessibility standards.
+
+## 2024-08-01 - Strip validation styling on input
+**Learning:** Actively stripping validation styling (`aria-invalid`) and hiding inline error messages when the user types (via the `input` event) improves the user experience by preventing lingering error states while the user is correcting their input.
+**Action:** Always attach `input` event listeners to form fields to actively strip validation styling (`aria-invalid`) and hide inline error messages as soon as the user resumes typing.

--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -444,6 +444,16 @@ def render_telegram_credential_form(
             var submitUrl = "{submit_url_escaped}";
             var activeTab = "{initial_tab}";
 
+            // Remove validation styling on input
+            form.querySelectorAll(".field-input").forEach(function (input) {{
+                input.addEventListener("input", function () {{
+                    input.removeAttribute("aria-invalid");
+                    statusBox.style.display = "none";
+                    statusBox.textContent = "";
+                }});
+            }});
+
+
             // --- Tab switching -------------------------------------------------
             var tabs = document.querySelectorAll(".tab");
             var tabsArray = Array.prototype.slice.call(tabs);
@@ -604,6 +614,11 @@ def render_telegram_credential_form(
                             evt.preventDefault();
                             submitStep();
                         }}
+                    }});
+                    inputEl.addEventListener("input", function () {{
+                        inputEl.removeAttribute("aria-invalid");
+                        errorEl.style.display = "none";
+                        errorEl.textContent = "";
                     }});
                 }}
 

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.7b2"
+version = "4.12.7b3"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
💡 What: Added `input` event listeners to actively strip validation styling (`aria-invalid`) and hide error messages in the form inputs.
🎯 Why: Prevents users from being distracted by lingering error states while actively correcting their input.
♿ Accessibility: Ensures that screen readers don't retain an "invalid" state announcement while the user is fixing the field.

---
*PR created automatically by Jules for task [689543922320418116](https://jules.google.com/task/689543922320418116) started by @n24q02m*