### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix memory exhaustion via uncontrolled httpx downloads

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-05-24 - Unbounded Memory Consumption via uncontrolled `httpx` Downloads
+**Vulnerability:** The application was using `httpx.AsyncClient.get` to download user-supplied URLs without enforcing a maximum file size. An attacker could exploit this by providing a URL to an extremely large file or an infinite stream, causing the server to buffer the entire response in memory, leading to an Out-Of-Memory (OOM) crash and Denial of Service (DoS).
+**Learning:** Functions that download files from untrusted sources must never load the entire payload into memory at once without bounds. Even with timeout mechanisms, an attacker can trickle data slowly or send a massive payload quickly before the timeout hits.
+**Prevention:** Always stream responses for file downloads using `client.stream("GET", ...)`. Inspect the `Content-Length` header upfront to reject oversized files immediately. Accumulate the response in chunks using `resp.aiter_bytes()` and strictly enforce a maximum file size limit (e.g., `MAX_FILE_SIZE = 50 * 1024 * 1024`) during accumulation to protect against malicious servers that omit or lie about their `Content-Length`.

--- a/src/better_telegram_mcp/backends/security.py
+++ b/src/better_telegram_mcp/backends/security.py
@@ -12,6 +12,10 @@ class SecurityError(Exception):
     pass
 
 
