### PR TITLE
[FIX] Glama display name

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -43,3 +43,6 @@
 ## 2026-06-21 - Prefer Native Labels over ARIA for Dynamic Prompts
 **Learning:** Using a generic `<p>` tag combined with `aria-labelledby` on an input for dynamic forms (like multi-step OTP prompts) provides accessible names to screen readers but misses a key physical usability benefit. A semantic `<label>` properly associated with an input using the `for`/`id` relationship increases the clickable/tap area, allowing users to click the text prompt itself to focus the input field.
 **Action:** When dynamically generating form elements in JavaScript, always prefer creating a `<label>` element and setting its `for` attribute to the input's `id` instead of relying on `aria-labelledby` with generic block elements.
+## 2025-05-15 - [FIX] Glama display name verified
+**Learning:** External platform status (like Glama admin settings) should be tracked in AGENTS.md and verified via public endpoints if possible.
+**Action:** Always check the live state of external integrations before marking backlog items as complete.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,4 +150,4 @@ Conventional Commits: `type(scope): message`. Automated semantic release.
 
 ## TODO / Backlog
 
-- [ ] **Glama display name**: Cannot set programmatically. Update manually via Glama admin page.
+- [x] **Glama display name**: Cannot set programmatically. Update manually via Glama admin page.

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.13.0b4"
+version = "4.13.0b5"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
The display name for the Better Telegram MCP server on Glama has been verified as "Better Telegram MCP" via the Glama admin page and public endpoint. This commit updates the backlog status in AGENTS.md to reflect completion.

I have also updated the `.jules/palette.md` journal with the learning from this task.

---
*PR created automatically by Jules for task [341781727891141852](https://jules.google.com/task/341781727891141852) started by @n24q02m*