### PR TITLE
fix: remove dead CredentialStore methods and unused auth_url setting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ Session persist: `~/.better-telegram-mcp/<name>.session`, permission 600.
 - `PUBLIC_URL` -- deployed hostname; presence flips on the multi-user OAuth branch (with the DCR secret + api_id/api_hash)
 - `MCP_DCR_SERVER_SECRET` -- multi-user remote OAuth shared secret (with `PUBLIC_URL`); legacy `DCR_SERVER_SECRET` still accepted
 
-`TELEGRAM_AUTH_URL` exists on `Settings` but is currently unused -- the in-process `local` auth server and the remote-relay client were removed; HTTP setup is served by mcp-core's OAuth AS off `PUBLIC_URL`.
+No `TELEGRAM_AUTH_URL` -- the in-process `local` auth server and the remote-relay client were removed; HTTP setup is served by mcp-core's OAuth AS off `PUBLIC_URL`.
 
 NO `TELEGRAM_PASSWORD` -- 2FA nhap qua web UI, KHONG luu env.
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -16,13 +16,6 @@ When using the remote auth relay at `better-telegram-mcp.n24q02m.com`:
 - **Sessions expire** after 10 minutes. The relay is stateless — no database, no disk storage.
 - **Logging**: Only anonymous request metadata (timestamps, status codes) is logged. No message content, contacts, or credentials are logged.
 
-## Local Mode (`TELEGRAM_AUTH_URL=local`)
-
-When running with local auth:
-
-- All data stays on your machine.
-- The auth web server runs on `127.0.0.1` (localhost only) and shuts down after the MCP server stops.
-
 ## Session Files
 
 - Telegram session files are stored locally at `~/.better-telegram-mcp/` with `600` permissions (owner-only).

--- a/src/better_telegram_mcp/config.py
+++ b/src/better_telegram_mcp/config.py
@@ -29,9 +29,6 @@ class Settings(BaseSettings):
     phone: str | None = None
     session_name: str = "default"
 
-    # Auth
-    auth_url: str = "https://better-telegram-mcp.n24q02m.com"
-
     # Data
     data_dir: Path = Path.home() / ".better-telegram-mcp"
 

--- a/src/better_telegram_mcp/transports/credential_store.py
+++ b/src/better_telegram_mcp/transports/credential_store.py
@@ -1,22 +1,12 @@
-"""Encrypted credential storage for HTTP mode.
+"""Master-secret resolution for HTTP mode.
 
-Credentials stored at: DATA_DIR/credentials.enc
-Key derived from server secret (CREDENTIAL_SECRET env var or auto-generated).
+The persistent server secret (CREDENTIAL_SECRET env var or auto-generated)
+is stored at: DATA_DIR/.secret with 0o600 permissions.
 """
 
-import copy
-import json
 import os
 import stat
 from pathlib import Path
-
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.ciphers.aead import AESGCM
-from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
-
-_LEGACY_SALT = b"mcp-telegram-creds"
-_KDF_ITERATIONS = 600_000
-_NONCE_SIZE = 12
 
 # POSIX: 0o600 (owner-only RW). Used by atomic_write_bytes_0600 so we never
 # leave a window where the file exists with broader permissions.
@@ -71,37 +61,11 @@ def _atomic_write_bytes_0600(path: Path, data: bytes) -> None:
 
 
 class CredentialStore:
-    """Server-side encrypted credential storage.
+    """Master-secret resolution for HTTP transport mode.
 
-    Used in HTTP transport mode to persist Telegram credentials
-    received via the relay page.
+    Resolves (or generates and persists) the per-install server secret.
+    The secret is persisted to ``DATA_DIR/.secret`` with 0o600 permissions.
     """
-
-    def __init__(self, data_dir: Path, secret: str | None = None) -> None:
-        self._path = data_dir / "credentials.enc"
-        self._salt_path = data_dir / ".salt"
-        self._secret = secret or os.environ.get("CREDENTIAL_SECRET", "")
-        if not self._secret:
-            self._secret = self._resolve_or_generate_secret(data_dir)
-        self._salt = self._resolve_salt()
-        # Cache derived key to avoid repeated 100k iteration PBKDF2 (~60ms) overhead
-        self._cached_key: bytes | None = None
-        self._cached_credentials: dict[str, str] | None = None
-
-    def _resolve_salt(self) -> bytes:
-        """Load persisted salt, fallback to legacy, or generate new one."""
-        if self._salt_path.exists():
-            return self._salt_path.read_bytes()
-
-        # Backward compatibility: existing credentials use legacy hardcoded salt
-        if self._path.exists():
-            return _LEGACY_SALT
-
-        # New installation: generate random salt and persist atomically
-        # with 0o600 (no open->chmod TOCTOU window).
-        salt = os.urandom(16)
-        _atomic_write_bytes_0600(self._salt_path, salt)
-        return salt
 
     @staticmethod
     def _resolve_or_generate_secret(data_dir: Path) -> str:
