### PR TITLE
🎨 Palette: Clear lingering error states on user input

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,7 @@
 ## 2024-07-28 - Contrast Requirements for Dark Themes
 **Learning:** Text using color `#666` fails WCAG AA 4.5:1 contrast requirements when placed against dark-themed backgrounds such as `#1a1a1a`.
 **Action:** When designing dark themes, ensure that subtle or secondary text elements (like `.server-id` and `.help-text`) are upgraded to at least `#888` or `#999` to maintain readability and accessibility standards.
+
+## 2024-11-20 - Clear Error States on Input
+**Learning:** In asynchronous forms or forms with client-side validation, error states (like visual `aria-invalid` styling or inline error messages) that linger even after the user begins typing to correct the issue create a frustrating experience. It forces the user to wonder if their new input is also invalid before they have even submitted it.
+**Action:** Always attach `input` event listeners to form fields to actively strip validation styling (`aria-invalid`) and hide inline error messages as soon as the user resumes typing, preventing lingering error states.

--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -448,6 +448,19 @@ def render_telegram_credential_form(
             var tabs = document.querySelectorAll(".tab");
             var tabsArray = Array.prototype.slice.call(tabs);
 
+            // Clear validation styling and inline error when the user resumes typing
+            form.querySelectorAll(".field-input").forEach(function (input) {{
+                input.addEventListener("input", function () {{
+                    if (input.hasAttribute("aria-invalid")) {{
+                        input.removeAttribute("aria-invalid");
+                    }}
+                    if (statusBox.className.indexOf("error") !== -1 && statusBox.style.display === "block") {{
+                        statusBox.style.display = "none";
+                        statusBox.textContent = "";
+                    }}
+                }});
+            }});
+
             tabs.forEach(function (tab, index) {{
                 tab.addEventListener("click", function () {{
                     if (tab.disabled) {{


### PR DESCRIPTION
### 💡 What
Added `input` event listeners to form input fields in `credential_form.py` to immediately remove validation styling (`aria-invalid`) and hide the inline global error message container (`statusBox`) as soon as the user resumes typing. 

### 🎯 Why
Lingering error states in client-side validated or asynchronous forms create a frustrating and confusing UX. By actively clearing error indicators when a user attempts to correct their input, we provide immediate positive feedback and reduce cognitive load. 

### ♿ Accessibility
This enhancement improves accessibility by ensuring that `aria-invalid="true"` attributes are not incorrectly maintained on fields that the user is actively amending.

Also added a corresponding learning entry to `.jules/palette.md`.

---
*PR created automatically by Jules for task [5560458805990146975](https://jules.google.com/task/5560458805990146975) started by @n24q02m*