### PR TITLE
fix: right-size CF container to basic instance and cap max_instances at 10

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -15,8 +15,8 @@
       // docker tag ... better-telegram-mcp:beta && wrangler containers push
       // better-telegram-mcp:beta, then fill <YOUR_ACCOUNT_ID>.
       "image": "registry.cloudflare.com/<YOUR_ACCOUNT_ID>/better-telegram-mcp:beta",
-      "instance_type": "standard-1",
-      "max_instances": 100
+      "instance_type": "basic",
+      "max_instances": 10
     }
   ],
   "durable_objects": {


### PR DESCRIPTION
## Summary

Container memory (GiB-second) is the dominant line on the Cloudflare bill (~95% of the total), and it is currently running well over the $10 budget. This config-only change right-sizes the container for the cloud-mode MCP workload.

## Changes (`wrangler.jsonc`, `containers[]`)

- `instance_type`: `standard-1` (4 GiB) -> `basic` (1 GiB). The cloud-mode MCP server is stateless and loads no local model, so it needs well under 1 GiB; 4 GiB was heavily over-provisioned.
- `max_instances`: `100` -> `10`. Bounds peak fan-out so a spike cannot multiply the per-instance memory cost by 100x.

## Intentionally not changed

- `sleepAfter` stays at `1h`. The Telethon OTP session lives in RAM during the auth setup flow (documented footgun in `src/worker.ts`); a shorter idle timeout would drop an in-flight OTP/2FA flow. Lowering it is out of scope.
- No application logic touched.

## Verification

- `wrangler deploy --dry-run`: config parses and the worker bundles with no schema error.
- Python CI gates (`ruff check`, `ruff format --check`, `ty check`, `pytest`): all pass.
- Worker `vitest` suite: 6/6 pass.