### PR TITLE
🛡️ Sentinel: [security improvement] Use secrets module for token generation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** fetch_url_safely used httpx.AsyncClient.get which loads the entire response into memory at once, creating a risk for Denial of Service (DoS) via Out-Of-Memory (OOM) attacks if a malicious or large file is fetched.
 **Learning:** External URLs should be fetched with size limits and streaming to prevent memory exhaustion, as even validated internal IPs/URLs can return massive payloads.
 **Prevention:** Always use httpx.stream and iterate over chunks (`aiter_bytes`) while enforcing a strict `max_size` limit on the accumulated data and checking the Content-Length header.
+## 2025-02-24 - Cryptographically secure token generation
+**Vulnerability:** Use of `os.urandom(32).hex()` for secret token generation.
+**Learning:** While `os.urandom` is cryptographically secure, using the explicit `secrets` module (e.g. `secrets.token_hex(32)`) conveys a clearer security intent, is less prone to misuse, and aligns with modern Python security best practices.
+**Prevention:** Use `secrets.token_hex()` or `secrets.token_urlsafe()` instead of raw `os.urandom` where appropriate.

--- a/src/better_telegram_mcp/transports/credential_store.py
+++ b/src/better_telegram_mcp/transports/credential_store.py
@@ -5,6 +5,7 @@ is stored at: DATA_DIR/.secret with 0o600 permissions.
 """
 
 import os
+import secrets
 import stat
 from pathlib import Path
 
@@ -73,6 +74,6 @@ class CredentialStore:
         secret_path = data_dir / ".secret"
         if secret_path.exists():
             return secret_path.read_text().strip()
-        secret = os.urandom(32).hex()
+        secret = secrets.token_hex(32)
         _atomic_write_bytes_0600(secret_path, secret.encode())
         return secret


### PR DESCRIPTION
🚨 Severity: LOW / Enhancement
💡 Vulnerability: Used `os.urandom(32).hex()` for token generation. While cryptographically secure, it is less explicit and slightly more prone to errors than using the dedicated `secrets` module.
🎯 Impact: Minor security enhancement; clearer intent and aligns with Python 3.6+ best practices.
🔧 Fix: Replaced `os.urandom(32).hex()` with `secrets.token_hex(32)`.
✅ Verification: Ran unit tests and format checkers.

---
*PR created automatically by Jules for task [6061417313875176897](https://jules.google.com/task/6061417313875176897) started by @n24q02m*