### PR TITLE
🛡️ Sentinel: [HIGH] Fix DoS via memory exhaustion in fetch_url_safely

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-27 - Fix DoS via memory exhaustion in fetch_url_safely
+**Vulnerability:** fetch_url_safely used httpx.AsyncClient.get which loads the entire response into memory at once, creating a risk for Denial of Service (DoS) via Out-Of-Memory (OOM) attacks if a malicious or large file is fetched.
+**Learning:** External URLs should be fetched with size limits and streaming to prevent memory exhaustion, as even validated internal IPs/URLs can return massive payloads.
+**Prevention:** Always use httpx.stream and iterate over chunks (`aiter_bytes`) while enforcing a strict `max_size` limit on the accumulated data and checking the Content-Length header.

--- a/src/better_telegram_mcp/backends/security.py
+++ b/src/better_telegram_mcp/backends/security.py
@@ -235,7 +235,11 @@ def validate_output_dir(output_dir: str, *, base_dir: Path | None = None) -> Pat
     return path
 
 
-async def fetch_url_safely(url: str, timeout: float = 30.0) -> bytes:
+async def fetch_url_safely(
+    url: str,
+    timeout: float = 30.0,
+    max_size: int = 50 * 1024 * 1024,  # Default 50MB
+) -> bytes:
     """Fetch URL content safely by pinning the IP to prevent DNS rebinding."""
     from urllib.parse import urlunparse
 
@@ -259,12 +263,35 @@ async def fetch_url_safely(url: str, timeout: float = 30.0) -> bytes:
     extensions = {"sni_hostname": parsed.hostname}
 
     async with httpx.AsyncClient(verify=True) as client:
-        resp = await client.get(
+        # Use stream to prevent OOM / memory exhaustion DoS
+        async with client.stream(
+            "GET",
             new_url,
             headers=headers,
             extensions=extensions,
             timeout=timeout,
             follow_redirects=False,  # Redirects could lead to rebinding or other SSRF
-        )
-        resp.raise_for_status()
-        return resp.content
+        ) as resp:
+            resp.raise_for_status()
+
+            # Early check if Content-Length exceeds max_size
+            content_length = resp.headers.get("Content-Length")
+            if content_length:
+                try:
+                    if int(content_length) > max_size:
+                        msg = f"File size exceeds maximum allowed ({max_size} bytes)"
+                        raise SecurityError(msg)
+                except ValueError:
+                    # Ignore malformed Content-Length header and rely on chunk accumulation
+                    pass
+
+            chunks = []
+            accumulated_size = 0
+            async for chunk in resp.aiter_bytes(chunk_size=8192):
+                accumulated_size += len(chunk)
+                if accumulated_size > max_size:
+                    msg = f"File size exceeds maximum allowed ({max_size} bytes)"
+                    raise SecurityError(msg)
+                chunks.append(chunk)
+
+            return b"".join(chunks)

--- a/tests/test_backends/test_security.py
+++ b/tests/test_backends/test_security.py
@@ -163,7 +163,7 @@ class TestValidateUrl:
     @pytest.mark.asyncio
     async def test_fetch_url_safely_prevents_rebinding(self, monkeypatch):
         """Test that fetch_url_safely uses the validated IP and ignores subsequent DNS changes."""
-        from unittest.mock import patch, MagicMock
+        from unittest.mock import MagicMock, patch
 
         import httpx
 
@@ -192,6 +192,7 @@ class TestValidateUrl:
 
             async def mock_aiter_bytes(chunk_size=None):
                 yield b"content"
+
             resp.aiter_bytes = mock_aiter_bytes
 
             mock_stream.return_value.__aenter__.return_value = resp

--- a/tests/test_backends/test_security.py
+++ b/tests/test_backends/test_security.py
@@ -163,7 +163,7 @@ class TestValidateUrl:
     @pytest.mark.asyncio
     async def test_fetch_url_safely_prevents_rebinding(self, monkeypatch):
         """Test that fetch_url_safely uses the validated IP and ignores subsequent DNS changes."""
-        from unittest.mock import AsyncMock, patch
+        from unittest.mock import patch, MagicMock
 
         import httpx
 
@@ -185,29 +185,29 @@ class TestValidateUrl:
 
         monkeypatch.setattr("socket.getaddrinfo", mock_getaddrinfo)
 
-        # Mock httpx.AsyncClient.get to verify the URL used
-        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
-            # Return a real Response object with a request to allow raise_for_status()
-            resp = httpx.Response(200, content=b"content")
+        # Mock httpx.AsyncClient.stream to verify the URL used
+        with patch("httpx.AsyncClient.stream", new_callable=MagicMock) as mock_stream:
+            resp = httpx.Response(200)
             resp._request = httpx.Request("GET", f"http://{safe_ip}/data")
-            mock_get.return_value = resp
+
+            async def mock_aiter_bytes(chunk_size=None):
+                yield b"content"
+            resp.aiter_bytes = mock_aiter_bytes
+
+            mock_stream.return_value.__aenter__.return_value = resp
 
             await fetch_url_safely(f"http://{target_hostname}/data")
 
-            # Verify that the URL passed to httpx uses the SAFE IP, not the hostname or malicious IP
-            args, kwargs = mock_get.call_args
-            requested_url = str(args[0])
+            # Verify httpx.stream was called with the SAFE IP in the URL, not the hostname
+            args, _ = mock_stream.call_args
+            requested_url = str(args[1])
             assert safe_ip in requested_url
-            assert target_hostname not in requested_url
             assert malicious_ip not in requested_url
