### PR TITLE
[TEST] Missing tests for formatting utilities

### DIFF
--- a/src/better_telegram_mcp/utils/formatting.py
+++ b/src/better_telegram_mcp/utils/formatting.py
@@ -1,12 +1,17 @@
+"""Formatting utilities for text and messages."""
+
 import json
+import re
 from typing import Any
 
 
 def ok(data: Any) -> str:
+    """Return a successful MCP tool response."""
     return json.dumps(data, ensure_ascii=False, default=str)
 
 
 def err(message: str) -> str:
+    """Return an error MCP tool response."""
     return json.dumps({"error": message}, ensure_ascii=False)
 
 
@@ -18,3 +23,68 @@ def safe_error(e: Exception) -> str:
     if isinstance(e, (ModeError, SecurityError, ValueError, FileNotFoundError)):
         return err(str(e))
     return err(f"{type(e).__name__}: Operation failed. Check server logs for details.")
+
+
+# --- Telegram Styling Helpers ---
+
+
+def escape_html(text: str) -> str:
+    """Escape text for use in HTML parse_mode."""
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def escape_markdown_v2(text: str, entity_type: str | None = None) -> str:
+    """
+    Escape text for use in MarkdownV2 parse_mode.
+
+    Args:
+        text: The text to escape.
+        entity_type: Special context like 'code', 'pre', 'link_text', or 'link_url'.
+    """
+    if entity_type in ("code", "pre"):
+        return re.sub(r"([`\\])", r"\\\1", text)
+    if entity_type == "link_text":
+        return re.sub(r"([\[\]\\])", r"\\\1", text)
+    if entity_type == "link_url":
+        return re.sub(r"([)\\])", r"\\\1", text)
+
+    return re.sub(r"([_*\[\]()~`>#+\-=|{}.!])", r"\\\1", text)
+
+
+def bold(text: str, mode: str | None = "HTML") -> str:
+    """Format text as bold."""
+    if mode == "MarkdownV2":
+        return f"*{escape_markdown_v2(text)}*"
+    return f"<b>{escape_html(text)}</b>"
+
+
+def italic(text: str, mode: str | None = "HTML") -> str:
+    """Format text as italic."""
+    if mode == "MarkdownV2":
+        return f"_{escape_markdown_v2(text)}_"
+    return f"<i>{escape_html(text)}</i>"
+
+
+def code(text: str, mode: str | None = "HTML") -> str:
+    """Format text as inline code."""
+    if mode == "MarkdownV2":
+        return f"`{escape_markdown_v2(text, entity_type='code')}`"
+    return f"<code>{escape_html(text)}</code>"
+
+
+def pre(text: str, mode: str | None = "HTML", language: str | None = None) -> str:
+    """Format text as a code block."""
+    if mode == "MarkdownV2":
+        lang = escape_markdown_v2(language) if language else ""
+        return f"```{lang}\n{escape_markdown_v2(text, entity_type='pre')}\n```"
+    lang_attr = f' class="language-{language}"' if language else ""
+    return f"<pre{lang_attr}>{escape_html(text)}</pre>"
+
+
+def link(text: str, url: str, mode: str | None = "HTML") -> str:
+    """Format an inline link."""
+    if mode == "MarkdownV2":
+        e_text = escape_markdown_v2(text, entity_type="link_text")
+        e_url = escape_markdown_v2(url, entity_type="link_url")
+        return f"[{e_text}]({e_url})"
+    return f'<a href="{escape_html(url)}">{escape_html(text)}</a>'

--- a/tests/test_utils/test_formatting.py
+++ b/tests/test_utils/test_formatting.py
@@ -3,7 +3,18 @@ from datetime import datetime
 
 from better_telegram_mcp.backends.base import ModeError
 from better_telegram_mcp.backends.security import SecurityError
-from better_telegram_mcp.utils.formatting import err, ok, safe_error
+from better_telegram_mcp.utils.formatting import (
+    bold,
+    code,
+    err,
+    escape_html,
+    escape_markdown_v2,
+    italic,
+    link,
+    ok,
+    pre,
+    safe_error,
+)
 
 
 def test_ok_basic_serialization():
@@ -191,3 +202,100 @@ def test_ok_nested_mixed_types():
     assert parsed["nested"]["exc"] == "nested error"
     assert parsed["list"][0] == 1
     assert parsed["list"][1]["a"] == 1
