### PR TITLE
🎨 Palette: Actively clear form error states on user input

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,6 @@
 ## 2024-07-28 - Contrast Requirements for Dark Themes
 **Learning:** Text using color `#666` fails WCAG AA 4.5:1 contrast requirements when placed against dark-themed backgrounds such as `#1a1a1a`.
 **Action:** When designing dark themes, ensure that subtle or secondary text elements (like `.server-id` and `.help-text`) are upgraded to at least `#888` or `#999` to maintain readability and accessibility standards.
+## 2024-05-20 - Prevent Lingering Form Errors
+**Learning:** Users can become confused or frustrated when error messages or validation styling (like `aria-invalid`) persist while they are actively trying to correct their input. Lingering errors fail to provide immediate, positive feedback that their corrective action is being registered.
+**Action:** Always attach an `input` event listener to form fields to actively strip validation styling (`aria-invalid="true"`) and hide inline error messages as soon as the user resumes typing. This provides an immediate sense of progress and reduces cognitive load during form correction.

--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -605,6 +605,15 @@ def render_telegram_credential_form(
                             submitStep();
                         }}
                     }});
+                    inputEl.addEventListener("input", function () {{
+                        if (inputEl.hasAttribute("aria-invalid")) {{
+                            inputEl.removeAttribute("aria-invalid");
+                        }}
+                        if (errorEl.style.display !== "none") {{
+                            errorEl.style.display = "none";
+                            errorEl.textContent = "";
+                        }}
+                    }});
                 }}
 
                 promptEl.textContent = ns.text || "";
@@ -703,6 +712,19 @@ def render_telegram_credential_form(
                         inputEl.focus();
                     }});
             }}
+
+            // --- Clear error state on input ------------------------------------
+            form.querySelectorAll(".field-input").forEach(function (input) {{
+                input.addEventListener("input", function () {{
+                    if (input.hasAttribute("aria-invalid")) {{
+                        input.removeAttribute("aria-invalid");
+                    }}
+                    if (statusBox.style.display !== "none" && statusBox.className.indexOf("error") !== -1) {{
+                        statusBox.style.display = "none";
+                        statusBox.textContent = "";
+                    }}
+                }});
+            }});
 
             // --- Form submit ---------------------------------------------------
             form.addEventListener("submit", function (event) {{


### PR DESCRIPTION
**What:** Added `input` event listeners to the authentication form fields in `credential_form.py` (both the main fields and the dynamically rendered step inputs). When a user types, it strips the `aria-invalid` attribute and hides the `status-box`/`step-error` messages.

**Why:** Lingering error states cause cognitive load. Once a user receives an error and begins to correct their input by typing again, the previous error state becomes invalid and visually confusing. Actively clearing it makes the interface feel much more responsive and intuitive.

**Accessibility:** This directly improves accessibility by correctly toggling the `aria-invalid` state off when the user attempts a correction, preventing screen readers from redundantly announcing the field as invalid after the user has begun addressing the issue.

Also included an update to the `.jules/palette.md` journal to codify this pattern for future implementations.

---
*PR created automatically by Jules for task [4094493287215517420](https://jules.google.com/task/4094493287215517420) started by @n24q02m*