### PR TITLE
[FIX] Sequential Session Revocation in Cleanup

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - Concurrent Session Revocation
+**Learning:** Sequential async calls for disconnecting multiple backends (e.g., Telethon clients) can cause significant delays because each disconnect involves an MTProto roundtrip. Using `asyncio.gather` reduces this latency to a single roundtrip.
+**Action:** Always use `asyncio.gather` when performing bulk operations that involve network I/O or other awaitable tasks, especially for cleanup or shutdown procedures.

--- a/src/better_telegram_mcp/auth/telegram_auth_provider.py
+++ b/src/better_telegram_mcp/auth/telegram_auth_provider.py
@@ -341,14 +341,18 @@ class TelegramAuthProvider:
 
         Returns True if the session existed.
         """
+        tasks = []
         backend = self.active_clients.pop(bearer, None)
         if backend is not None:
-            await backend.disconnect()
+            tasks.append(backend.disconnect())
 
         # Remove pending OTP if any
         pending = self._pending_otps.pop(bearer, None)
         if pending is not None:
-            await pending["backend"].disconnect()
+            tasks.append(pending["backend"].disconnect())
+
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
 
         # Remove from ownership map
         to_remove = [sid for sid, b in self.session_owners.items() if b == bearer]
@@ -384,18 +388,28 @@ class TelegramAuthProvider:
         # Since start_user_auth pops-then-reinserts each bearer, the oldest entries
         # are always at the front, so we can stop at the first non-stale entry instead
         # of scanning the full dict on every cleanup tick.
+        stale_otps = []
         while self._pending_otps:
             bearer, pending = next(iter(self._pending_otps.items()))
             if now - pending["created_at"] <= 300:
                 break
-            self._pending_otps.pop(bearer)
-            try:
-                await pending["backend"].disconnect()
-            except Exception as exc:  # pragma: no cover - best-effort cleanup
-                logger.warning(
-                    "Error disconnecting stale OTP backend {}: {}", bearer[:8], exc
-                )
-            removed += 1
+            stale_otps.append((bearer, self._pending_otps.pop(bearer)))
+
+        if stale_otps:
+
+            async def _disconnect(b: str, p: dict) -> None:
+                try:
+                    await p["backend"].disconnect()
+                except Exception as exc:  # pragma: no cover - best-effort cleanup
+                    logger.warning(
+                        "Error disconnecting stale OTP backend {}: {}", b[:8], exc
+                    )
+
+            await asyncio.gather(
+                *(_disconnect(b, p) for b, p in stale_otps),
+                return_exceptions=True,
+            )
+            removed += len(stale_otps)
 
         return removed
 

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.13.0b4"
+version = "4.13.0b5"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
The `cleanup_expired` method and `revoke_session` in `TelegramAuthProvider` were performing some async disconnections sequentially. Each Telethon disconnect can take an MTProto roundtrip, so sequential calls lead to avoidable latency.

This commit refactors these paths to use `asyncio.gather`:
- `revoke_session` now concurrently disconnects both active and pending backends for a given bearer.
- `cleanup_expired` now concurrently disconnects all stale pending OTP backends after collecting them using the early-exit optimization.

Existing tests verify that functionality remains correct, and a timing test confirmed the concurrency.

---
*PR created automatically by Jules for task [9697693910851752046](https://jules.google.com/task/9697693910851752046) started by @n24q02m*