### PR TITLE
[CLEANUP] Unused function `_normalize_for_prefix_check`

### DIFF
--- a/src/better_telegram_mcp/backends/security.py
+++ b/src/better_telegram_mcp/backends/security.py
@@ -108,20 +108,6 @@ def validate_url(url: str) -> str:
         raise SecurityError(msg) from e
 
 
-def _normalize_for_prefix_check(path: Path) -> str:
-    """Return a forward-slash path string suitable for blocked-prefix matching.
-
-    Handles the macOS firmlink quirk where `/etc`, `/var`, `/tmp` resolve to
-    `/private/etc`, `/private/var`, `/private/tmp`. We strip a leading `/private`
-    so the same blocklist works identically on Linux and macOS.
-    """
-    path_str = str(path).replace("\\", "/")
-    if path_str.startswith("/private/"):
-        # /private/etc -> /etc, /private/var -> /var, /private/tmp -> /tmp
-        path_str = path_str[len("/private") :]
-    return path_str if path_str.endswith("/") else path_str + "/"
-
-
 def _is_under_blocked_prefix(
     resolved: Path, lexical: Path, prefixes: tuple[str, ...]
 ) -> str | None:

--- a/tests/test_backends/test_security.py
+++ b/tests/test_backends/test_security.py
@@ -5,13 +5,11 @@ from __future__ import annotations
 import os
 import socket
 import sys
-from pathlib import Path
 
 import pytest
 
 from better_telegram_mcp.backends.security import (
     SecurityError,
-    _normalize_for_prefix_check,
     validate_file_path,
     validate_output_dir,
     validate_url,
@@ -319,14 +317,6 @@ class TestValidateFilePath:
         photo = tmp_path / "photo.jpg"
         result = validate_file_path(str(photo))
         assert result == photo.resolve()
-
-    def test_macos_firmlink_normalization(self):
-        """Verify _normalize_for_prefix_check handles /private prefix."""
-        # This covers the line 77 coverage gap
-        assert (
-            _normalize_for_prefix_check(Path("/private/etc/passwd")) == "/etc/passwd/"
-        )
-        assert _normalize_for_prefix_check(Path("/etc/passwd")) == "/etc/passwd/"
 
     @pytest.mark.skipif(_IS_WINDOWS, reason="Unix-only blocked paths")
     def test_etc_passwd_blocked(self):


### PR DESCRIPTION
This PR removes the `_normalize_for_prefix_check` function from `src/better_telegram_mcp/backends/security.py` as it is no longer used. Its purpose (handling macOS `/private` prefix) is now handled more robustly by `_is_under_blocked_prefix` using `Path.resolve()` and `Path.is_relative_to()`. Corresponding tests in `tests/test_backends/test_security.py` have also been removed.

---
*PR created automatically by Jules for task [3656122543414079208](https://jules.google.com/task/3656122543414079208) started by @n24q02m*