### PR TITLE
[TEST] Missing Edge Case in Formatting Utils

### DIFF
--- a/src/better_telegram_mcp/utils/formatting.py
+++ b/src/better_telegram_mcp/utils/formatting.py
@@ -1,3 +1,4 @@
+import html
 import json
 from typing import Any
 
@@ -18,3 +19,10 @@ def safe_error(e: Exception) -> str:
     if isinstance(e, (ModeError, SecurityError, ValueError, FileNotFoundError)):
         return err(str(e))
     return err(f"{type(e).__name__}: Operation failed. Check server logs for details.")
+
+
+def escape_html(text: Any) -> str:
+    """
+    A lightweight helper for Telegram HTML formatting.
+    """
+    return html.escape(str(text))

--- a/tests/test_utils/test_formatting.py
+++ b/tests/test_utils/test_formatting.py
@@ -1,9 +1,11 @@
 import json
 from datetime import datetime
 
+import pytest
+
 from better_telegram_mcp.backends.base import ModeError
 from better_telegram_mcp.backends.security import SecurityError
-from better_telegram_mcp.utils.formatting import err, ok, safe_error
+from better_telegram_mcp.utils.formatting import err, escape_html, ok, safe_error
 
 
 def test_ok_basic_serialization():
@@ -191,3 +193,22 @@ def test_ok_nested_mixed_types():
     assert parsed["nested"]["exc"] == "nested error"
     assert parsed["list"][0] == 1
     assert parsed["list"][1]["a"] == 1
+
+
+@pytest.mark.parametrize(
+    "input_val, expected",
+    [
+        ("plain text", "plain text"),
+        ("Hello <world>", "Hello &lt;world&gt;"),
+        ("Keep & Calm", "Keep &amp; Calm"),
+        ("Quotes \"and\" 'more'", "Quotes &quot;and&quot; &#x27;more&#x27;"),
+        (None, "None"),
+        ("", ""),
+        (123, "123"),
+        ({"key": "value"}, "{&#x27;key&#x27;: &#x27;value&#x27;}"),
+        ([1, 2, "<"], "[1, 2, &#x27;&lt;&#x27;]"),
+        ("😊", "😊"),
+    ],
+)
+def test_escape_html(input_val, expected):
+    assert escape_html(input_val) == expected


### PR DESCRIPTION
This PR adds the `escape_html` utility to `src/better_telegram_mcp/utils/formatting.py` to handle Telegram HTML formatting safely. It also introduces comprehensive test coverage in `tests/test_utils/test_formatting.py`, specifically addressing edge cases like `None`, empty strings, and non-string object types as requested.

---
*PR created automatically by Jules for task [5730061462808753655](https://jules.google.com/task/5730061462808753655) started by @n24q02m*