### PR TITLE
🎨 Palette: Refine disabled states and dynamic form labels

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -35,3 +35,11 @@
 ## 2024-07-29 - Enhancing State Change UX with Subtle Animations
 **Learning:** Instantaneous layout shifts or state changes (e.g., switching between tabs or dynamically surfacing complex multi-step forms) can feel jarring or unpolished, potentially increasing cognitive load as users mentally trace the new UI structure. Subtle animations, such as a quick fade-in with a slight downward translation (`translateY`), soften these transitions, providing a much smoother, higher-quality interaction.
 **Action:** Apply lightweight, short-duration CSS `@keyframes` animations (e.g., `<0.3s`) to significant DOM additions or view transitions, particularly when toggling `.active` panel states or appending new user prompts.
+
+## 2026-06-21 - Prevent Hover Styles on Disabled Interactive Elements
+**Learning:** Applying `:hover` styles universally to interactive elements like buttons and tabs creates confusing visual feedback when those elements are `disabled`. Users may interpret the hover effect as an indication that the element is clickable, leading to frustration.
+**Action:** When styling `:hover` states, always use the `:not(:disabled):hover` pseudo-class (or equivalent) to ensure interactive styling is only applied to active elements. Additionally, explicitly style `:disabled` states (e.g. `opacity: 0.5; cursor: not-allowed;`) to make the disabled status visually unambiguous.
+
+## 2026-06-21 - Prefer Native Labels over ARIA for Dynamic Prompts
+**Learning:** Using a generic `<p>` tag combined with `aria-labelledby` on an input for dynamic forms (like multi-step OTP prompts) provides accessible names to screen readers but misses a key physical usability benefit. A semantic `<label>` properly associated with an input using the `for`/`id` relationship increases the clickable/tap area, allowing users to click the text prompt itself to focus the input field.
+**Action:** When dynamically generating form elements in JavaScript, always prefer creating a `<label>` element and setting its `for` attribute to the input's `id` instead of relying on `aria-labelledby` with generic block elements.

--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -172,7 +172,7 @@ def render_telegram_credential_form(
             font-family: inherit;
         }}
 
-        .tab:hover {{
+        .tab:not(:disabled):hover {{
             color: #ccc;
         }}
 
@@ -258,9 +258,14 @@ def render_telegram_credential_form(
             font-family: inherit;
         }}
 
-        .password-toggle:hover {{
+        .password-toggle:not(:disabled):hover {{
             color: #ccc;
             background-color: rgba(255, 255, 255, 0.05);
+        }}
+
+        .password-toggle:disabled {{
+            cursor: not-allowed;
+            opacity: 0.5;
         }}
 
         .password-toggle:focus-visible {{
@@ -346,7 +351,7 @@ def render_telegram_credential_form(
             font-family: inherit;
         }}
 
-        .submit-btn:hover {{
+        .submit-btn:not(:disabled):hover {{
             background-color: #5a7fb5;
         }}
 
@@ -645,8 +650,9 @@ def render_telegram_credential_form(
                     container = document.createElement("div");
                     container.id = "step-container";
 
-                    promptEl = document.createElement("p");
+                    promptEl = document.createElement("label");
                     promptEl.id = "step-prompt";
+                    promptEl.setAttribute("for", "step-input");
                     promptEl.className = "form-title";
                     container.appendChild(promptEl);
 
@@ -664,7 +670,6 @@ def render_telegram_credential_form(
                     inputEl.setAttribute("autocorrect", "off");
                     inputEl.setAttribute("autocapitalize", "off");
                     inputEl.setAttribute("spellcheck", "false");
-                    inputEl.setAttribute("aria-labelledby", "step-prompt");
                     inputEl.setAttribute("aria-describedby", "step-error");
 
                     var toggleBtn = document.createElement("button");

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.13.0b2"
+version = "4.13.0b3"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
This PR introduces two micro-UX/accessibility improvements to the Telegram auth credential form:

1. **Disabled State Visual Polish:** Interactive elements (tabs, submit buttons, password toggles) no longer trigger `:hover` styling when they are `disabled`. This prevents users from confusing a disabled element for an active one. Also added an explicit `disabled` style block for the password toggle button.
2. **Semantic Dynamic Labels:** The dynamic multi-step (e.g. OTP) prompt generated by JavaScript has been upgraded from a generic `<p>` tag using `aria-labelledby` to a proper semantic `<label>` explicitly tied to the input via `for="step-input"`. This natively increases the tap target size, allowing users to click the text prompt to focus the input field.

Also updated the `palette.md` journal to record these learnings for future reference.

---
*PR created automatically by Jules for task [7746924203357547630](https://jules.google.com/task/7746924203357547630) started by @n24q02m*