### PR TITLE
[SECURITY] Insecure Security Downgrade via Configuration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,8 @@
 **Vulnerability:** Use of `os.urandom(32).hex()` for secret token generation.
 **Learning:** While `os.urandom` is cryptographically secure, using the explicit `secrets` module (e.g. `secrets.token_hex(32)`) conveys a clearer security intent, is less prone to misuse, and aligns with modern Python security best practices.
 **Prevention:** Use `secrets.token_hex()` or `secrets.token_urlsafe()` instead of raw `os.urandom` where appropriate.
+
+## 2025-05-22 - Insecure Security Downgrade via Configuration
+**Vulnerability:** The server allowed a `TELEGRAM_ACCEPT_SHARED_SINGLE_USER=1` override to skip safety checks when `PUBLIC_URL` was set, allowing a single shared session to be used in public deployments.
+**Learning:** Providing explicit "escape hatches" for security guards, even if opt-in, significantly increases the risk of catastrophic misconfiguration and credential leakage in multi-user environments.
+**Prevention:** Remove dangerous security overrides entirely. If a deployment mode is inherently insecure (like shared single-user on a public URL), the application should refuse to start without exception.

--- a/src/better_telegram_mcp/transports/http.py
+++ b/src/better_telegram_mcp/transports/http.py
@@ -117,16 +117,14 @@ def start_http(settings: Settings) -> None:
       fallback would serve a shared ``default.session`` + ``TELEGRAM_PHONE``
       across every visitor, which leaks credentials (the 2026-04-21
       incident). Refuse to start rather than silently ship that behaviour.
-      Override with ``TELEGRAM_ACCEPT_SHARED_SINGLE_USER=1`` iff you really
-      do own every request (e.g. a private CF Tunnel behind basic auth).
+
     """
     if _is_multi_user_mode(settings):
         _start_multi_user_http(settings)
         return
 
     public_url = os.environ.get("PUBLIC_URL")
-    override = os.environ.get("TELEGRAM_ACCEPT_SHARED_SINGLE_USER") == "1"
-    if public_url and not override:
+    if public_url:
         missing = []
         if not _dcr_secret():
             missing.append("MCP_DCR_SERVER_SECRET (legacy DCR_SERVER_SECRET)")
@@ -137,10 +135,8 @@ def start_http(settings: Settings) -> None:
             "but multi-user mode requires "
             f"{', '.join(missing)} to be set as well. Without them the server "
             "falls back to a SHARED default.session + TELEGRAM_PHONE across "
-            "every visitor, which leaks credentials. Either provide the "
-            "missing values to enable per-user OAuth 2.1, or set "
-            "TELEGRAM_ACCEPT_SHARED_SINGLE_USER=1 to explicitly opt in to "
-            "single-user behaviour (only safe on private networks)."
+            "every visitor, which leaks credentials. Please provide the "
+            "missing values to enable per-user OAuth 2.1."
         )
         raise RuntimeError(msg)
 

--- a/tests/test_transports/test_http.py
+++ b/tests/test_transports/test_http.py
@@ -353,26 +353,6 @@ class TestStartHttp:
         ):
             start_http(settings)
 
-    def test_start_http_public_url_override_allows_single_user(
-        self, settings: Settings
-    ) -> None:
-        """TELEGRAM_ACCEPT_SHARED_SINGLE_USER=1 opt-in skips the refuse-guard."""
-        env = {
-            "PUBLIC_URL": "https://mcp.example.com",
-            "TELEGRAM_ACCEPT_SHARED_SINGLE_USER": "1",
-        }
-
-        with (
-            patch.dict("os.environ", env, clear=True),
-            patch(
-                "mcp_core.transport.local_server.run_http_server",
-                new_callable=AsyncMock,
-            ) as mock_run,
-        ):
-            start_http(settings)
-
-        mock_run.assert_called_once()
-
 
 class TestPerRequestSubScope:
     """The auth_scope middleware that pins per-request sub + backend."""


### PR DESCRIPTION
Removed the TELEGRAM_ACCEPT_SHARED_SINGLE_USER=1 override in HTTP transport which allowed potential session leakage by bypassing multi-user requirements in public deployments. Updated documentation and error messages to reflect this change. Deleted the associated test case.

---
*PR created automatically by Jules for task [16682893688614218044](https://jules.google.com/task/16682893688614218044) started by @n24q02m*