### PR TITLE
⚡ Bolt: optimize KvSessionStore.load_all to run in parallel

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2025-05-15 - Concurrent Session Revocation
 **Learning:** Sequential async calls for disconnecting multiple backends (e.g., Telethon clients) can cause significant delays because each disconnect involves an MTProto roundtrip. Using `asyncio.gather` reduces this latency to a single roundtrip.
 **Action:** Always use `asyncio.gather` when performing bulk operations that involve network I/O or other awaitable tasks, especially for cleanup or shutdown procedures.
+## 2025-06-29 - Parallel KV Store Session Restoration
+**Learning:** In scenarios with multiple active users, loading all session metadata via `KvSessionStore.load_all()` sequentially introduces an N+1 query bottleneck. Because mcp-core `PerPluginStore` uses PBKDF2 derivations (which release the GIL in the `cryptography` library), this loop is highly inefficient.
+**Action:** Use `concurrent.futures.ThreadPoolExecutor.map()` alongside `zip(..., strict=True)` to parallelize independent backend load calls, drastically reducing I/O wait times and PBKDF2 bottlenecks.

--- a/src/better_telegram_mcp/auth/kv_session_store.py
+++ b/src/better_telegram_mcp/auth/kv_session_store.py
@@ -89,12 +89,18 @@ class KvSessionStore:
 
     def load_all(self) -> dict[str, SessionInfo]:
         """Load all stored sessions from the index."""
+        import concurrent.futures
+
         subs = self._load_index()
         result: dict[str, SessionInfo] = {}
-        for sub in subs:
-            info = self.load(sub)
-            if info is not None:
-                result[sub] = info
+
+        # ⚡ Bolt: Execute N+1 KV store I/O and PBKDF2 derivations in parallel.
+        # This speeds up load_all by avoiding sequential bottleneck.
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            infos = executor.map(self.load, subs)
+            for sub, info in zip(subs, infos, strict=True):
+                if info is not None:
+                    result[sub] = info
         return result
 
     def delete(self, bearer: str) -> bool:


### PR DESCRIPTION
💡 What: Replaced a sequential `for` loop in `KvSessionStore.load_all()` with a parallel `ThreadPoolExecutor.map()` to process `self.load()` concurrently. Also added a `.jules/bolt.md` learning entry.

🎯 Why: In deployments with many active users, loading all session metadata sequentially is extremely slow. `self.load()` involves fetching from the KV store and performing a PBKDF2 derivation (600,000 iterations). Because the `cryptography` library releases the Python GIL during this derivation, using threads allows the work to be heavily parallelized.

📊 Impact: Reduces N+1 sequential blocking to a parallel operation bounded by available CPU cores and network concurrency. Should drastically reduce initialization time in multi-user environments.

🔬 Measurement: Run a test suite with 100+ concurrent sessions. Time `load_all` sequentially vs in parallel. The parallel method should execute in O(1) batch time relative to thread limits, rather than strict O(N).

---
*PR created automatically by Jules for task [13918691726191054250](https://jules.google.com/task/13918691726191054250) started by @n24q02m*