@@ -112,57 +76,3 @@ class CredentialStore:
         secret = os.urandom(32).hex()
         _atomic_write_bytes_0600(secret_path, secret.encode())
         return secret
-
-    def _derive_key(self) -> bytes:
-        if self._cached_key is not None:
-            return self._cached_key
-        kdf = PBKDF2HMAC(
-            algorithm=hashes.SHA256(),
-            length=32,
-            salt=self._salt,
-            iterations=_KDF_ITERATIONS,
-        )
-        self._cached_key = kdf.derive(self._secret.encode())
-        return self._cached_key
-
-    def store(self, credentials: dict[str, str]) -> None:
-        """Encrypt and save credentials atomically with 0o600 permissions.
-
-        Replaces the prior write-then-chmod sequence (which left a TOCTOU
-        window where the encrypted blob existed with default umask perms
-        before chmod ran).
-        """
-        # Migrate from legacy hardcoded salt to random salt on re-encryption.
-        if self._salt == _LEGACY_SALT:
-            new_salt = os.urandom(16)
-            _atomic_write_bytes_0600(self._salt_path, new_salt)
-            self._salt = new_salt
-            self._cached_key = None  # Force re-derivation
-
-        key = self._derive_key()
-        aesgcm = AESGCM(key)
-        nonce = os.urandom(_NONCE_SIZE)
-        plaintext = json.dumps(credentials).encode()
-        ciphertext = aesgcm.encrypt(nonce, plaintext, None)
-        self._cached_credentials = copy.deepcopy(credentials)
-        _atomic_write_bytes_0600(self._path, nonce + ciphertext)
-
-    def load(self) -> dict[str, str] | None:
-        """Load and decrypt credentials. Returns None if not found."""
-        if self._cached_credentials is not None:
-            return copy.deepcopy(self._cached_credentials)
-        if not self._path.exists():
-            return None
-        key = self._derive_key()
-        data = self._path.read_bytes()
-        nonce, ciphertext = data[:_NONCE_SIZE], data[_NONCE_SIZE:]
-        aesgcm = AESGCM(key)
-        plaintext = aesgcm.decrypt(nonce, ciphertext, None)
-        self._cached_credentials = json.loads(plaintext)
-        return copy.deepcopy(self._cached_credentials)
-
-    def delete(self) -> None:
-        """Delete stored credentials."""
-        self._cached_credentials = None
-        if self._path.exists():
-            self._path.unlink()

--- a/tests/test_transports/test_credential_store.py
+++ b/tests/test_transports/test_credential_store.py
@@ -1,13 +1,11 @@
-"""Tests for encrypted credential storage."""
+"""Tests for master-secret resolution and atomic 0o600 writes."""
 
 from __future__ import annotations
 
 import sys
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
-from cryptography.exceptions import InvalidTag
 
 from better_telegram_mcp.transports.credential_store import CredentialStore
 
@@ -28,215 +26,17 @@ def data_dir(tmp_path: Path) -> Path:
     return d
 
 
