### PR TITLE
[FIX] N+1 Query in KvSessionStore.load_all()

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-06-29 - Parallelizing N+1 KV Store Queries
+**Learning:** Sequential KV reads involving CPU-heavy PBKDF2 key derivations (600k iterations) are a major bottleneck in load_all operations. Parallelization via ThreadPoolExecutor effectively overlaps network I/O and utilizes multiple cores for cryptography.
+**Action:** Always prefer parallelizing independent KV operations when bulk APIs are unavailable and cryptographic operations are involved.

--- a/src/better_telegram_mcp/auth/kv_session_store.py
+++ b/src/better_telegram_mcp/auth/kv_session_store.py
@@ -88,14 +88,25 @@ class KvSessionStore:
         return SessionInfo.from_dict(data)
 
     def load_all(self) -> dict[str, SessionInfo]:
-        """Load all stored sessions from the index."""
+        """Load all stored sessions from the index in parallel.
+
+        Addresses the N+1 slowness caused by individual KV reads and heavy
+        PBKDF2 key derivation (600k iterations) for each session.
+        """
         subs = self._load_index()
-        result: dict[str, SessionInfo] = {}
-        for sub in subs:
-            info = self.load(sub)
-            if info is not None:
-                result[sub] = info
-        return result
+        if not subs:
+            return {}
+
+        from concurrent.futures import ThreadPoolExecutor
+
+        # Parallelize to overlap KV I/O and utilize multiple cores for PBKDF2.
+        # cryptography releases the GIL during PBKDF2HMAC.derive().
+        with ThreadPoolExecutor() as executor:
+            infos = list(executor.map(self.load, subs))
+
+        return {
+            sub: info for sub, info in zip(subs, infos, strict=True) if info is not None
+        }
 
     def delete(self, bearer: str) -> bool:
         """Delete session for bearer. Returns True if it existed."""

--- a/tests/auth/test_kv_session_store_parallel.py
+++ b/tests/auth/test_kv_session_store_parallel.py
@@ -1,14 +1,18 @@
 import pytest
 from mcp_core.storage.backends import InMemoryBackend
+
 from better_telegram_mcp.auth.in_memory_session_store import SessionInfo
 from better_telegram_mcp.auth.kv_session_store import KvSessionStore
+
 
 def _info(name: str) -> SessionInfo:
     return SessionInfo(session_name=name, mode="user", phone="+1")
 
+
 @pytest.fixture(autouse=True)
 def _patch_credential_secret(monkeypatch):
     monkeypatch.setenv("CREDENTIAL_SECRET", "test-secret-32-bytes-padded-here!")
+
 
 def test_load_all_many_sessions_parallel():
     """Verify that load_all works correctly with many sessions.
@@ -28,10 +32,12 @@ def test_load_all_many_sessions_parallel():
         assert sub in all_sessions
         assert all_sessions[sub].session_name == f"sess-{sub}"
 
+
 def test_load_all_empty():
     backend = InMemoryBackend()
     store = KvSessionStore(backend=backend)
     assert store.load_all() == {}
+
 
 def test_load_all_handles_missing_data():
     """Verify load_all skips subs that exist in index but not in storage."""

--- a/tests/auth/test_kv_session_store_parallel.py
+++ b/tests/auth/test_kv_session_store_parallel.py
@@ -1,0 +1,52 @@
+import pytest
+from mcp_core.storage.backends import InMemoryBackend
+from better_telegram_mcp.auth.in_memory_session_store import SessionInfo
+from better_telegram_mcp.auth.kv_session_store import KvSessionStore
+
+def _info(name: str) -> SessionInfo:
+    return SessionInfo(session_name=name, mode="user", phone="+1")
+
+@pytest.fixture(autouse=True)
+def _patch_credential_secret(monkeypatch):
+    monkeypatch.setenv("CREDENTIAL_SECRET", "test-secret-32-bytes-padded-here!")
+
+def test_load_all_many_sessions_parallel():
+    """Verify that load_all works correctly with many sessions.
+    This test will exercise the parallel implementation once applied.
+    """
+    backend = InMemoryBackend()
+    store = KvSessionStore(backend=backend)
+
+    num_sessions = 5
+    subs = [f"sub-{i}" for i in range(num_sessions)]
+    for sub in subs:
+        store.store(sub, _info(f"sess-{sub}"))
+
+    all_sessions = store.load_all()
+    assert len(all_sessions) == num_sessions
+    for sub in subs:
+        assert sub in all_sessions
+        assert all_sessions[sub].session_name == f"sess-{sub}"
+
+def test_load_all_empty():
+    backend = InMemoryBackend()
+    store = KvSessionStore(backend=backend)
+    assert store.load_all() == {}
+
+def test_load_all_handles_missing_data():
+    """Verify load_all skips subs that exist in index but not in storage."""
+    backend = InMemoryBackend()
+    store = KvSessionStore(backend=backend)
+
+    store.store("sub-1", _info("sess-1"))
+    store.store("sub-2", _info("sess-2"))
+
+    # Manually corrupt the index or delete one sub without updating index
+    # (delete sub-2 directly from backend)
+    # The key format is "telegram/subs/sub-2/session_meta"
+    backend.delete("telegram/subs/sub-2/session_meta")
+
+    all_sessions = store.load_all()
+    assert "sub-1" in all_sessions
+    assert "sub-2" not in all_sessions
+    assert len(all_sessions) == 1


### PR DESCRIPTION
Optimized KvSessionStore.load_all() by parallelizing individual session loads using ThreadPoolExecutor. This addresses the slowness caused by sequential KV reads and heavy PBKDF2 key derivations (600,000 iterations) for each session. Added tests/auth/test_kv_session_store_parallel.py for verification.

---
*PR created automatically by Jules for task [9834865398646135539](https://jules.google.com/task/9834865398646135539) started by @n24q02m*