### PR TITLE
fix: pin CF container max_instances to 3

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -16,7 +16,7 @@
       // better-telegram-mcp:beta, then fill <YOUR_ACCOUNT_ID>.
       "image": "registry.cloudflare.com/<YOUR_ACCOUNT_ID>/better-telegram-mcp:beta",
       "instance_type": "basic",
-      "max_instances": 10
+      "max_instances": 3
     }
   ],
   "durable_objects": {


### PR DESCRIPTION
The live CF container app (better-telegram-mcp-worker) was right-sized to max_instances=3 via API PATCH, but the committed wrangler.jsonc still declared max_instances: 10. A future `wrangler deploy` would regress the live cap back to 10.

This pins the committed config to match the live state (3). Single-number change to the containers[] entry; instance_type, image, and all other fields unchanged.

Verified live CF app: max_instances=3, image=registry.cloudflare.com/<acc>/better-telegram-mcp:beta.