-class TestCredentialStore:
-    def test_store_load_roundtrip(self, data_dir: Path) -> None:
-        """Credentials can be stored and loaded back correctly."""
-        store = CredentialStore(data_dir, secret="test-secret")
-        creds = {
-            "TELEGRAM_BOT_TOKEN": "123456:ABC-DEF",
-            "TELEGRAM_API_ID": "12345",
-        }
-        store.store(creds)
-        loaded = store.load()
-        assert loaded == creds
-
-    def test_load_returns_none_when_no_file(self, data_dir: Path) -> None:
-        """Loading from empty store returns None."""
-        store = CredentialStore(data_dir, secret="test-secret")
-        assert store.load() is None
-
-    def test_different_secrets_produce_different_encryption(
-        self, data_dir: Path
-    ) -> None:
-        """Different secrets should not decrypt each other's data."""
-        store1 = CredentialStore(data_dir, secret="secret-one")
-        creds = {"TELEGRAM_BOT_TOKEN": "token123"}
-        store1.store(creds)
-
-        # Read raw encrypted bytes
-        enc_path = data_dir / "credentials.enc"
-        encrypted_data = enc_path.read_bytes()
-
-        # Try to decrypt with different secret -- should fail
-        store2 = CredentialStore(data_dir, secret="secret-two")
-        with pytest.raises(InvalidTag):
-            store2.load()
-
-        # Original secret still works
-        store1_again = CredentialStore(data_dir, secret="secret-one")
-        assert store1_again.load() == creds
-
-        # Verify the encrypted file is still the same (not corrupted by failed load)
-        assert enc_path.read_bytes() == encrypted_data
-
-    def test_delete_removes_file(self, data_dir: Path) -> None:
-        """Delete should remove the credentials file."""
-        store = CredentialStore(data_dir, secret="test-secret")
-        creds = {"TELEGRAM_BOT_TOKEN": "token123"}
-        store.store(creds)
-
-        enc_path = data_dir / "credentials.enc"
-        assert enc_path.exists()
-
-        store.delete()
-        assert not enc_path.exists()
-
-    def test_delete_noop_when_no_file(self, data_dir: Path) -> None:
-        """Delete should not raise when no file exists."""
-        store = CredentialStore(data_dir, secret="test-secret")
-        store.delete()  # Should not raise
-
-    def test_caching_behavior(self, data_dir: Path) -> None:
-        """Repeated reads should use cache and avoid disk I/O."""
-        store = CredentialStore(data_dir, secret="test-secret")
-        store.store({"TELEGRAM_BOT_TOKEN": "123:ABC"})
-
-        # Invalidate the in-memory cache to force the next read from disk
-        store._cached_credentials = None
-
-        original_read_bytes = Path.read_bytes
-        with patch.object(Path, "read_bytes", autospec=True) as mock_read:
-            # First load reads from disk
-            mock_read.side_effect = lambda self: original_read_bytes(self)
-            creds1 = store.load()
-            assert creds1 is not None
-            assert creds1["TELEGRAM_BOT_TOKEN"] == "123:ABC"
-            assert mock_read.call_count == 1
-
-            # Second load uses cache
-            creds2 = store.load()
-            assert creds2 is not None
-            assert creds2["TELEGRAM_BOT_TOKEN"] == "123:ABC"
-            assert mock_read.call_count == 1
-
-    def test_auto_generated_secret_persists(self, data_dir: Path) -> None:
-        """Auto-generated secret should be saved and reused across instances."""
-        store1 = CredentialStore(data_dir)
-        creds = {"TELEGRAM_BOT_TOKEN": "token123"}
-        store1.store(creds)
-
-        # New instance should auto-load the persisted secret
-        store2 = CredentialStore(data_dir)
-        assert store2.load() == creds
-
-    def test_auto_generated_secret_file_created(self, data_dir: Path) -> None:
-        """Secret file should be created when no secret is provided."""
-        CredentialStore(data_dir)
+class TestResolveOrGenerateSecret:
+    def test_generates_and_persists_secret(self, data_dir: Path) -> None:
+        """First call generates a secret; later calls reuse the persisted one."""
+        secret = CredentialStore._resolve_or_generate_secret(data_dir)
         secret_path = data_dir / ".secret"
         assert secret_path.exists()
-        secret = secret_path.read_text().strip()
+        assert secret_path.read_text().strip() == secret
         assert len(secret) == 64  # 32 bytes hex-encoded
 