+# 50MB maximum file size for downloaded media
+MAX_FILE_SIZE = 50 * 1024 * 1024
+
+
 # Private/internal IP ranges that should not be accessed via SSRF
 _BLOCKED_NETWORKS = (
     ipaddress.ip_network("0.0.0.0/8"),
@@ -259,12 +263,24 @@ async def fetch_url_safely(url: str, timeout: float = 30.0) -> bytes:
     extensions = {"sni_hostname": parsed.hostname}
 
     async with httpx.AsyncClient(verify=True) as client:
-        resp = await client.get(
+        async with client.stream(
+            "GET",
             new_url,
             headers=headers,
             extensions=extensions,
             timeout=timeout,
             follow_redirects=False,  # Redirects could lead to rebinding or other SSRF
-        )
-        resp.raise_for_status()
-        return resp.content
+        ) as resp:
+            resp.raise_for_status()
+
+            content_length = resp.headers.get("Content-Length")
+            if content_length and int(content_length) > MAX_FILE_SIZE:
+                raise SecurityError(f"File size exceeds {MAX_FILE_SIZE} bytes")
+
+            chunks = bytearray()
+            async for chunk in resp.aiter_bytes():
+                chunks.extend(chunk)
+                if len(chunks) > MAX_FILE_SIZE:
+                    raise SecurityError(f"File size exceeds {MAX_FILE_SIZE} bytes")
+
+            return bytes(chunks)

--- a/tests/test_backends/test_security.py
+++ b/tests/test_backends/test_security.py
@@ -163,7 +163,7 @@ class TestValidateUrl:
     @pytest.mark.asyncio
     async def test_fetch_url_safely_prevents_rebinding(self, monkeypatch):
         """Test that fetch_url_safely uses the validated IP and ignores subsequent DNS changes."""
-        from unittest.mock import AsyncMock, patch
+        from unittest.mock import patch
 
         import httpx
 
@@ -186,17 +186,18 @@ class TestValidateUrl:
         monkeypatch.setattr("socket.getaddrinfo", mock_getaddrinfo)
 
         # Mock httpx.AsyncClient.get to verify the URL used
-        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
-            # Return a real Response object with a request to allow raise_for_status()
+        from unittest.mock import MagicMock
+
+        with patch("httpx.AsyncClient.stream", new_callable=MagicMock) as mock_stream:
             resp = httpx.Response(200, content=b"content")
             resp._request = httpx.Request("GET", f"http://{safe_ip}/data")
-            mock_get.return_value = resp
+            mock_stream.return_value.__aenter__.return_value = resp
 
             await fetch_url_safely(f"http://{target_hostname}/data")
 
             # Verify that the URL passed to httpx uses the SAFE IP, not the hostname or malicious IP
-            args, kwargs = mock_get.call_args
-            requested_url = str(args[0])
+            args, kwargs = mock_stream.call_args
+            requested_url = str(args[1])
             assert safe_ip in requested_url
             assert target_hostname not in requested_url
             assert malicious_ip not in requested_url
@@ -207,7 +208,7 @@ class TestValidateUrl:
 
     async def test_fetch_url_safely_ipv6(self, monkeypatch):
         """Verify fetch_url_safely correctly constructs URL with IPv6 address."""
-        from unittest.mock import AsyncMock, patch
+        from unittest.mock import patch
 
         import httpx
 
@@ -221,15 +222,17 @@ class TestValidateUrl:
 
         monkeypatch.setattr("socket.getaddrinfo", mock_getaddrinfo)
 
-        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+        from unittest.mock import MagicMock
+
+        with patch("httpx.AsyncClient.stream", new_callable=MagicMock) as mock_stream:
             resp = httpx.Response(200, content=b"content")
             resp._request = httpx.Request("GET", f"http://[{safe_ip}]:8080/data")
-            mock_get.return_value = resp
+            mock_stream.return_value.__aenter__.return_value = resp
 
             await fetch_url_safely(f"http://{target_hostname}:8080/data")
 
-            args, kwargs = mock_get.call_args
-            requested_url = str(args[0])
+            args, kwargs = mock_stream.call_args
+            requested_url = str(args[1])
             assert requested_url == f"http://[{safe_ip}]:8080/data"
             assert kwargs["headers"]["Host"] == target_hostname
             assert kwargs["extensions"]["sni_hostname"] == target_hostname
@@ -423,3 +426,112 @@ class TestValidateOutputDir:
         """Test that paths like ~/../../etc/cron.d are expanded and blocked."""
         with pytest.raises(SecurityError, match="/etc/"):
             validate_output_dir("~/../../etc/cron.d")
+
+    async def test_fetch_url_safely_size_limit_content_length(self, monkeypatch):
+        """Test that fetch_url_safely rejects files over MAX_FILE_SIZE via Content-Length."""
+        target_hostname = "example.com"
+        target_ip = "93.184.216.34"
+
+        def mock_validate_url(url):
+            return target_ip
+
+        monkeypatch.setattr(
+            "better_telegram_mcp.backends.security.validate_url", mock_validate_url
+        )
+
+        # Mock httpx.AsyncClient.stream to return a response with a large Content-Length
+
+        from better_telegram_mcp.backends.security import (
+            MAX_FILE_SIZE,
+            fetch_url_safely,
+        )
+
+        class MockResponse:
+            def __init__(self):
+                self.headers = {"Content-Length": str(MAX_FILE_SIZE + 1)}
+
+            def raise_for_status(self):
+                pass
+
+        class MockStreamContext:
+            async def __aenter__(self):
+                return MockResponse()
+
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                pass
+
+        class MockClient:
+            def __init__(self, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                pass
+
+            def stream(self, *args, **kwargs):
+                return MockStreamContext()
+
+        monkeypatch.setattr("httpx.AsyncClient", MockClient)
+
+        with pytest.raises(
+            SecurityError, match=f"File size exceeds {MAX_FILE_SIZE} bytes"
+        ):
+            await fetch_url_safely(f"http://{target_hostname}/data")
+
+    async def test_fetch_url_safely_size_limit_chunks(self, monkeypatch):
+        """Test that fetch_url_safely rejects files over MAX_FILE_SIZE via chunk accumulation."""
+        target_hostname = "example.com"
+        target_ip = "93.184.216.34"
+
+        def mock_validate_url(url):
+            return target_ip
+
+        monkeypatch.setattr(
+            "better_telegram_mcp.backends.security.validate_url", mock_validate_url
+        )
+
+        from better_telegram_mcp.backends.security import (
+            MAX_FILE_SIZE,
+            fetch_url_safely,
+        )
+
+        # Mock httpx.AsyncClient.stream to return chunks that sum up to > MAX_FILE_SIZE
+        class MockResponse:
+            def __init__(self):
+                self.headers = {}  # No Content-Length
+
+            def raise_for_status(self):
+                pass
+
+            async def aiter_bytes(self):
+                yield b"A" * (MAX_FILE_SIZE // 2)
+                yield b"B" * (MAX_FILE_SIZE // 2 + 10)
+
+        class MockStreamContext:
+            async def __aenter__(self):
+                return MockResponse()
+
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                pass
+
+        class MockClient:
+            def __init__(self, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                pass
+
+            def stream(self, *args, **kwargs):
+                return MockStreamContext()
+
+        monkeypatch.setattr("httpx.AsyncClient", MockClient)
+
+        with pytest.raises(
+            SecurityError, match=f"File size exceeds {MAX_FILE_SIZE} bytes"
+        ):
+            await fetch_url_safely(f"http://{target_hostname}/data")

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.13.0b1"
+version = "4.13.0b2"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix memory exhaustion via uncontrolled httpx downloads

🚨 Severity: CRITICAL
💡 Vulnerability: `fetch_url_safely` fetched user-supplied URLs using `client.get`, buffering the entire response in memory. This could lead to an Out-Of-Memory (OOM) Denial of Service (DoS) if an attacker supplied a URL to a massive file or infinite stream.
🎯 Impact: Attackers could cause the MCP server to run out of memory and crash.
🔧 Fix:
- Added `MAX_FILE_SIZE = 50 * 1024 * 1024` (50MB) limit.
- Switched `fetch_url_safely` to use `client.stream`.
- Immediately raised `SecurityError` if the `Content-Length` header exceeds `MAX_FILE_SIZE`.
- Accumulated the response using `aiter_bytes()` and iteratively checked the accumulated size to prevent malicious servers from omitting or falsifying `Content-Length`.
✅ Verification: Added tests `test_fetch_url_safely_size_limit_content_length` and `test_fetch_url_safely_size_limit_chunks` in `test_security.py` to ensure large files are rejected properly. Updated existing tests to mock `stream` instead of `get`.

---
*PR created automatically by Jules for task [6078301887287545299](https://jules.google.com/task/6078301887287545299) started by @n24q02m*