### PR TITLE
[FIX] Hardcoded Telegram API ID and Hash

### DIFF
--- a/src/better_telegram_mcp/config.py
+++ b/src/better_telegram_mcp/config.py
@@ -23,9 +23,9 @@ class Settings(BaseSettings):
     # Bot mode
     bot_token: str | None = None
 
-    # User mode (app-level credentials with built-in defaults, like Google Drive client_id/secret)
-    api_id: int | None = 37984984
-    api_hash: str | None = "2f5f4c76c4de7c07302380c788390100"
+    # User mode (app-level credentials)
+    api_id: int | None = None
+    api_hash: str | None = None
     phone: str | None = None
     session_name: str = "default"
 
@@ -58,7 +58,7 @@ class Settings(BaseSettings):
         self.phone = _empty_to_none(self.phone)
 
         has_bot = self.bot_token is not None
-        # User mode requires phone (api_id/api_hash have built-in defaults)
+        # User mode requires phone, api_id and api_hash
         has_user = (
             self.api_id is not None
             and self.api_hash is not None
@@ -87,7 +87,6 @@ class Settings(BaseSettings):
 
         Args:
             config: Dict with keys like TELEGRAM_BOT_TOKEN, TELEGRAM_API_ID, etc.
-            API_ID and API_HASH use built-in defaults if not provided.
 
         Returns:
             A configured Settings instance.
@@ -96,7 +95,7 @@ class Settings(BaseSettings):
             "bot_token": config.get("TELEGRAM_BOT_TOKEN"),
             "phone": config.get("TELEGRAM_PHONE"),
         }
-        # Only override defaults if relay explicitly provides values
+        # Set values if relay explicitly provides them
         if config.get("TELEGRAM_API_ID"):
             kwargs["api_id"] = int(config["TELEGRAM_API_ID"])
         if config.get("TELEGRAM_API_HASH"):

--- a/src/better_telegram_mcp/credential_state.py
+++ b/src/better_telegram_mcp/credential_state.py
@@ -135,9 +135,7 @@ def resolve_credential_state() -> CredentialState:
 
     if check_saved_sessions():
         logger.info(
-            "Found saved Telethon session files. "
-            "Set TELEGRAM_PHONE to reuse them "
-            "(API credentials have built-in defaults)."
+            "Found saved Telethon session files. Set TELEGRAM_PHONE to reuse them "
         )
         _state = CredentialState.AWAITING_SETUP
         return _state

--- a/src/better_telegram_mcp/relay_setup.py
+++ b/src/better_telegram_mcp/relay_setup.py
@@ -104,7 +104,7 @@ def check_saved_sessions() -> bool:
 def _is_user_mode_config(config: dict[str, str]) -> bool:
     """Check if config has user-mode credentials (phone number).
 
-    API ID and API Hash have built-in defaults in config.py, so only phone
+    Only phone
     is needed from relay to identify user mode.
     """
     return bool(config.get("TELEGRAM_PHONE"))

--- a/src/better_telegram_mcp/server.py
+++ b/src/better_telegram_mcp/server.py
@@ -75,7 +75,7 @@ def _not_ready_response() -> str:
                     },
                     "user_mode": {
                         "env_vars": ["TELEGRAM_PHONE"],
-                        "how": "Set your phone number (API credentials have built-in defaults)",
+                        "how": "Set your phone number",
                     },
                 },
             }
@@ -520,10 +520,7 @@ async def config(
                     "config": _runtime_config,
                     "setup": {
                         "bot_mode": "Set TELEGRAM_BOT_TOKEN (get from @BotFather)",
-                        "user_mode": (
-                            "Set TELEGRAM_PHONE"
-                            " (API credentials have built-in defaults)"
-                        ),
+                        "user_mode": ("Set TELEGRAM_PHONE"),
                     },
                     "hint": "Use action='setup_start' to configure via browser relay.",
                 }

--- a/src/better_telegram_mcp/transports/http.py
+++ b/src/better_telegram_mcp/transports/http.py
@@ -17,10 +17,10 @@ Two outcomes (both via mcp-core ``run_http_server``):
   OTP/2FA flow runs against ``/otp``, and the global single backend in
   ``server.py`` is hot-reloaded once credentials land.
 
-The ``api_id``/``api_hash`` pair has built-in defaults in ``config.py``
-(public Telegram app registration) so a deployed container only needs
-``MCP_DCR_SERVER_SECRET`` (legacy ``DCR_SERVER_SECRET`` still accepted) +
-``PUBLIC_URL`` set to flip on multi-user.
+The ``api_id``/``api_hash`` pair must be provided via env vars
+(``TELEGRAM_API_ID`` and ``TELEGRAM_API_HASH``) for a deployed container
+to flip on multi-user mode alongside ``MCP_DCR_SERVER_SECRET`` and
+``PUBLIC_URL``.
 
 Per spec ``2026-05-01-stdio-pure-http-multiuser.md``: there is no
 ``MCP_MODE`` env var, no remote-relay client, no daemon-bridge. Stdio mode
@@ -85,9 +85,7 @@ def _is_multi_user_mode(settings: Settings | None = None) -> bool:
     Multi-user requires: ``MCP_DCR_SERVER_SECRET`` (OAuth shared secret;
     legacy ``DCR_SERVER_SECRET`` still accepted) + ``PUBLIC_URL`` (deployed
     hostname) + a Telegram ``api_id`` / ``api_hash`` pair. The
