### PR TITLE
[TEST] Missing Edge Case in Formatting Utils

### DIFF
--- a/src/better_telegram_mcp/utils/formatting.py
+++ b/src/better_telegram_mcp/utils/formatting.py
@@ -1,3 +1,4 @@
+import html
 import json
 from typing import Any
 
@@ -8,6 +9,13 @@ def ok(data: Any) -> str:
 
 def err(message: str) -> str:
     return json.dumps({"error": message}, ensure_ascii=False)
+
+
+def escape_html(text: str) -> str:
+    """
+    A lightweight helper for Telegram HTML formatting.
+    """
+    return html.escape(str(text))
 
 
 def safe_error(e: Exception) -> str:

--- a/tests/test_utils/test_formatting.py
+++ b/tests/test_utils/test_formatting.py
@@ -1,9 +1,31 @@
 import json
 from datetime import datetime
 
+import pytest
+
 from better_telegram_mcp.backends.base import ModeError
 from better_telegram_mcp.backends.security import SecurityError
-from better_telegram_mcp.utils.formatting import err, ok, safe_error
+from better_telegram_mcp.utils.formatting import err, escape_html, ok, safe_error
+
+
+@pytest.mark.parametrize(
+    "input_val, expected",
+    [
+        ("Hello World", "Hello World"),
+        ("", ""),
+        ("<tag>", "&lt;tag&gt;"),
+        ("A & B", "A &amp; B"),
+        ('Quote "test"', "Quote &quot;test&quot;"),
+        ("Single 'quote'", "Single &#x27;quote&#x27;"),
+        (123, "123"),
+        (1.23, "1.23"),
+        (None, "None"),
+        ([1, 2], "[1, 2]"),
+        ({"a": 1}, "{&#x27;a&#x27;: 1}"),
+    ],
+)
+def test_escape_html(input_val, expected):
+    assert escape_html(input_val) == expected
 
 
 def test_ok_basic_serialization():

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.13.0b4"
+version = "4.13.0b5"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
This PR adds a missing `escape_html` utility to `src/better_telegram_mcp/utils/formatting.py`. This utility is a lightweight wrapper around `html.escape` that ensures the input is converted to a string before escaping, allowing it to safely handle various types like `None`, integers, or collections.

Key changes:
- Added `escape_html` to `formatting.py`.
- Added a comprehensive suite of parameterized tests to `tests/test_utils/test_formatting.py` to cover normal use cases and edge cases (empty strings, special characters, various object types).
- Verified that the new tests pass and no regressions were introduced in the existing 600+ tests.
- Confirmed that the code follows the project's linting and formatting rules.

---
*PR created automatically by Jules for task [2566140681699140668](https://jules.google.com/task/2566140681699140668) started by @n24q02m*