### PR TITLE
[FIX] Remove lingering references to deprecated per_user_session_store.py

### DIFF
--- a/src/better_telegram_mcp/auth/in_memory_session_store.py
+++ b/src/better_telegram_mcp/auth/in_memory_session_store.py
@@ -1,9 +1,8 @@
 """In-memory per-user session store (TC-NearZK).
 
-Replaces deprecated per_user_session_store.py (disk-encrypted AES-GCM +
-PBKDF2) for HTTP multi-user mode. Aligns with Notion's in-memory
-pattern: server has access during request lifetime; restart clears all
-sessions, users re-auth via OTP/2FA flow.
+Used for HTTP multi-user mode. Aligns with Notion's in-memory pattern:
+server has access during request lifetime; restart clears all sessions,
+users re-auth via OTP/2FA flow.
 
 Trust model: server admin (n24q02m operator) can dump live memory via
 debugger but no persistent file = no FS-dump compromise.
@@ -43,7 +42,6 @@ class SessionInfo:
 class InMemorySessionStore:
     """Per-user MTProto session store with no disk persistence.
 
-    Drop-in replacement for PerUserSessionStore (same public API).
     Constructor takes no arguments — no data_dir or secret needed.
     """
 

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.7b2"
+version = "4.12.7b3"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
The file per_user_session_store.py was already removed, but docstrings in in_memory_session_store.py still referred to it. This cleanup removes those stale references.

---
*PR created automatically by Jules for task [8069541239462584668](https://jules.google.com/task/8069541239462584668) started by @n24q02m*