### PR TITLE
🎨 Palette: Clear inline error state on user input

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,6 @@
 ## 2024-07-28 - Contrast Requirements for Dark Themes
 **Learning:** Text using color `#666` fails WCAG AA 4.5:1 contrast requirements when placed against dark-themed backgrounds such as `#1a1a1a`.
 **Action:** When designing dark themes, ensure that subtle or secondary text elements (like `.server-id` and `.help-text`) are upgraded to at least `#888` or `#999` to maintain readability and accessibility standards.
+## 2024-06-15 - Clear Inline Error State on Input
+**Learning:** Lingering error states and messages after a user has resumed typing can cause confusion and a feeling of 'being stuck', especially in multi-step auth flows like OTP verification.
+**Action:** Always attach an `input` event listener to form fields to actively strip validation styling (`aria-invalid`) and hide inline error messages as soon as the user starts typing, providing immediate positive feedback.

--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -444,6 +444,14 @@ def render_telegram_credential_form(
             var submitUrl = "{submit_url_escaped}";
             var activeTab = "{initial_tab}";
 
+            // Clear validation styling when user resumes typing
+            form.querySelectorAll(".field-input").forEach(function (input) {{
+                input.addEventListener("input", function () {{
+                    input.removeAttribute("aria-invalid");
+                    statusBox.style.display = "none";
+                }});
+            }});
+
             // --- Tab switching -------------------------------------------------
             var tabs = document.querySelectorAll(".tab");
             var tabsArray = Array.prototype.slice.call(tabs);
@@ -604,6 +612,10 @@ def render_telegram_credential_form(
                             evt.preventDefault();
                             submitStep();
                         }}
+                    }});
+                    inputEl.addEventListener("input", function () {{
+                        inputEl.removeAttribute("aria-invalid");
+                        errorEl.style.display = "none";
                     }});
                 }}
 


### PR DESCRIPTION
💡 What: Added an `input` event listener to all `.field-input` and dynamic `step-input` elements in `credential_form.py` to remove the `aria-invalid` attribute and hide error elements immediately when the user resumes typing.
🎯 Why: Lingering error states and messages after a user begins correcting a field can cause confusion and a feeling of "being stuck", especially in the multi-step auth flows like OTP verification. This UX enhancement provides immediate positive feedback.
📸 Before/After: Verified visually via Playwright that error styling is immediately cleared.
♿ Accessibility: The explicit `aria-invalid` attribute is removed as soon as the user starts modifying the input, improving accuracy of screen reader feedback.

---
*PR created automatically by Jules for task [4978116521659975590](https://jules.google.com/task/4978116521659975590) started by @n24q02m*