### PR TITLE
🎨 Palette: [UX improvement] Clear form validation automatically upon input

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,7 @@
 ## 2024-07-28 - Contrast Requirements for Dark Themes
 **Learning:** Text using color `#666` fails WCAG AA 4.5:1 contrast requirements when placed against dark-themed backgrounds such as `#1a1a1a`.
 **Action:** When designing dark themes, ensure that subtle or secondary text elements (like `.server-id` and `.help-text`) are upgraded to at least `#888` or `#999` to maintain readability and accessibility standards.
+
+## 2024-08-01 - Active Validation Feedback via Event Listeners
+**Learning:** Providing active feedback to users when correcting form validation errors improves form usability. Lingering validation error styles and messages after a user begins to correct an entry are confusing and reduce confidence.
+**Action:** Always attach `input` event listeners to conditionally styled form fields to dynamically remove invalid states (`aria-invalid`) and hide associated error messages exactly when the user begins to correct the input.

--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -444,6 +444,17 @@ def render_telegram_credential_form(
             var submitUrl = "{submit_url_escaped}";
             var activeTab = "{initial_tab}";
 
+            // Clear validation styling when user resumes typing
+            form.querySelectorAll(".field-input").forEach(function(input) {{
+                input.addEventListener("input", function() {{
+                    if (input.getAttribute("aria-invalid") === "true") {{
+                        input.removeAttribute("aria-invalid");
+                        statusBox.style.display = "none";
+                        statusBox.textContent = "";
+                    }}
+                }});
+            }});
+
             // --- Tab switching -------------------------------------------------
             var tabs = document.querySelectorAll(".tab");
             var tabsArray = Array.prototype.slice.call(tabs);
@@ -603,6 +614,13 @@ def render_telegram_credential_form(
                         if (evt.key === "Enter") {{
                             evt.preventDefault();
                             submitStep();
+                        }}
+                    }});
+                    inputEl.addEventListener("input", function () {{
+                        if (inputEl.getAttribute("aria-invalid") === "true") {{
+                            inputEl.removeAttribute("aria-invalid");
+                            errorEl.style.display = "none";
+                            errorEl.textContent = "";
                         }}
                     }});
                 }}

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.7b2"
+version = "4.12.7b3"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
As per the `Palette` persona instructions, this PR implements a single, <50 line micro-UX improvement to the user interface by clearing lingering form validation messages and `aria-invalid` attributes exactly when the user begins to correct an entry.

Changes:
- Added Javascript event listeners triggered by `input` events on all input fields.
- Verified keyboard accessibility/screen reader fallback (removes `aria-invalid` state correctly).
- Documented learning to `.jules/palette.md` journal.

---
*PR created automatically by Jules for task [10632014214744762867](https://jules.google.com/task/10632014214744762867) started by @n24q02m*