### PR TITLE
fix: sync README tagline to current capability description

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 mcp-name: io.github.n24q02m/better-telegram-mcp
 
-**MCP server for Telegram with dual-mode support: Bot API (httpx) for quick bot integrations and MTProto (Telethon) for full user-account access.**
+**Telegram for AI agents -- messages, chats, media, and contacts across both bot and full user-account modes.**
 
 <!-- Badge Row 1: Status -->
 [![CI](https://github.com/n24q02m/better-telegram-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/n24q02m/better-telegram-mcp/actions/workflows/ci.yml)


### PR DESCRIPTION
Sync the README tagline to the cleaned-up, jargon-free repo description (drop dated/internal jargon and brittle tool counts; frame by capability).