### PR TITLE
[FIX] Missing DNS Cache in SSRF Validation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-05-22 - DNS Cache for SSRF Validation
+**Learning:** `socket.getaddrinfo` is a blocking network operation that can introduce significant latency and overhead when called frequently (e.g., during media downloads or API hits). Caching DNS results locally with a short TTL (e.g., 60s) prevents repeated network roundtrips while still allowing for IP changes.
+**Action:** Implement a thread-safe (or event-loop safe) DNS cache for security-critical URL validations. Ensure the cache can be cleared manually via backend management tools.

--- a/src/better_telegram_mcp/backends/bot_backend.py
+++ b/src/better_telegram_mcp/backends/bot_backend.py
@@ -7,7 +7,7 @@ import httpx
 
 from ..relay_setup import redact_bot_token
 from .base import TelegramBackend
-from .security import fetch_url_safely, validate_file_path
+from .security import clear_dns_cache, fetch_url_safely, validate_file_path
 
 API_BASE = "https://api.telegram.org/bot{}/"
 
@@ -89,7 +89,8 @@ class BotBackend(TelegramBackend):
         return {"message": "Bot mode does not require sign-in."}
 
     async def clear_cache(self) -> None:
-        pass  # Bot API is stateless, no cache to clear
+        # Bot API is stateless, but we clear the shared DNS cache
+        clear_dns_cache()
 
     # --- Messages ---
     async def send_message(

--- a/src/better_telegram_mcp/backends/security.py
+++ b/src/better_telegram_mcp/backends/security.py
@@ -4,12 +4,23 @@ from __future__ import annotations
 
 import ipaddress
 import socket
+import time
 from pathlib import Path
 from urllib.parse import urlparse
 
 
 class SecurityError(Exception):
     pass
+
+
+# DNS cache to avoid repeated network overhead
+_DNS_CACHE: dict[str, tuple[float, list[tuple]]] = {}
+_DNS_CACHE_TTL = 60.0  # seconds
+
+
+def clear_dns_cache() -> None:
+    """Clear the local DNS cache."""
+    _DNS_CACHE.clear()
 
 
 # Private/internal IP ranges that should not be accessed via SSRF
@@ -54,7 +65,8 @@ def _validate_ip(ip_str: str, hostname: str) -> None:
                 msg = f"Access to internal/private IP {ip_str} ({hostname}) is blocked"
                 raise SecurityError(msg)
     except ValueError as e:
-        # Handle potential zone indices in IPv6 (e.g., fe80::1%eth0)
+        # Check if it has a zone index (e.g. fe80::1%eth0) which ipaddress doesn't support
+        # but socket.getaddrinfo can return. We block all potential zone indices in IPv6
         if "%" in ip_str:
             try:
                 clean_ip = ip_str.split("%")[0]
@@ -92,6 +104,12 @@ def validate_url(url: str) -> str:
         msg = f"Access to {hostname} is blocked"
         raise SecurityError(msg)
     try:
+        now = time.monotonic()
+        if hostname in _DNS_CACHE:
+            timestamp, addr_info = _DNS_CACHE[hostname]
+            if now - timestamp < _DNS_CACHE_TTL:
+                return addr_info[0][4][0]
+
         # Get all IPs for this hostname
         addr_info = socket.getaddrinfo(hostname, None)
         for _, _, _, _, sockaddr in addr_info:
@@ -100,6 +118,8 @@ def validate_url(url: str) -> str:
         if not addr_info:
             msg = f"Failed to resolve hostname {hostname}"
             raise SecurityError(msg)
+
+        _DNS_CACHE[hostname] = (now, addr_info)
         return addr_info[0][4][0]
     except OSError as e:
         # If hostname resolution fails, deny access instead of silently passing

--- a/src/better_telegram_mcp/backends/user_backend.py
+++ b/src/better_telegram_mcp/backends/user_backend.py
@@ -17,6 +17,7 @@ from telethon.tl.types import Channel, Chat, InputPhoneContact, User
 from ..config import Settings
 from .base import TelegramBackend
 from .security import (
+    clear_dns_cache,
     fetch_url_safely,
     validate_file_path,
     validate_output_dir,
@@ -163,6 +164,7 @@ class UserBackend(TelegramBackend):
         return bool(connected)
 
     async def clear_cache(self) -> None:
+        clear_dns_cache()
         if self._client is not None and self._client.session:
             # Clear Telethon's entity cache by deleting cached entities
             try:

--- a/tests/test_backends/test_dns_cache.py
+++ b/tests/test_backends/test_dns_cache.py
@@ -1,0 +1,110 @@
+import socket
+from unittest.mock import patch
+
+import pytest
+
+from better_telegram_mcp.backends.bot_backend import BotBackend
+from better_telegram_mcp.backends.security import (
+    _DNS_CACHE,
+    clear_dns_cache,
+    validate_url,
+)
+from better_telegram_mcp.backends.user_backend import UserBackend
+from better_telegram_mcp.config import Settings
+
+
+def test_dns_cache_hits():
+    clear_dns_cache()
+    hostname = "example.com"
+    safe_ip = "93.184.216.34"
+
+    def mock_getaddrinfo(host, port, *args, **kwargs):
+        return [(socket.AF_INET, 1, 6, "", (safe_ip, 80, 0, 0))]
+
+    with patch("socket.getaddrinfo", side_effect=mock_getaddrinfo) as mock_socket:
+        # First call should hit the network
+        res1 = validate_url(f"http://{hostname}/")
+        assert res1 == safe_ip
+        assert mock_socket.call_count == 1
+
+        # Second call should hit the cache
+        res2 = validate_url(f"http://{hostname}/")
+        assert res2 == safe_ip
+        assert mock_socket.call_count == 1
+
+
+def test_dns_cache_expiration():
+    clear_dns_cache()
+    hostname = "expired.com"
+    safe_ip = "1.2.3.4"
+
+    def mock_getaddrinfo(host, port, *args, **kwargs):
+        return [(socket.AF_INET, 1, 6, "", (safe_ip, 80, 0, 0))]
+
+    with patch("socket.getaddrinfo", side_effect=mock_getaddrinfo) as mock_socket:
+        with patch("time.monotonic") as mock_time:
+            mock_time.return_value = 100.0
+
+            # First call
+            validate_url(f"http://{hostname}/")
+            assert mock_socket.call_count == 1
+
+            # Second call, still within TTL
+            mock_time.return_value = 150.0
+            validate_url(f"http://{hostname}/")
+            assert mock_socket.call_count == 1
+
+            # Third call, expired (TTL is 60.0)
+            mock_time.return_value = 220.0
+            validate_url(f"http://{hostname}/")
+            assert mock_socket.call_count == 2
+
+
+def test_clear_dns_cache():
+    clear_dns_cache()
+    hostname = "clear.com"
+    safe_ip = "5.6.7.8"
+
+    def mock_getaddrinfo(host, port, *args, **kwargs):
+        return [(socket.AF_INET, 1, 6, "", (safe_ip, 80, 0, 0))]
+
+    with patch("socket.getaddrinfo", side_effect=mock_getaddrinfo) as mock_socket:
+        validate_url(f"http://{hostname}/")
+        assert mock_socket.call_count == 1
+
+        clear_dns_cache()
+        assert len(_DNS_CACHE) == 0
+
+        validate_url(f"http://{hostname}/")
+        assert mock_socket.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_backend_clear_cache_clears_dns():
+    clear_dns_cache()
+    hostname = "backend.com"
+    safe_ip = "1.1.1.1"
+
+    def mock_getaddrinfo(host, port, *args, **kwargs):
+        return [(socket.AF_INET, 1, 6, "", (safe_ip, 80, 0, 0))]
+
+    with patch("socket.getaddrinfo", side_effect=mock_getaddrinfo) as mock_socket:
+        validate_url(f"http://{hostname}/")
+        assert mock_socket.call_count == 1
+
+        # Test BotBackend
+        bot = BotBackend("fake_token")
+        await bot.clear_cache()
+        assert len(_DNS_CACHE) == 0
+
+        validate_url(f"http://{hostname}/")
+        assert mock_socket.call_count == 2
+
+        # Test UserBackend
+        settings = Settings(api_id=123, api_hash="hash", phone="phone")
+        user = UserBackend(settings)
+        await user.clear_cache()
+        assert len(_DNS_CACHE) == 0
+
+        validate_url(f"http://{hostname}/")
+        assert mock_socket.call_count == 3

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.13.0b4"
+version = "4.13.0b5"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
This PR addresses the missing DNS cache in SSRF validation.

Key changes:
- Added `_DNS_CACHE` and `_DNS_CACHE_TTL` (60s) to `security.py`.
- Modified `validate_url` to cache and reuse DNS results.
- Added `clear_dns_cache()` function.
- Updated `BotBackend.clear_cache` and `UserBackend.clear_cache` to clear the DNS cache.
- Added comprehensive tests in `tests/test_backends/test_dns_cache.py`.
- Recorded performance learnings in `.jules/bolt.md`.

This improvement reduces network overhead and latency when the server performs frequent URL validations, while maintaining security by pinning validated IPs.

---
*PR created automatically by Jules for task [8607104636776262389](https://jules.google.com/task/8607104636776262389) started by @n24q02m*