### PR TITLE
fix: route OAuth /token refresh to sub DO (avoid max_instances=1 deadlock)

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -105,7 +105,7 @@ export default {
     // registry below; unit tests call the handler directly via the exported
     // TelegramContainer.outboundByHost.
     if (env.TELEGRAM) {
-      const userId = extractUserId(request)
+      const userId = await extractUserId(request)
       const stub = env.TELEGRAM.get(env.TELEGRAM.idFromName(userId))
       return stub.fetch(request)
     }
@@ -113,7 +113,7 @@ export default {
   },
 }
 
-function extractUserId(request: Request): string {
+async function extractUserId(request: Request): Promise<string> {
   // JWT sub from the Bearer token (verified by mcp-core OAuth middleware in the
   // container). SINGLE-USER CONTRACT (E.2): no token or no `sub` -> the reserved
   // id "default", so setup and serving collapse onto ONE Durable Object id and
@@ -121,13 +121,37 @@ function extractUserId(request: Request): string {
   // their own isolated DO (multi-user). Downstream servers MUST keep this.
   const auth = request.headers.get('authorization') ?? ''
   const m = auth.match(/^Bearer\s+(.+)$/)
-  if (!m) return 'default'
-  try {
-    const payload = JSON.parse(atob(m[1].split('.')[1] ?? ''))
-    return typeof payload.sub === 'string' ? payload.sub : 'default'
-  } catch {
-    return 'default'
+  if (m) {
+    try {
+      const payload = JSON.parse(atob(m[1].split('.')[1] ?? ''))
+      if (typeof payload.sub === 'string') return payload.sub
+    } catch {
+      /* fall through to the OAuth /token + default handling below */
+    }
   }
+  // OAuth `POST /token` (grant_type=refresh_token) carries NO Bearer header, so
+  // it would route to "default". But the refresh_token IS a self-contained JWT
+  // with `sub`, and refresh rotation is stateless (any warm container can
+  // verify+rotate it). Route it to that sub's already-warm DO instead of
+  // "default" so a refresh while the sub container is warm does NOT need to spawn
+  // a second container -- under max_instances=1 that spawn fails ("max running
+  // container instances exceeded" -> 500 -> refresh fails -> server unusable).
+  // Read the body off a CLONE so the original (forwarded to the container) is
+  // untouched. authorization_code + /authorize + /.well-known keep "default".
+  try {
+    const url = new URL(request.url)
+    if (request.method === 'POST' && url.pathname === '/token') {
+      const form = await request.clone().formData()
+      if (form.get('grant_type') === 'refresh_token') {
+        const rt = String(form.get('refresh_token') ?? '')
+        const payload = JSON.parse(atob(rt.split('.')[1] ?? ''))
+        if (typeof payload.sub === 'string') return payload.sub
+      }
+    }
+  } catch {
+    /* malformed token/body -> fall through to default */
+  }
+  return 'default'
 }
 
 // Per-user container Durable Object. wrangler.jsonc binds TELEGRAM to this class


### PR DESCRIPTION
Mirror wet PR#1452. refresh_token JWT sub + stateless rotation -> route /token refresh to the sub's warm DO instead of 'default' (max_instances=1 deadlock). Verified pattern on wet.