### PR TITLE
[CLEANUP] Remove unused function `_is_user_mode_config`

### DIFF
--- a/src/better_telegram_mcp/relay_setup.py
+++ b/src/better_telegram_mcp/relay_setup.py
@@ -1,7 +1,7 @@
 """Credential resolution helpers for better-telegram-mcp.
 
 Public surface used by ``credential_state``:
-- ``check_saved_sessions`` / ``_is_user_mode_config``
+- ``check_saved_sessions``
 - ``_sanitize_error`` / ``_needs_2fa_password``
 - Module-level constants (``SERVER_NAME``, ``REQUIRED_FIELDS_*`` ...).
 
@@ -110,12 +110,3 @@ def check_saved_sessions(backend=None) -> bool:
         return False
     sessions = list(data_dir.glob("*.session"))
     return len(sessions) > 0
-
-
-def _is_user_mode_config(config: dict[str, str]) -> bool:
-    """Check if config has user-mode credentials (phone number).
-
-    API ID and API Hash have built-in defaults in config.py, so only phone
-    is needed from relay to identify user mode.
-    """
-    return bool(config.get("TELEGRAM_PHONE"))

--- a/tests/test_relay_setup.py
+++ b/tests/test_relay_setup.py
@@ -8,7 +8,6 @@ import pytest
 
 from better_telegram_mcp.config import Settings
 from better_telegram_mcp.relay_setup import (
-    _is_user_mode_config,
     _needs_2fa_password,
     _sanitize_error,
     redact_bot_token,
@@ -323,32 +322,3 @@ class TestNeeds2faPassword:
     )
     def test_needs_2fa_password(self, error_msg: str, expected: bool):
         assert _needs_2fa_password(error_msg) is expected
-
-
-# --- _is_user_mode_config ---
-
-
-class TestIsUserModeConfig:
-    def test_phone_present(self):
-        config = {"TELEGRAM_PHONE": "+84912345678"}
-        assert _is_user_mode_config(config) is True
-
-    def test_full_user_config_with_phone(self):
-        config = {
-            "TELEGRAM_API_ID": "123",
-            "TELEGRAM_API_HASH": "abc",
-            "TELEGRAM_PHONE": "+84912345678",
-        }
-        assert _is_user_mode_config(config) is True
-
-    def test_missing_phone(self):
-        config = {"TELEGRAM_API_ID": "123", "TELEGRAM_API_HASH": "abc"}
-        assert _is_user_mode_config(config) is False
-
-    def test_bot_config(self):
-        config = {"TELEGRAM_BOT_TOKEN": "123:ABC"}
-        assert _is_user_mode_config(config) is False
-
-    def test_empty_phone(self):
-        config = {"TELEGRAM_PHONE": ""}
-        assert _is_user_mode_config(config) is False


### PR DESCRIPTION
This PR removes the unused internal helper function `_is_user_mode_config` from `src/better_telegram_mcp/relay_setup.py`. 

Ripgrep confirmed that the function was not used anywhere in the codebase outside of its definition and its tests. Removing it simplifies the code without affecting any functionality.

Changes:
- Removed `_is_user_mode_config` from `src/better_telegram_mcp/relay_setup.py`.
- Updated `src/better_telegram_mcp/relay_setup.py` module docstring to remove the mention of this function.
- Removed `TestIsUserModeConfig` and related imports from `tests/test_relay_setup.py`.
- Verified changes with `pytest`, `ruff`, and `ty`.

---
*PR created automatically by Jules for task [16272187038281512042](https://jules.google.com/task/16272187038281512042) started by @n24q02m*