### PR TITLE
🎨 Palette: Add active states to interactive elements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -43,3 +43,6 @@
 ## 2026-06-21 - Prefer Native Labels over ARIA for Dynamic Prompts
 **Learning:** Using a generic `<p>` tag combined with `aria-labelledby` on an input for dynamic forms (like multi-step OTP prompts) provides accessible names to screen readers but misses a key physical usability benefit. A semantic `<label>` properly associated with an input using the `for`/`id` relationship increases the clickable/tap area, allowing users to click the text prompt itself to focus the input field.
 **Action:** When dynamically generating form elements in JavaScript, always prefer creating a `<label>` element and setting its `for` attribute to the input's `id` instead of relying on `aria-labelledby` with generic block elements.
+## 2024-08-01 - Active States for Interactive Elements
+**Learning:** Adding subtle `:active` pseudo-class styles with `transform: scale()` provides tactile visual feedback for interactive elements (like buttons and tabs), making the interface feel more responsive.
+**Action:** When creating custom buttons or interactive tabs, define an `:active` state using `:not(:disabled):active` and apply a slight scale down (e.g., `transform: scale(0.98)`) and ensure `transform` is included in the element's `transition` property.

--- a/src/better_telegram_mcp/auth/telegram_auth_provider.py
+++ b/src/better_telegram_mcp/auth/telegram_auth_provider.py
@@ -388,7 +388,7 @@ class TelegramAuthProvider:
 
         self._store.store(bearer, info)
         self.active_clients[bearer] = backend
-        logger.info("Registered user session: {}", pending["session_name"][:8])
+        logger.info("Registered user session: {}", info.session_name[:8])
         return result
 
     async def revoke_session(self, bearer: str) -> bool:

--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -168,12 +168,17 @@ def render_telegram_credential_form(
             font-size: 0.9rem;
             font-weight: 500;
             border-bottom: 2px solid transparent;
-            transition: color 0.15s ease, border-color 0.15s ease;
+            transition: color 0.15s ease, border-color 0.15s ease, background-color 0.15s ease, transform 0.1s ease;
             font-family: inherit;
         }}
 
         .tab:not(:disabled):hover {{
             color: #ccc;
+        }}
+
+        .tab:not(:disabled):active {{
+            background-color: rgba(255, 255, 255, 0.03);
+            transform: scale(0.98);
         }}
 
         .tab:focus-visible {{
@@ -254,7 +259,7 @@ def render_telegram_credential_form(
             cursor: pointer;
             padding: 0.25rem 0.5rem;
             border-radius: 4px;
-            transition: color 0.15s ease, background-color 0.15s ease;
+            transition: color 0.15s ease, background-color 0.15s ease, transform 0.1s ease;
             font-family: inherit;
         }}
 
@@ -266,6 +271,10 @@ def render_telegram_credential_form(
         .password-toggle:disabled {{
             cursor: not-allowed;
             opacity: 0.5;
+        }}
+
+        .password-toggle:not(:disabled):active {{
+            transform: scale(0.96);
         }}
 
         .password-toggle:focus-visible {{
@@ -346,13 +355,17 @@ def render_telegram_credential_form(
             font-size: 0.9375rem;
             font-weight: 500;
             padding: 0.75rem 1.5rem;
-            transition: background-color 0.15s ease, opacity 0.15s ease;
+            transition: background-color 0.15s ease, opacity 0.15s ease, transform 0.1s ease;
             margin-top: 0.5rem;
             font-family: inherit;
         }}
 
         .submit-btn:not(:disabled):hover {{
             background-color: #5a7fb5;
+        }}
+
+        .submit-btn:not(:disabled):active {{
+            transform: scale(0.98);
         }}
 
         .submit-btn:focus-visible {{


### PR DESCRIPTION
Adds subtle `:active` pseudo-class states (a `transform: scale()`) to interactive elements in `credential_form.py` like the tabs, the show/hide password toggle, and the connect button. This micro-interaction provides much-needed tactile visual feedback when interacting with the form, making it feel snappier. A type check issue in `telegram_auth_provider.py` was also resolved to get tests and ty checks fully green.

---
*PR created automatically by Jules for task [11331496723235139161](https://jules.google.com/task/11331496723235139161) started by @n24q02m*