### PR TITLE
[PERF] Sequential async calls in session cleanup loop

### DIFF
--- a/src/better_telegram_mcp/auth/telegram_auth_provider.py
+++ b/src/better_telegram_mcp/auth/telegram_auth_provider.py
@@ -355,10 +355,22 @@ class TelegramAuthProvider:
         removed = 0
         now = time.time()
 
-        for bearer, info in sessions.items():
-            if now - info.created_at > _SESSION_TTL:
-                await self.revoke_session(bearer)
-                removed += 1
+        to_revoke = [
+            bearer
+            for bearer, info in sessions.items()
+            if now - info.created_at > _SESSION_TTL
+        ]
+
+        if to_revoke:
+            results = await asyncio.gather(
+                *(self.revoke_session(b) for b in to_revoke),
+                return_exceptions=True,
+            )
+            for res in results:
+                if isinstance(res, Exception):
+                    logger.warning("Error revoking session during cleanup: {}", res)
+                elif res is True:
+                    removed += 1
 
         # Clean up stale pending OTPs (5 min TTL) using chronological insertion order.
         # Since start_user_auth pops-then-reinserts each bearer, the oldest entries

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.7b2"
+version = "4.12.7b3"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
Optimized the `cleanup_expired` method in `TelegramAuthProvider` to use `asyncio.gather` for concurrent session revocation. This reduces total wait time from O(N * RTT) to O(RTT) for N expired sessions.

Changes:
- Replaced sequential `await self.revoke_session(bearer)` loop with concurrent gather.
- Added `return_exceptions=True` and explicit result checking to ensure that a failure in one revocation doesn't abort the entire cleanup process.
- Verified improvement with performance tests (speedup confirmed and error robustness validated).
- Ensured 100% pass rate for existing auth provider tests.

---
*PR created automatically by Jules for task [10954670264739316932](https://jules.google.com/task/10954670264739316932) started by @n24q02m*