### PR TITLE
🛡️ Sentinel: [CRITICAL] Remove hardcoded API credentials

### DIFF
--- a/src/better_telegram_mcp/config.py
+++ b/src/better_telegram_mcp/config.py
@@ -24,8 +24,8 @@ class Settings(BaseSettings):
     bot_token: str | None = None
 
     # User mode (app-level credentials with built-in defaults, like Google Drive client_id/secret)
-    api_id: int | None = 37984984
-    api_hash: str | None = "2f5f4c76c4de7c07302380c788390100"
+    api_id: int | None = None
+    api_hash: str | None = None
     phone: str | None = None
     session_name: str = "default"
 
@@ -55,7 +55,7 @@ class Settings(BaseSettings):
         self.phone = _empty_to_none(self.phone)
 
         has_bot = self.bot_token is not None
-        # User mode requires phone (api_id/api_hash have built-in defaults)
+        # User mode requires phone, api_id, and api_hash
         has_user = (
             self.api_id is not None
             and self.api_hash is not None
@@ -89,7 +89,6 @@ class Settings(BaseSettings):
 
         Args:
             config: Dict with keys like TELEGRAM_BOT_TOKEN, TELEGRAM_API_ID, etc.
-            API_ID and API_HASH use built-in defaults if not provided.
 
         Returns:
             A configured Settings instance.

--- a/tests/auth/test_auth_provider_string_session.py
+++ b/tests/auth/test_auth_provider_string_session.py
@@ -25,7 +25,7 @@ async def test_provider_injects_backend_into_user_backend(monkeypatch, tmp_path)
     monkeypatch.setattr(
         "better_telegram_mcp.auth.telegram_auth_provider.UserBackend", _FakeUserBackend
     )
-    provider = TelegramAuthProvider(tmp_path, 37984984, "hash", backend=mem)
+    provider = TelegramAuthProvider(tmp_path, 12345, "hash", backend=mem)
     info = SessionInfo(session_name="abc123", mode="user", phone="+1")
     await provider._create_backend(info)
     assert captured["backend"] is mem

--- a/tests/test_backends/test_user_backend_string_session.py
+++ b/tests/test_backends/test_user_backend_string_session.py
@@ -12,8 +12,8 @@ from tests.conftest_cf import FakeStringSessionClient
 
 def _settings(tmp_path) -> Settings:
     return Settings(
-        api_id=37984984,
-        api_hash="2f5f4c76c4de7c07302380c788390100",
+        api_id=12345,
+        api_hash="hash",
         phone="+10000000000",
         session_name="deadbeefdeadbeef",
         data_dir=tmp_path,

--- a/tests/test_cf_e2e.py
+++ b/tests/test_cf_e2e.py
@@ -46,7 +46,7 @@ async def test_session_survives_recreate(monkeypatch, tmp_path):
     )
     provider = TelegramAuthProvider(
         tmp_path,
-        37984984,
+        12345,
         "hash",
         backend=backend,
         store=KvSessionStore(backend=backend),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -54,7 +54,7 @@ def test_is_configured_user(monkeypatch):
 
 
 def test_api_id_api_hash_without_phone_not_configured(monkeypatch):
-    """api_id + api_hash without phone should NOT be configured (defaults exist)."""
+    """api_id + api_hash without phone should NOT be configured."""
     monkeypatch.setenv("TELEGRAM_API_ID", "12345")
     monkeypatch.setenv("TELEGRAM_API_HASH", "abcdef123456")
     s = Settings()
@@ -63,10 +63,10 @@ def test_api_id_api_hash_without_phone_not_configured(monkeypatch):
 
 
 def test_default_api_credentials():
-    """api_id and api_hash have built-in defaults."""
+    """api_id and api_hash have no built-in defaults."""
     s = Settings()
-    assert s.api_id == 37984984
-    assert s.api_hash == "2f5f4c76c4de7c07302380c788390100"
+    assert s.api_id is None
+    assert s.api_hash is None
 
 
 def test_default_data_dir(monkeypatch):
@@ -185,5 +185,5 @@ def test_from_relay_config():
 
     # Defaults
     s2 = Settings.from_relay_config({})
-    assert s2.api_id == 37984984
-    assert s2.api_hash == "2f5f4c76c4de7c07302380c788390100"
+    assert s2.api_id is None
+    assert s2.api_hash is None

--- a/tests/test_relay_setup.py
+++ b/tests/test_relay_setup.py
@@ -79,12 +79,12 @@ def test_from_relay_config_empty_values():
 
 
 def test_from_relay_config_missing_keys():
-    """Missing keys should use built-in defaults for api_id/api_hash."""
+    """Missing keys should result in api_id/api_hash being None."""
     config = {}
     s = Settings.from_relay_config(config)
     assert s.bot_token is None
-    assert s.api_id == 37984984  # built-in default
-    assert s.api_hash == "2f5f4c76c4de7c07302380c788390100"  # built-in default
+    assert s.api_id is None
+    assert s.api_hash is None
     assert s.is_configured is False  # no phone, no bot_token
 
 

--- a/tests/test_transports/test_http.py
+++ b/tests/test_transports/test_http.py
@@ -82,13 +82,14 @@ class TestResolvePort:
 
 class TestIsMultiUserMode:
     def test_is_multi_user_mode_true(self, settings: Settings) -> None:
-        """Returns True when DCR_SERVER_SECRET and PUBLIC_URL are set."""
+        """Returns True when DCR_SERVER_SECRET, PUBLIC_URL, and api_id/hash are set."""
         env = {
             "DCR_SERVER_SECRET": "secret",
             "PUBLIC_URL": "https://mcp.example.com",
         }
+        settings.api_id = 12345
+        settings.api_hash = "hash"
         with patch.dict("os.environ", env, clear=True):
-            # settings has api_id/api_hash by default
             assert _is_multi_user_mode(settings) is True
 
     def test_is_multi_user_mode_true_mcp_prefixed_secret(
@@ -100,6 +101,8 @@ class TestIsMultiUserMode:
             "MCP_DCR_SERVER_SECRET": "secret",
             "PUBLIC_URL": "https://mcp.example.com",
         }
+        settings.api_id = 12345
+        settings.api_hash = "hash"
         with patch.dict("os.environ", env, clear=True):
             assert _is_multi_user_mode(settings) is True
 
@@ -110,6 +113,8 @@ class TestIsMultiUserMode:
             "DCR_SERVER_SECRET": "secret",
             "PUBLIC_URL": "https://mcp.example.com",
         }
+        settings.api_id = 12345
+        settings.api_hash = "hash"
         with patch.dict("os.environ", env, clear=True):
             assert _is_multi_user_mode(settings) is True
 


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Remove hardcoded API credentials

🚨 Severity: CRITICAL
💡 Vulnerability: Default values for `api_id` and `api_hash` were hardcoded directly in `src/better_telegram_mcp/config.py`.
🎯 Impact: Embedded secrets in version control could be exposed if the codebase is distributed, violating security best practices.
🔧 Fix: Removed defaults, changing them to `None`, forcing explicit configuration. Updated all dependent tests to mock these values.
✅ Verification: Ran `uv run pytest` to ensure all tests passed.

---
*PR created automatically by Jules for task [3637693340934003310](https://jules.google.com/task/3637693340934003310) started by @n24q02m*