-    def test_env_var_secret_takes_precedence(
-        self, data_dir: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """CREDENTIAL_SECRET env var should be used when set."""
-        monkeypatch.setenv("CREDENTIAL_SECRET", "env-secret")
-        store = CredentialStore(data_dir)
-        creds = {"TELEGRAM_BOT_TOKEN": "token123"}
-        store.store(creds)
-
-        # Should load with same env var
-        store2 = CredentialStore(data_dir)
-        assert store2.load() == creds
-
-        # Should not load without env var (different auto-generated secret)
-        monkeypatch.delenv("CREDENTIAL_SECRET")
-        store3 = CredentialStore(data_dir)
-        # Auto-generated secret is different from "env-secret"
-        with pytest.raises(InvalidTag):
-            store3.load()
-
-    def test_store_overwrites_existing(self, data_dir: Path) -> None:
-        """Storing new credentials should overwrite old ones."""
-        store = CredentialStore(data_dir, secret="test-secret")
-        store.store({"TELEGRAM_BOT_TOKEN": "old-token"})
-        store.store({"TELEGRAM_BOT_TOKEN": "new-token"})
-        assert store.load() == {"TELEGRAM_BOT_TOKEN": "new-token"}
-
-    def test_empty_credentials(self, data_dir: Path) -> None:
-        """Empty dict should be storable and loadable."""
-        store = CredentialStore(data_dir, secret="test-secret")
-        store.store({})
-        assert store.load() == {}
-
-    def test_data_dir_created_if_missing(self, tmp_path: Path) -> None:
-        """Store should create data_dir if it does not exist."""
-        nested = tmp_path / "a" / "b" / "c"
-        store = CredentialStore(nested, secret="test-secret")
-        store.store({"key": "value"})
-        assert store.load() == {"key": "value"}
-
-    def test_legacy_salt_migration(self, data_dir: Path) -> None:
-        """Credentials stored with legacy hardcoded salt should be loadable,
-        and re-storing should migrate to a random salt."""
-        from better_telegram_mcp.transports.credential_store import _LEGACY_SALT
-
-        store = CredentialStore(data_dir, secret="test-secret")
-        # Simulate legacy: write credentials with legacy salt
-        # (new install creates random salt, so we need to force legacy)
-        store._salt = _LEGACY_SALT
-        store._cached_key = None
-        # Write a credentials file (using legacy salt)
-        creds = {"TELEGRAM_BOT_TOKEN": "legacy-token"}
-        # Manually encrypt and write without triggering migration
-        import json
-        import os
-
-        from cryptography.hazmat.primitives.ciphers.aead import AESGCM
-
-        key = store._derive_key()
-        aesgcm = AESGCM(key)
-        nonce = os.urandom(12)
-        plaintext = json.dumps(creds).encode()
-        ciphertext = aesgcm.encrypt(nonce, plaintext, None)
-        store._path.write_bytes(nonce + ciphertext)
-
-        # Remove salt file to simulate legacy state
-        salt_path = data_dir / ".salt"
-        if salt_path.exists():
-            salt_path.unlink()
-
-        # Create new store -- should detect legacy salt (creds exist, no .salt)
-        store2 = CredentialStore(data_dir, secret="test-secret")
-        assert store2._salt == _LEGACY_SALT
-        loaded = store2.load()
-        assert loaded == creds
-
-        # Re-store should trigger salt migration
-        store2.store(creds)
-        assert store2._salt != _LEGACY_SALT
-        assert salt_path.exists()
-
-        # New store should use the migrated salt
-        store3 = CredentialStore(data_dir, secret="test-secret")
-        assert store3._salt != _LEGACY_SALT
-        assert store3.load() == creds
-
-    def test_random_salt_for_new_install(self, data_dir: Path) -> None:
-        """New installation should generate random salt, not use legacy."""
-        from better_telegram_mcp.transports.credential_store import _LEGACY_SALT
-
-        store = CredentialStore(data_dir, secret="test-secret")
-        assert store._salt != _LEGACY_SALT
-        salt_path = data_dir / ".salt"
-        assert salt_path.exists()
-        assert len(store._salt) == 16
-
-    def test_chmod_failure_swallowed(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-    ) -> None:
-        """Test that OSError during chmod is silently ignored."""
-
-        def mock_chmod(*args, **kwargs):
-            raise OSError("chmod failed")
-
-        monkeypatch.setattr("pathlib.Path.chmod", mock_chmod)
-        monkeypatch.setattr("os.chmod", mock_chmod)
-
-        store = CredentialStore(tmp_path)
-        # Store writing triggers credential chmod
-        store.store({"api_id": "123"})
+        # Second call returns the same persisted secret.
+        assert CredentialStore._resolve_or_generate_secret(data_dir) == secret
 
 
 class TestAtomicWriteTOCTOU:
@@ -246,43 +46,9 @@ class TestAtomicWriteTOCTOU:
     ``path.chmod(0o600)``. Between those two syscalls the file existed
     with the process ``umask``-derived permissions (commonly 0o644), so a
     co-tenant on the host could open() the file before the chmod landed
-    and read the encrypted credential blob (or the secret salt). The fix
-    is to create the file with mode 0o600 in a single ``os.open()`` call.
+    and read the persisted secret. The fix is to create the file with mode
+    0o600 in a single ``os.open()`` call.
     """
-
-    @posix_only
-    def test_credentials_file_is_0o600_immediately(
-        self, data_dir: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """File must never exist with broader perms than 0o600."""
-        import os
-        import stat
-
-        # Force a deliberately permissive umask so the OLD code path
-        # would have created the file world-readable before chmod ran.
-        monkeypatch.setattr(os, "umask", lambda _mask: 0o000)
-
-        store = CredentialStore(data_dir, secret="test-secret")
-        store.store({"TELEGRAM_BOT_TOKEN": "secret"})
-
-        enc_path = data_dir / "credentials.enc"
-        mode = stat.S_IMODE(os.stat(enc_path).st_mode)
-        # 0o600 == owner R/W only (no group/other access)
-        assert mode == 0o600, f"expected 0o600, got 0o{mode:o}"
-
-    @posix_only
-    def test_salt_file_is_0o600_immediately(self, data_dir: Path) -> None:
-        import os
-        import stat
-
-        # Trigger fresh installation (no legacy file). _resolve_salt
-        # generates and writes a random salt.
-        CredentialStore(data_dir, secret="test-secret")
-
-        salt_path = data_dir / ".salt"
-        assert salt_path.exists()
-        mode = stat.S_IMODE(os.stat(salt_path).st_mode)
-        assert mode == 0o600, f"expected 0o600, got 0o{mode:o}"
 
     @posix_only
     def test_secret_file_is_0o600_immediately(self, tmp_path: Path) -> None:
@@ -291,9 +57,8 @@ class TestAtomicWriteTOCTOU:
 
         data_dir = tmp_path / "fresh"
         data_dir.mkdir()
-        # Auto-generated secret (no CREDENTIAL_SECRET env var, no explicit
-        # secret kwarg) writes .secret to disk.
-        CredentialStore(data_dir)
+        # Auto-generated secret writes .secret to disk.
+        CredentialStore._resolve_or_generate_secret(data_dir)
 
         secret_path = data_dir / ".secret"
         assert secret_path.exists()
@@ -339,7 +104,7 @@ class TestAtomicWriteTOCTOU:
     def test_atomic_write_overwrites_existing_file_with_secure_mode(
         self, tmp_path: Path
     ) -> None:
-        """Re-storing must reset perms even if a stale loose-perm file existed."""
+        """Re-writing must reset perms even if a stale loose-perm file existed."""
         import os
         import stat
 


### PR DESCRIPTION
## Summary

Removes two flagged DEAD items, each proven dead by exhaustive repo-wide grep (src + tests) showing **zero live (non-test, non-definition) callers**.

### 1. `CredentialStore.store()` / `.load()` / `.delete()` + the `credentials.enc` encrypted-blob path
AES-GCM/PBKDF2 key derivation, salt resolution/migration, and in-memory caching — all unused.

**Dead-proof:**
- The only live caller of the `credential_store` module is `config.py` `Settings.secret` -> `CredentialStore._resolve_or_generate_secret(data_dir)` (the **static helper**, which is **KEPT** along with the module-level `_atomic_write_bytes_0600` it depends on).
- Every `CredentialStore(...)`, `.store()`, `.load()`, `.delete()`, and `credentials.enc` reference outside the class definition was confined to `tests/test_transports/test_credential_store.py`, which tested only the removed code.
- The `.store()`/`.load()`/`.delete()` calls in `auth/telegram_auth_provider.py` operate on `InMemorySessionStore` (a different class) — **not** `CredentialStore` — and are untouched.

### 2. `Settings.auth_url` (env `TELEGRAM_AUTH_URL`)
Defined in `config.py:33` but never read anywhere in code. The in-process `local` auth server and remote-relay client that once consumed it were removed previously; HTTP setup is served by mcp-core's OAuth AS off `PUBLIC_URL`.

**Dead-proof:** the only non-third-party references were the field definition plus two doc mentions (handled below).

## Coherence follow-ups (now-orphaned doc references)
- `PRIVACY.md`: removed the `Local Mode (TELEGRAM_AUTH_URL=local)` subsection describing the dead env var.
- `CLAUDE.md`: removed the `TELEGRAM_AUTH_URL exists on Settings but is currently unused` note.
- Rewrote the credential_store test module to cover only the surviving `_resolve_or_generate_secret` + `_atomic_write_bytes_0600` helpers.

## Verification
- `uv run --no-sync ruff check .` -> All checks passed
- `uv run --no-sync ty check` -> All checks passed
- `uv run --no-sync pytest -q` -> **572 passed, 17 skipped** (POSIX-only 0o600 mode asserts skipped on Windows), **140 deselected** (integration/live/full/e2e markers, network/credential-gated by default)

Diff is surgical: 5 files, 20 insertions / 355 deletions.