-    api_id/api_hash pair is satisfied either by the corresponding env vars
-    OR by the built-in Settings defaults (the code ships a public app
-    registration — see ``config.py``), so a deployed container only needs
+    is provided (via ``TELEGRAM_API_ID`` + ``TELEGRAM_API_HASH``), AND
     to set the two "secret" variables to flip on multi-user mode.
     """
     has_dcr = bool(_dcr_secret())
@@ -104,12 +102,7 @@ def start_http(settings: Settings) -> None:
     Three outcomes:
     - Full multi-user OAuth 2.1 when ``MCP_DCR_SERVER_SECRET`` (legacy
       ``DCR_SERVER_SECRET`` still accepted) + ``PUBLIC_URL``
-      are set and a ``api_id``/``api_hash`` pair is available (via env var
-      or the built-in Settings defaults). Per-JWT-sub Telethon clients,
-      isolated credentials, the intended public-deploy mode.
-    - Single-user relay fallback when ``PUBLIC_URL`` is absent — that's
-      self-host / localhost ``uvx`` usage and a single shared config is
-      correct there.
+      are set and a ``api_id``/``api_hash`` pair is available (via env vars). Per-JWT-sub Telethon clients,
     - ``RuntimeError`` when ``PUBLIC_URL`` is set but
       ``MCP_DCR_SERVER_SECRET`` / ``DCR_SERVER_SECRET``
       or the api_id/api_hash pair is missing. Without all three, the

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -54,19 +54,12 @@ def test_is_configured_user(monkeypatch):
 
 
 def test_api_id_api_hash_without_phone_not_configured(monkeypatch):
-    """api_id + api_hash without phone should NOT be configured (defaults exist)."""
+    """api_id + api_hash without phone should NOT be configured."""
     monkeypatch.setenv("TELEGRAM_API_ID", "12345")
     monkeypatch.setenv("TELEGRAM_API_HASH", "abcdef123456")
     s = Settings()
     assert s.is_configured is False
     assert s.mode == "bot"
-
-
-def test_default_api_credentials():
-    """api_id and api_hash have built-in defaults."""
-    s = Settings()
-    assert s.api_id == 37984984
-    assert s.api_hash == "2f5f4c76c4de7c07302380c788390100"
 
 
 def test_default_data_dir(monkeypatch):
@@ -185,5 +178,5 @@ def test_from_relay_config():
 
     # Defaults
     s2 = Settings.from_relay_config({})
-    assert s2.api_id == 37984984
-    assert s2.api_hash == "2f5f4c76c4de7c07302380c788390100"
+    assert s2.api_id is None
+    assert s2.api_hash is None

--- a/tests/test_relay_setup.py
+++ b/tests/test_relay_setup.py
@@ -79,12 +79,12 @@ def test_from_relay_config_empty_values():
 
 
 def test_from_relay_config_missing_keys():
-    """Missing keys should use built-in defaults for api_id/api_hash."""
+    """Missing keys should have None for api_id/api_hash."""
     config = {}
     s = Settings.from_relay_config(config)
     assert s.bot_token is None
-    assert s.api_id == 37984984  # built-in default
-    assert s.api_hash == "2f5f4c76c4de7c07302380c788390100"  # built-in default
+    assert s.api_id is None
+    assert s.api_hash is None
     assert s.is_configured is False  # no phone, no bot_token
 
 

--- a/tests/test_transports/test_http.py
+++ b/tests/test_transports/test_http.py
@@ -88,7 +88,9 @@ class TestIsMultiUserMode:
             "PUBLIC_URL": "https://mcp.example.com",
         }
         with patch.dict("os.environ", env, clear=True):
-            # settings has api_id/api_hash by default
+            # settings must have api_id/api_hash
+            settings.api_id = 12345
+            settings.api_hash = "hash"
             assert _is_multi_user_mode(settings) is True
 
     def test_is_multi_user_mode_true_mcp_prefixed_secret(
@@ -101,6 +103,8 @@ class TestIsMultiUserMode:
             "PUBLIC_URL": "https://mcp.example.com",
         }
         with patch.dict("os.environ", env, clear=True):
+            settings.api_id = 12345
+            settings.api_hash = "hash"
             assert _is_multi_user_mode(settings) is True
 
     def test_is_multi_user_mode_true_legacy_secret(self, settings: Settings) -> None:
@@ -111,6 +115,8 @@ class TestIsMultiUserMode:
             "PUBLIC_URL": "https://mcp.example.com",
         }
         with patch.dict("os.environ", env, clear=True):
+            settings.api_id = 12345
+            settings.api_hash = "hash"
             assert _is_multi_user_mode(settings) is True
 
     def test_is_multi_user_mode_false_missing_dcr(self, settings: Settings) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.7b2"
+version = "4.12.7b3"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
Removed hardcoded Telegram API ID and Hash from the configuration and updated all related tests and documentation. These credentials must now be provided via environment variables (TELEGRAM_API_ID and TELEGRAM_API_HASH). Updated tests to provide explicit credentials where needed.

---
*PR created automatically by Jules for task [17613476336077052637](https://jules.google.com/task/17613476336077052637) started by @n24q02m*