### PR TITLE
🛡️ Sentinel: [Security Enhancement] Use secrets module for token generation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** fetch_url_safely used httpx.AsyncClient.get which loads the entire response into memory at once, creating a risk for Denial of Service (DoS) via Out-Of-Memory (OOM) attacks if a malicious or large file is fetched.
 **Learning:** External URLs should be fetched with size limits and streaming to prevent memory exhaustion, as even validated internal IPs/URLs can return massive payloads.
 **Prevention:** Always use httpx.stream and iterate over chunks (`aiter_bytes`) while enforcing a strict `max_size` limit on the accumulated data and checking the Content-Length header.
+## 2025-02-27 - Use secrets module for cryptographically secure random values
+**Vulnerability:** `os.urandom().hex()` was used to generate a master server secret. While technically secure via OS entropy, it lacks explicit semantic meaning for security operations and is not the recommended standard.
+**Learning:** Python's `secrets` module is the official library for generating cryptographically strong random numbers suitable for managing data such as passwords, account authentication, security tokens, and related secrets.
+**Prevention:** Always use `secrets.token_hex()` or similar functions from the `secrets` module instead of `os.urandom()` directly when generating secure credentials or tokens to explicitly convey security intent and conform to best practices.

--- a/src/better_telegram_mcp/auth/pending_otp_store.py
+++ b/src/better_telegram_mcp/auth/pending_otp_store.py
@@ -154,7 +154,10 @@ class PendingOtpStore:
             stale_bearers = []
             now = time.time()
             for bearer, entry in existing.items():
-                if isinstance(entry, dict) and now - entry.get("created_at", 0) > _OTP_TTL:
+                if (
+                    isinstance(entry, dict)
+                    and now - entry.get("created_at", 0) > _OTP_TTL
+                ):
                     stale_bearers.append(bearer)
             for bearer in stale_bearers:
                 del existing[bearer]

--- a/src/better_telegram_mcp/auth/telegram_auth_provider.py
+++ b/src/better_telegram_mcp/auth/telegram_auth_provider.py
@@ -329,9 +329,7 @@ class TelegramAuthProvider:
         # but the metadata may still be in KV. Recreate a fresh UserBackend
         # from the persisted metadata.
         if pending is None and self._pending_store is not None:
-            kv_data = self._pending_store.load_pending_otp(
-                sub=bearer, bearer=bearer
-            )
+            kv_data = self._pending_store.load_pending_otp(sub=bearer, bearer=bearer)
             if kv_data is not None:
                 phone = kv_data["phone"]
                 session_name = kv_data["session_name"]

--- a/src/better_telegram_mcp/auth/telegram_auth_provider.py
+++ b/src/better_telegram_mcp/auth/telegram_auth_provider.py
@@ -380,7 +380,8 @@ class TelegramAuthProvider:
 
         self._store.store(bearer, info)
         self.active_clients[bearer] = backend
-        logger.info("Registered user session: {}", pending["session_name"][:8])
+        session_name: str = pending["session_name"]  # type: ignore[assignment]
+        logger.info("Registered user session: {}", session_name[:8])
         return result
 
     async def revoke_session(self, bearer: str) -> bool:

--- a/src/better_telegram_mcp/transports/credential_store.py
+++ b/src/better_telegram_mcp/transports/credential_store.py
@@ -5,6 +5,7 @@ is stored at: DATA_DIR/.secret with 0o600 permissions.
 """
 
 import os
+import secrets
 import stat
 from pathlib import Path
 
@@ -73,6 +74,6 @@ class CredentialStore:
         secret_path = data_dir / ".secret"
         if secret_path.exists():
             return secret_path.read_text().strip()
-        secret = os.urandom(32).hex()
+        secret = secrets.token_hex(32)
         _atomic_write_bytes_0600(secret_path, secret.encode())
         return secret

--- a/tests/auth/test_pending_otp_store.py
+++ b/tests/auth/test_pending_otp_store.py
@@ -1,0 +1,65 @@
+import os
+
+import pytest
+from mcp_core.storage.backends import InMemoryBackend
+
+from better_telegram_mcp.auth.pending_otp_store import PendingOtpStore
+
+
+@pytest.fixture(autouse=True)
+def set_env():
+    os.environ["CREDENTIAL_SECRET"] = (
+        "0000000000000000000000000000000000000000000000000000000000000000"
+    )
+    yield
+    del os.environ["CREDENTIAL_SECRET"]
+
+
+@pytest.fixture
+def backend():
+    return InMemoryBackend()
+
+
+@pytest.fixture
+def store(backend):
+    return PendingOtpStore(backend)
+
+
+def test_store_and_load(store):
+    store.save_pending_otp(
+        "sub1",
+        "bearer1",
+        {"phone": "123", "session_name": "sess", "phone_code_hash": "hash"},
+    )
+    loaded = store.load_pending_otp("sub1", "bearer1")
+    assert loaded["phone"] == "123"
+    assert loaded["session_name"] == "sess"
+    assert loaded["phone_code_hash"] == "hash"
+    assert "created_at" in loaded
+
+
+def test_delete(store):
+    store.save_pending_otp(
+        "sub1",
+        "bearer1",
+        {"phone": "123", "session_name": "sess", "phone_code_hash": "hash"},
+    )
+    store.delete_pending_otp("sub1", "bearer1")
+    assert store.load_pending_otp("sub1", "bearer1") is None
+
+
+def test_cleanup_expired(store, monkeypatch):
+    import time
+
+    store.save_pending_otp(
+        "sub1",
+        "bearer1",
+        {"phone": "123", "session_name": "sess", "phone_code_hash": "hash"},
+    )
+
+    # Fast forward time beyond TTL
+    current_time = time.time()
+    monkeypatch.setattr(time, "time", lambda: current_time + 700)
+    store.cleanup_expired()
+
+    assert store.load_pending_otp("sub1", "bearer1") is None

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.13.0b4"
+version = "4.13.0b5"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
🚨 **Severity:** Enhancement
💡 **Vulnerability:** `os.urandom().hex()` was used to generate the master server secret. While technically secure because it relies on OS entropy, it is not the Pythonic standard for security-sensitive operations.
🎯 **Impact:** Using `os.urandom()` directly obfuscates the security intent of the code, which could lead to misunderstandings or less secure practices elsewhere in the codebase. 
🔧 **Fix:** Replaced `os.urandom(32).hex()` with `secrets.token_hex(32)` in `src/better_telegram_mcp/transports/credential_store.py`. The `secrets` module is the official library for generating cryptographically strong random numbers suitable for managing secrets, tokens, and passwords. This change improves code readability and conforms to standard security best practices.
✅ **Verification:** Verified by running the test suite (`uv run pytest`), ensuring no regressions occurred in the master secret generation and atomic file writing behaviors.

---
*PR created automatically by Jules for task [6302129165373045880](https://jules.google.com/task/6302129165373045880) started by @n24q02m*