+
+
+# --- New styling tests ---
+
+
+def test_escape_html():
+    assert escape_html("Hello <world> & friends") == "Hello &lt;world&gt; &amp; friends"
+    assert escape_html("") == ""
+
+
+def test_escape_markdown_v2_basic():
+    # General escape
+    text = "_*[]()~`>#+-=|{}.!"
+    escaped = escape_markdown_v2(text)
+    assert (
+        escaped
+        == r"\_"
+        + r"\*"
+        + r"\["
+        + r"\]"
+        + r"\("
+        + r"\)"
+        + r"\~"
+        + r"\`"
+        + r"\>"
+        + r"\#"
+        + r"\+"
+        + r"\-"
+        + r"\="
+        + r"\|"
+        + r"\{"
+        + r"\}"
+        + r"\."
+        + r"\!"
+    )
+
+
+def test_escape_markdown_v2_code():
+    assert (
+        escape_markdown_v2("code ` with \\ slash", "code") == r"code \` with \\ slash"
+    )
+    assert escape_markdown_v2("pre ` with \\ slash", "pre") == r"pre \` with \\ slash"
+
+
+def test_escape_markdown_v2_links():
+    assert (
+        escape_markdown_v2("link ] with \\ slash", "link_text")
+        == r"link \] with \\ slash"
+    )
+    assert (
+        escape_markdown_v2("url ) with \\ slash", "link_url") == r"url \) with \\ slash"
+    )
+
+
+def test_bold():
+    assert bold("hello") == "<b>hello</b>"
+    assert bold("hello", mode="HTML") == "<b>hello</b>"
+    assert bold("hello", mode="MarkdownV2") == "*hello*"
+    assert bold("<tag>", mode="HTML") == "<b>&lt;tag&gt;</b>"
+    assert bold("_tag_", mode="MarkdownV2") == r"*\_tag\_*"
+
+
+def test_italic():
+    assert italic("hello") == "<i>hello</i>"
+    assert italic("hello", mode="HTML") == "<i>hello</i>"
+    assert italic("hello", mode="MarkdownV2") == "_hello_"
+    assert italic("<tag>", mode="HTML") == "<i>&lt;tag&gt;</i>"
+    assert italic("*tag*", mode="MarkdownV2") == r"_\*tag\*_"
+
+
+def test_code():
+    assert code("hello") == "<code>hello</code>"
+    assert code("hello", mode="HTML") == "<code>hello</code>"
+    assert code("hello", mode="MarkdownV2") == r"`hello`"
+    assert code("<tag>", mode="HTML") == "<code>&lt;tag&gt;</code>"
+    assert code("`tag`", mode="MarkdownV2") == r"`\`tag\``"
+
+
+def test_pre():
+    assert pre("hello") == "<pre>hello</pre>"
+    assert pre("hello", mode="HTML") == "<pre>hello</pre>"
+    assert (
+        pre("hello", mode="HTML", language="python")
+        == '<pre class="language-python">hello</pre>'
+    )
+    assert pre("hello", mode="MarkdownV2") == "```\nhello\n```"
+    assert pre("hello", mode="MarkdownV2", language="python") == "```python\nhello\n```"
+    assert pre("<tag>", mode="HTML") == "<pre>&lt;tag&gt;</pre>"
+    assert pre("```", mode="MarkdownV2") == "```\n\\`\\`\\`\n```"
+
+
+def test_link():
+    assert link("text", "url") == '<a href="url">text</a>'
+    assert link("text", "url", mode="HTML") == '<a href="url">text</a>'
+    assert link("text", "url", mode="MarkdownV2") == "[text](url)"
+    assert link("<t>", "&u", mode="HTML") == '<a href="&amp;u">&lt;t&gt;</a>'
+    assert link("[t]", "u)", mode="MarkdownV2") == r"[\[t\]](u\))"

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.7b2"
+version = "4.12.7b3"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
This PR implements missing Telegram-specific formatting utilities and provides comprehensive test coverage.

### Changes:
- **`src/better_telegram_mcp/utils/formatting.py`**: Added `escape_html`, `escape_markdown_v2`, `bold`, `italic`, `code`, `pre`, and `link` helpers.
- **`tests/test_utils/test_formatting.py`**: Added detailed tests for all new utilities, including context-aware MarkdownV2 escaping and HTML entity handling.

### Verification:
- `uv run pytest tests/test_utils/test_formatting.py` passes with 100% coverage.
- `uv run ruff check .` and `uv run ruff format .` passed.
- `uv run ty check` passed.
- Standard tool tests pass.

---
*PR created automatically by Jules for task [17069228334990944043](https://jules.google.com/task/17069228334990944043) started by @n24q02m*