### PR TITLE
[FIX] Function save_credentials is too long

### DIFF
--- a/src/better_telegram_mcp/credential_state.py
+++ b/src/better_telegram_mcp/credential_state.py
@@ -208,88 +208,62 @@ def resolve_credential_state() -> CredentialState:
     return _state
 
 
-async def save_credentials(
-    config: dict[str, str], context: dict[str, str]
+async def _save_multi_user_credentials(
+    provider, sub: str, config: dict[str, str], is_user_mode: bool
 ) -> dict | None:
-    """Persist credentials from the local OAuth form and drive Telethon auth.
-
-    Called by ``mcp_core``'s local OAuth AS when the user submits credentials
-    via the browser form. Handles both bot mode and user mode.
-
-    Bot mode: validates token (single-user persists to config.enc;
-    multi-user registers a per-sub Telethon backend), returns ``None``.
-    User mode: triggers Telethon ``send_code``, returns ``otp_required`` so
-    the form prompts for the OTP. OTP verification happens via
-    ``on_step_submitted`` (bound to ``POST /otp``).
-
-    ``context`` carries the per-authorize ``sub``. In multi-user mode (when
-    ``transports/http._start_multi_user_http`` has registered a global
-    :class:`TelegramAuthProvider`), credentials are stored per-``sub`` in
-    that provider so concurrent users get isolated Telethon sessions. In
-    single-user mode the sub is ignored and a single ``config.enc`` on the
-    host is reused (existing behaviour, ``feedback_remote_relay_multi_user_enforcement.md``
-    refuse-guard ensures this only happens on private networks).
-    """
     global _state
+    _current_sub.set(sub)
 
-    from .auth.telegram_auth_provider import get_global_provider
+    if is_user_mode:
+        _state = CredentialState.SETUP_IN_PROGRESS
+        phone = config.get("TELEGRAM_PHONE", "")
+        logger.info("Multi-user: starting OTP flow for sub={}", sub[:8])
 
-    provider = get_global_provider()
-    sub = (context or {}).get("sub")
-
-    is_user_mode = bool(config.get("TELEGRAM_PHONE")) and not config.get(
-        "TELEGRAM_BOT_TOKEN"
-    )
-
-    # ----- Multi-user branch: per-sub TelegramAuthProvider -----
-    if provider is not None and sub:
-        _current_sub.set(sub)
-
-        if is_user_mode:
-            _state = CredentialState.SETUP_IN_PROGRESS
-            phone = config.get("TELEGRAM_PHONE", "")
-            logger.info("Multi-user: starting OTP flow for sub={}", sub[:8])
-
-            try:
-                result = await provider.start_user_auth(sub, phone)
-                # Provider stores backend internally keyed by sub. Stash the
-                # phone so the OTP step can reference it.
-                _per_sub_steps[sub] = (None, phone, None)
-            except ValueError as e:
-                logger.error("Multi-user OTP start failed: {}", e)
-                return {
-                    "type": "error",
-                    "text": f"Failed to send OTP: {_sanitize_error(str(e))}",
-                }
-            else:
-                _ = result  # bearer/phone_code_hash retained inside provider
-                return {
-                    "type": "otp_required",
-                    "text": "Enter the OTP code sent to your Telegram app",
-                    "field": "otp_code",
-                    "input_type": "text",
-                }
-
-        # Bot mode (multi-user): register backend keyed by sub.
-        bot_token = config.get("TELEGRAM_BOT_TOKEN", "")
-        if not bot_token:
-            return {
-                "type": "error",
-                "text": "Either bot token or phone number is required.",
-            }
         try:
-            await provider.register_bot(sub, bot_token)
+            result = await provider.start_user_auth(sub, phone)
+            # Provider stores backend internally keyed by sub. Stash the
+            # phone so the OTP step can reference it.
+            _per_sub_steps[sub] = (None, phone, None)
         except ValueError as e:
-            logger.error("Multi-user bot registration failed: {}", e)
+            logger.error("Multi-user OTP start failed: {}", e)
             return {
                 "type": "error",
-                "text": _sanitize_error(str(e)),
+                "text": f"Failed to send OTP: {_sanitize_error(str(e))}",
             }
-        _state = CredentialState.CONFIGURED
-        logger.info("Multi-user: bot backend registered for sub={}", sub[:8])
-        return None
+        else:
+            _ = result  # bearer/phone_code_hash retained inside provider
+            return {
+                "type": "otp_required",
+                "text": "Enter the OTP code sent to your Telegram app",
+                "field": "otp_code",
+                "input_type": "text",
+            }
 
-    # ----- Single-user branch: shared config.enc (local) / KV (CF) + global backend -----
+    # Bot mode (multi-user): register backend keyed by sub.
+    bot_token = config.get("TELEGRAM_BOT_TOKEN", "")
+    if not bot_token:
+        return {
+            "type": "error",
+            "text": "Either bot token or phone number is required.",
+        }
+    try:
+        await provider.register_bot(sub, bot_token)
+    except ValueError as e:
+        logger.error("Multi-user bot registration failed: {}", e)
+        return {
+            "type": "error",
+            "text": _sanitize_error(str(e)),
+        }
+    _state = CredentialState.CONFIGURED
+    logger.info("Multi-user: bot backend registered for sub={}", sub[:8])
+    return None
+
+
+async def _save_single_user_credentials(
+    config: dict[str, str], is_user_mode: bool
+) -> dict | None:
+    global _state, _step_backend, _step_phone, _step_otp_code
+
     _write_single_user_config(config)
 
     for key, value in config.items():
@@ -308,7 +282,6 @@ async def save_credentials(
             from .config import Settings
 
             settings = Settings.from_relay_config(config)
-            global _step_backend, _step_phone, _step_otp_code
             _step_backend = UserBackend(settings)
             _step_phone = phone
             _step_otp_code = None
@@ -338,6 +311,45 @@ async def save_credentials(
             logger.warning("Backend reinit after save failed: {}", e)
 
     return None
+
+
+async def save_credentials(
+    config: dict[str, str], context: dict[str, str]
+) -> dict | None:
+    """Persist credentials from the local OAuth form and drive Telethon auth.
+
+    Called by ``mcp_core``'s local OAuth AS when the user submits credentials
+    via the browser form. Handles both bot mode and user mode.
+
+    Bot mode: validates token (single-user persists to config.enc;
+    multi-user registers a per-sub Telethon backend), returns ``None``.
+    User mode: triggers Telethon ``send_code``, returns ``otp_required`` so
+    the form prompts for the OTP. OTP verification happens via
+    ``on_step_submitted`` (bound to ``POST /otp``).
+
+    ``context`` carries the per-authorize ``sub``. In multi-user mode (when
+    ``transports/http._start_multi_user_http`` has registered a global
+    :class:`TelegramAuthProvider`), credentials are stored per-``sub`` in
+    that provider so concurrent users get isolated Telethon sessions. In
+    single-user mode the sub is ignored and a single ``config.enc`` on the
+    host is reused (existing behaviour, ``feedback_remote_relay_multi_user_enforcement.md``
+    refuse-guard ensures this only happens on private networks).
+    """
+    from .auth.telegram_auth_provider import get_global_provider
+
+    provider = get_global_provider()
+    sub = (context or {}).get("sub")
+
+    is_user_mode = bool(config.get("TELEGRAM_PHONE")) and not config.get(
+        "TELEGRAM_BOT_TOKEN"
+    )
+
+    # ----- Multi-user branch: per-sub TelegramAuthProvider -----
+    if provider is not None and sub:
+        return await _save_multi_user_credentials(provider, sub, config, is_user_mode)
+
+    # ----- Single-user branch: shared config.enc (local) / KV (CF) + global backend -----
+    return await _save_single_user_credentials(config, is_user_mode)
 
 
 def set_on_configured(callback: Callable[[], Awaitable[None]]) -> None:


### PR DESCRIPTION
The `save_credentials` function in `src/better_telegram_mcp/credential_state.py` was too long (over 120 lines) and contained complex branching logic for multi-user vs single-user modes.

I have refactored it by:
1. Extracting multi-user authentication logic into `_save_multi_user_credentials`.
2. Extracting single-user authentication logic into `_save_single_user_credentials`.
3. Updating `save_credentials` to act as a dispatcher.

Verified with full test suite (`uv run pytest`) and linting (`uv run ruff check`).

---
*PR created automatically by Jules for task [432313220009914522](https://jules.google.com/task/432313220009914522) started by @n24q02m*