### PR TITLE
🎨 Palette: Add `aria-pressed` state to password visibility toggles

### DIFF
--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -437,7 +437,7 @@ def render_telegram_credential_form(
                                 inputmode="text"{bot_token_value_attr}
                                 aria-describedby="help-bot-token status-box"{bot_token_required}
                             />
-                            <button type="button" class="password-toggle" id="toggle-bot-token" aria-label="Show bot token" aria-controls="field-TELEGRAM_BOT_TOKEN">Show</button>
+                            <button type="button" class="password-toggle" id="toggle-bot-token" aria-label="Show bot token" aria-controls="field-TELEGRAM_BOT_TOKEN" aria-pressed="false">Show</button>
                         </div>
                         <p id="help-bot-token" class="help-text">
                             <a href="https://core.telegram.org/bots#botfather" target="_blank" rel="noopener noreferrer">Get from @BotFather on Telegram</a>
@@ -493,10 +493,12 @@ def render_telegram_credential_form(
                         inputEl.type = "text";
                         toggleBtn.textContent = "Hide";
                         toggleBtn.setAttribute("aria-label", "Hide " + labelBase);
+                        toggleBtn.setAttribute("aria-pressed", "true");
                     }} else {{
                         inputEl.type = "password";
                         toggleBtn.textContent = "Show";
                         toggleBtn.setAttribute("aria-label", "Show " + labelBase);
+                        toggleBtn.setAttribute("aria-pressed", "false");
                     }}
                 }});
             }}
@@ -661,6 +663,7 @@ def render_telegram_credential_form(
                     toggleBtn.textContent = "Show";
                     toggleBtn.setAttribute("aria-label", "Show password");
                     toggleBtn.setAttribute("aria-controls", "step-input");
+                    toggleBtn.setAttribute("aria-pressed", "false");
                     toggleBtn.style.display = "none";
                     setupPasswordToggle(inputEl, toggleBtn, "password");
 

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.13.0b1"
+version = "4.13.0b2"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
💡 What: Added the `aria-pressed` ARIA attribute to the "Show/Hide" toggle buttons for password inputs within the telegram credential form. The attribute dynamically updates to `"true"` when the text is visible ("Hide" mode) and `"false"` when obscured ("Show" mode).
🎯 Why: Enhances accessibility for screen reader users by programmatically exposing the toggle's binary state, making it clear whether the obscured information is currently revealed or hidden without relying solely on visual cues or text content changes.
♿ Accessibility: Addresses a missing ARIA attribute on state-toggling buttons, improving compliance with W3C patterns for toggle buttons.

---
*PR created automatically by Jules for task [11194551268422560038](https://jules.google.com/task/11194551268422560038) started by @n24q02m*