### PR TITLE
fix: correct stdio credential storage path and dead auth env var in docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,9 +62,12 @@ Session persist: `~/.better-telegram-mcp/<name>.session`, permission 600.
 - `TELEGRAM_BOT_TOKEN` -- bot mode
 - `TELEGRAM_API_ID` + `TELEGRAM_API_HASH` -- user mode (built-in defaults, override optional)
 - `TELEGRAM_PHONE` -- phone (required for auth web UI)
-- `TELEGRAM_AUTH_URL` -- `local` | remote URL (default: remote)
 - `TELEGRAM_SESSION_NAME`, `TELEGRAM_DATA_DIR` -- optional
+- `MCP_TRANSPORT` / `TRANSPORT_MODE` -- set to `http` to opt into HTTP mode (default wire transport is stdio); `--http` CLI flag does the same
+- `PUBLIC_URL` -- deployed hostname; presence flips on the multi-user OAuth branch (with the DCR secret + api_id/api_hash)
 - `MCP_DCR_SERVER_SECRET` -- multi-user remote OAuth shared secret (with `PUBLIC_URL`); legacy `DCR_SERVER_SECRET` still accepted
+
+`TELEGRAM_AUTH_URL` exists on `Settings` but is currently unused -- the in-process `local` auth server and the remote-relay client were removed; HTTP setup is served by mcp-core's OAuth AS off `PUBLIC_URL`.
 
 NO `TELEGRAM_PASSWORD` -- 2FA nhap qua web UI, KHONG luu env.
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ This plugin implements **TC-NearZK** (in-memory, ephemeral). See [mcp-core trust
 |---|---|---|---|
 | HTTP n24q02m-hosted (default) | In-memory `dict[sub] = MTProtoSession` | In-process only | Server process (cleared on restart) |
 | HTTP self-host | Same as hosted | Same | Only you (admin = user) |
-| stdio proxy | `~/.better-telegram-mcp/config.json` | AES-GCM, machine-bound key | Only your OS user (file perm 0600) |
+| stdio | `~/.config/mcp/config.enc` (credentials) + `~/.better-telegram-mcp/<name>.session` (Telethon session) | AES-GCM, machine-bound key | Only your OS user (file perm 0600) |
 
 ## License
 


### PR DESCRIPTION
Two documentation corrections, each verified against the current code and the running deployment.

## Trust Model: stdio storage path (README.md)

The Trust Model table listed the stdio-mode credential store as `~/.better-telegram-mcp/config.json`. That path/filename is wrong:

- Single-user credentials are persisted through mcp-core's `config_file.write_config`, which writes to `~/.config/mcp/config.enc` (machine-bound AES-GCM).
- `~/.better-telegram-mcp/` only holds the Telethon `<name>.session` file.

Updated the row to list both locations accurately and renamed the column from "stdio proxy" to "stdio" (there is no proxy/bridge layer in stdio mode).

## Dead `TELEGRAM_AUTH_URL` env var (CLAUDE.md)

CLAUDE.md documented `TELEGRAM_AUTH_URL` (`local` | remote URL) as an active env var. The setting still exists on `Settings` but is no longer read anywhere — the in-process `local` auth server and the remote-relay client were removed; HTTP setup is served by mcp-core's OAuth AS keyed off `PUBLIC_URL`. Replaced that line with the env vars the code actually consumes (`MCP_TRANSPORT` / `TRANSPORT_MODE`, `PUBLIC_URL`) and added a note that `TELEGRAM_AUTH_URL` is currently unused.

No code changes.