### PR TITLE
🛡️ Sentinel: [CRITICAL] Remove hardcoded Telegram API credentials

### DIFF
--- a/src/better_telegram_mcp/config.py
+++ b/src/better_telegram_mcp/config.py
@@ -24,8 +24,8 @@ class Settings(BaseSettings):
     bot_token: str | None = None
 
     # User mode (app-level credentials with built-in defaults, like Google Drive client_id/secret)
-    api_id: int | None = 37984984
-    api_hash: str | None = "2f5f4c76c4de7c07302380c788390100"
+    api_id: int | None = None
+    api_hash: str | None = None
     phone: str | None = None
     session_name: str = "default"
 
@@ -55,7 +55,7 @@ class Settings(BaseSettings):
         self.phone = _empty_to_none(self.phone)
 
         has_bot = self.bot_token is not None
-        # User mode requires phone (api_id/api_hash have built-in defaults)
+        # User mode requires phone
         has_user = (
             self.api_id is not None
             and self.api_hash is not None
@@ -84,7 +84,6 @@ class Settings(BaseSettings):
 
         Args:
             config: Dict with keys like TELEGRAM_BOT_TOKEN, TELEGRAM_API_ID, etc.
-            API_ID and API_HASH use built-in defaults if not provided.
 
         Returns:
             A configured Settings instance.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -54,7 +54,7 @@ def test_is_configured_user(monkeypatch):
 
 
 def test_api_id_api_hash_without_phone_not_configured(monkeypatch):
-    """api_id + api_hash without phone should NOT be configured (defaults exist)."""
+    """api_id + api_hash without phone should NOT be configured."""
     monkeypatch.setenv("TELEGRAM_API_ID", "12345")
     monkeypatch.setenv("TELEGRAM_API_HASH", "abcdef123456")
     s = Settings()
@@ -63,10 +63,10 @@ def test_api_id_api_hash_without_phone_not_configured(monkeypatch):
 
 
 def test_default_api_credentials():
-    """api_id and api_hash have built-in defaults."""
+    """api_id and api_hash defaults to None."""
     s = Settings()
-    assert s.api_id == 37984984
-    assert s.api_hash == "2f5f4c76c4de7c07302380c788390100"
+    assert s.api_id is None
+    assert s.api_hash is None
 
 
 def test_default_data_dir(monkeypatch):
@@ -185,5 +185,5 @@ def test_from_relay_config():
 
     # Defaults
     s2 = Settings.from_relay_config({})
-    assert s2.api_id == 37984984
-    assert s2.api_hash == "2f5f4c76c4de7c07302380c788390100"
+    assert s2.api_id is None
+    assert s2.api_hash is None

--- a/tests/test_relay_setup.py
+++ b/tests/test_relay_setup.py
@@ -79,12 +79,12 @@ def test_from_relay_config_empty_values():
 
 
 def test_from_relay_config_missing_keys():
-    """Missing keys should use built-in defaults for api_id/api_hash."""
+    """Missing keys should default to None for api_id/api_hash."""
     config = {}
     s = Settings.from_relay_config(config)
     assert s.bot_token is None
-    assert s.api_id == 37984984  # built-in default
-    assert s.api_hash == "2f5f4c76c4de7c07302380c788390100"  # built-in default
+    assert s.api_id is None
+    assert s.api_hash is None
     assert s.is_configured is False  # no phone, no bot_token
 
 

--- a/tests/test_transports/test_http.py
+++ b/tests/test_transports/test_http.py
@@ -86,10 +86,12 @@ class TestIsMultiUserMode:
         env = {
             "DCR_SERVER_SECRET": "secret",
             "PUBLIC_URL": "https://mcp.example.com",
+            "TELEGRAM_API_ID": "12345",
+            "TELEGRAM_API_HASH": "abcde",
         }
         with patch.dict("os.environ", env, clear=True):
-            # settings has api_id/api_hash by default
-            assert _is_multi_user_mode(settings) is True
+            settings_with_api = Settings()
+            assert _is_multi_user_mode(settings_with_api) is True
 
     def test_is_multi_user_mode_true_mcp_prefixed_secret(
         self, settings: Settings
@@ -99,9 +101,12 @@ class TestIsMultiUserMode:
         env = {
             "MCP_DCR_SERVER_SECRET": "secret",
             "PUBLIC_URL": "https://mcp.example.com",
+            "TELEGRAM_API_ID": "12345",
+            "TELEGRAM_API_HASH": "abcde",
         }
         with patch.dict("os.environ", env, clear=True):
-            assert _is_multi_user_mode(settings) is True
+            settings_with_api = Settings()
+            assert _is_multi_user_mode(settings_with_api) is True
 
     def test_is_multi_user_mode_true_legacy_secret(self, settings: Settings) -> None:
         """Back-compat: returns True when only the legacy DCR_SERVER_SECRET
@@ -109,9 +114,12 @@ class TestIsMultiUserMode:
         env = {
             "DCR_SERVER_SECRET": "secret",
             "PUBLIC_URL": "https://mcp.example.com",
+            "TELEGRAM_API_ID": "12345",
+            "TELEGRAM_API_HASH": "abcde",
         }
         with patch.dict("os.environ", env, clear=True):
-            assert _is_multi_user_mode(settings) is True
+            settings_with_api = Settings()
+            assert _is_multi_user_mode(settings_with_api) is True
 
     def test_is_multi_user_mode_false_missing_dcr(self, settings: Settings) -> None:
         """Returns False when both DCR secret names are missing."""

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.12.7b2"
+version = "4.12.7b3"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Remove hardcoded Telegram API credentials

🚨 Severity: CRITICAL
💡 Vulnerability: Hardcoded API credentials (`api_id` and `api_hash`) were present as defaults in `src/better_telegram_mcp/config.py`.
🎯 Impact: Anyone with access to the code could use these credentials. This breaches the principle of least privilege and common security standard to avoid checking credentials into code.
🔧 Fix: Updated the default fallback values to `None` and modified unit tests to accommodate the change.
✅ Verification: `uv run pytest tests/` completed successfully with passing tests and verified there are no other hardcoded key occurrences via grep.

---
*PR created automatically by Jules for task [155270064656630793](https://jules.google.com/task/155270064656630793) started by @n24q02m*