### PR TITLE
🎨 Palette: Dynamic error clearing on form inputs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,7 @@
 ## 2024-07-28 - Contrast Requirements for Dark Themes
 **Learning:** Text using color `#666` fails WCAG AA 4.5:1 contrast requirements when placed against dark-themed backgrounds such as `#1a1a1a`.
 **Action:** When designing dark themes, ensure that subtle or secondary text elements (like `.server-id` and `.help-text`) are upgraded to at least `#888` or `#999` to maintain readability and accessibility standards.
+
+## 2024-06-25 - Improve Form Usability by Clearing Error States Early
+**Learning:** For forms that validate inputs upon submission and place the UI into an error state (adding `aria-invalid` and displaying inline error blocks), it is highly frustrating for users if the error states linger while they type to correct the mistake. Waiting until the next submission to remove `aria-invalid` undermines confidence.
+**Action:** Always attach an `input` event listener to form fields that actively strips validation styling (e.g., `aria-invalid`) and hides inline error messages immediately as soon as the user resumes typing.

--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -444,6 +444,17 @@ def render_telegram_credential_form(
             var submitUrl = "{submit_url_escaped}";
             var activeTab = "{initial_tab}";
 
+            // --- Clear errors on input -----------------------------------------
+            form.querySelectorAll(".field-input").forEach(function (input) {{
+                input.addEventListener("input", function () {{
+                    input.removeAttribute("aria-invalid");
+                    if (statusBox.className.indexOf("error") !== -1) {{
+                        statusBox.style.display = "none";
+                        statusBox.textContent = "";
+                    }}
+                }});
+            }});
+
             // --- Tab switching -------------------------------------------------
             var tabs = document.querySelectorAll(".tab");
             var tabsArray = Array.prototype.slice.call(tabs);
@@ -604,6 +615,11 @@ def render_telegram_credential_form(
                             evt.preventDefault();
                             submitStep();
                         }}
+                    }});
+                    inputEl.addEventListener("input", function () {{
+                        inputEl.removeAttribute("aria-invalid");
+                        errorEl.style.display = "none";
+                        errorEl.textContent = "";
                     }});
                 }}
 


### PR DESCRIPTION
### 💡 What
Added `input` event listeners to all `.field-input` and the `step-input` fields in `src/better_telegram_mcp/credential_form.py` to immediately remove validation styling (`aria-invalid="true"`) and hide error message boxes when the user starts typing to correct a mistake.

### 🎯 Why
When validation fails and marks inputs as invalid, leaving the visual error and `aria-invalid` state active while the user types to correct their input creates a confusing UX. Clearing it proactively signals to the user that they are back on the right track before they attempt to re-submit.

### ♿ Accessibility
This improvement directly aids users relying on screen readers or visual cues by immediately removing the `aria-invalid` flag and error styling as soon as they interact with the field, preventing false failure signals during their input process.

---
*PR created automatically by Jules for task [13830983630501917488](https://jules.google.com/task/13830983630501917488) started by @n24q02m*