-
-            # Verify headers and extensions preserve the hostname for SNI/Host
-            assert kwargs["headers"]["Host"] == target_hostname
-            assert kwargs["extensions"]["sni_hostname"] == target_hostname
+            assert target_hostname not in requested_url
 
     async def test_fetch_url_safely_ipv6(self, monkeypatch):
         """Verify fetch_url_safely correctly constructs URL with IPv6 address."""
-        from unittest.mock import AsyncMock, patch
+        from unittest.mock import MagicMock, patch
 
         import httpx
 
@@ -221,18 +221,96 @@ class TestValidateUrl:
 
         monkeypatch.setattr("socket.getaddrinfo", mock_getaddrinfo)
 
-        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
-            resp = httpx.Response(200, content=b"content")
+        with patch("httpx.AsyncClient.stream", new_callable=MagicMock) as mock_stream:
+            resp = httpx.Response(200)
             resp._request = httpx.Request("GET", f"http://[{safe_ip}]:8080/data")
-            mock_get.return_value = resp
+
+            async def mock_aiter_bytes(chunk_size=None):
+                yield b"content"
+
+            resp.aiter_bytes = mock_aiter_bytes
+
+            mock_stream.return_value.__aenter__.return_value = resp
 
             await fetch_url_safely(f"http://{target_hostname}:8080/data")
 
-            args, kwargs = mock_get.call_args
-            requested_url = str(args[0])
+            args, kwargs = mock_stream.call_args
+            requested_url = str(args[1])
             assert requested_url == f"http://[{safe_ip}]:8080/data"
             assert kwargs["headers"]["Host"] == target_hostname
             assert kwargs["extensions"]["sni_hostname"] == target_hostname
+
+    async def test_fetch_url_safely_max_size_content_length(self, monkeypatch):
+        """Verify fetch_url_safely rejects files larger than max_size based on Content-Length."""
+        from unittest.mock import MagicMock, patch
+
+        import httpx
+
+        from better_telegram_mcp.backends.security import (
+            SecurityError,
+            fetch_url_safely,
+        )
+
+        target_hostname = "example.com"
+        safe_ip = "93.184.216.34"
+
+        def mock_getaddrinfo(host, port, *args, **kwargs):
+            return [(socket.AF_INET, 1, 6, "", (safe_ip, 80, 0, 0))]
+
+        monkeypatch.setattr("socket.getaddrinfo", mock_getaddrinfo)
+
+        with patch("httpx.AsyncClient.stream", new_callable=MagicMock) as mock_stream:
+            resp = httpx.Response(200, headers={"Content-Length": "101"})
+            resp._request = httpx.Request("GET", f"http://{safe_ip}/data")
+
+            mock_stream.return_value.__aenter__.return_value = resp
+
+            import pytest
+
+            with pytest.raises(
+                SecurityError, match="File size exceeds maximum allowed"
+            ):
+                await fetch_url_safely(f"http://{target_hostname}/data", max_size=100)
+
+    async def test_fetch_url_safely_max_size_accumulated(self, monkeypatch):
+        """Verify fetch_url_safely rejects files larger than max_size based on accumulated chunks."""
+        from unittest.mock import MagicMock, patch
+
+        import httpx
+
+        from better_telegram_mcp.backends.security import (
+            SecurityError,
+            fetch_url_safely,
+        )
+
+        target_hostname = "example.com"
+        safe_ip = "93.184.216.34"
+
+        def mock_getaddrinfo(host, port, *args, **kwargs):
+            return [(socket.AF_INET, 1, 6, "", (safe_ip, 80, 0, 0))]
+
+        monkeypatch.setattr("socket.getaddrinfo", mock_getaddrinfo)
+
+        with patch("httpx.AsyncClient.stream", new_callable=MagicMock) as mock_stream:
+            resp = httpx.Response(200)
+            resp._request = httpx.Request("GET", f"http://{safe_ip}/data")
+
+            async def mock_aiter_bytes(chunk_size=None):
+                yield b"chunk1 "
+                yield b"chunk2 "
+                yield b"chunk3"
+
+            resp.aiter_bytes = mock_aiter_bytes
+
+            mock_stream.return_value.__aenter__.return_value = resp
+
+            import pytest
+
+            # Total size is 21 bytes. Let's limit it to 10
+            with pytest.raises(
+                SecurityError, match="File size exceeds maximum allowed"
+            ):
+                await fetch_url_safely(f"http://{target_hostname}/data", max_size=10)
 
 
 class TestValidateFilePath:


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** `fetch_url_safely` fetched user-supplied URLs using `httpx.AsyncClient.get()`, causing the entire HTTP response body to be buffered into memory at once.
🎯 **Impact:** If an attacker supplied a link to a very large file or a never-ending response stream, it could exhaust the system memory, resulting in an Out-Of-Memory (OOM) application crash and a Denial of Service (DoS).
🔧 **Fix:** Refactored the method to use `httpx.stream` and iterating through the stream using `aiter_bytes()`. Enforced a strict maximum file size default of 50MB to safely reject oversized requests. An early limit check was also added based on the `Content-Length` header if it's available. Both checks throw a `SecurityError`. A `ValueError` exception handler was added in case the `Content-Length` header contains a malformed string.
✅ **Verification:** Verified fix through rigorous test assertions in `tests/test_backends/test_security.py` that validated early `Content-Length` rejection, as well as chunk-by-chunk accumulation rejection. Checked that URL rebinding protections remained unaffected.

---
*PR created automatically by Jules for task [17809335101972485171](https://jules.google.com/task/17809335101972485171) started by @n24q02m*