### PR TITLE
[FIX] Glama display name documentation cleanup

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-06-29 - Documentation Maintenance
+**Learning:** Redundant "TODO" items that describe external, unresolvable limitations should be removed to maintain a clean backlog. The limitation remains documented in the descriptive "Architecture" section for future reference.
+**Action:** Prune redundant documentation markers once the underlying fact is properly explained in the descriptive sections of AGENTS.md.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,7 +147,3 @@ Conventional Commits: `type(scope): message`. Automated semantic release.
 - **Session persistence**: `~/.better-telegram-mcp/<name>.session` for Telethon (MTProto)
 - **Auth flow**: HTTP mode only. User-account auth runs through the relay credential form (phone -> OTP -> optional 2FA password) served by mcp-core's local OAuth AS; there is no terminal auth CLI or `config` auth action. Bot mode needs only `TELEGRAM_BOT_TOKEN`
 - **Glama integration**: The display name cannot be set programmatically and must be updated manually via the Glama admin page. Although 'server.json' contains a 'title' property, it does not control the external Glama listing. The 'glama.json' file is used exclusively for ownership claiming via the 'maintainers' array.
-
-## TODO / Backlog
-
-- [ ] **Glama display name**: Cannot set programmatically. Update manually via Glama admin page.


### PR DESCRIPTION
This PR removes a redundant "TODO / Backlog" item from `AGENTS.md` regarding the Glama display name.

The issue was documented as:
`- [ ] **Glama display name**: Cannot set programmatically. Update manually via Glama admin page.`

However, this exact limitation is already definitively explained in the "Architecture" section under "Glama integration":
> "**Glama integration**: The display name cannot be set programmatically and must be updated manually via the Glama admin page. Although 'server.json' contains a 'title' property, it does not control the external Glama listing. The 'glama.json' file is used exclusively for ownership claiming via the 'maintainers' array."

Since the limitation is external and correctly documented as a known fact, the TODO item is redundant. Removing it improves document clarity and maintains an actionable backlog.

Verification:
- Manually inspected `AGENTS.md` to ensure the section was removed.
- Ran `uv run ruff check .` and `uv run ty check` to ensure no regressions.
- Updated `.jules/bolt.md` with the maintenance learning.

---
*PR created automatically by Jules for task [15193356820743429464](https://jules.google.com/task/15193356820743429464) started by @n24q02m*