### PR TITLE
🎨 Palette: Add prefers-reduced-motion CSS media query

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -46,3 +46,6 @@
 ## 2024-08-01 - Active States for Interactive Elements
 **Learning:** Adding subtle `:active` pseudo-class styles with `transform: scale()` provides tactile visual feedback for interactive elements (like buttons and tabs), making the interface feel more responsive.
 **Action:** When creating custom buttons or interactive tabs, define an `:active` state using `:not(:disabled):active` and apply a slight scale down (e.g., `transform: scale(0.98)`) and ensure `transform` is included in the element's `transition` property.
+## 2024-08-05 - Reduced Motion Accessibility
+**Learning:** Animations and transitions can be uncomfortable or inaccessible for users with vestibular disorders or motion sensitivities. Relying solely on CSS transitions and keyframes without respecting the operating system's reduced motion settings is a widespread accessibility failure.
+**Action:** Always include a `@media (prefers-reduced-motion: reduce)` block in custom CSS to globally neutralize animations (e.g., setting `animation-duration: 0.01ms !important; transition-duration: 0.01ms !important;`) for environments where users have requested reduced motion.

--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -429,6 +429,17 @@ def render_telegram_credential_form(
             border: 1px solid rgba(74, 111, 165, 0.3);
             color: #6c9bd2;
         }}
+
+        @media (prefers-reduced-motion: reduce) {{
+            *,
+            *::before,
+            *::after {{
+                animation-duration: 0.01ms !important;
+                animation-iteration-count: 1 !important;
+                transition-duration: 0.01ms !important;
+                scroll-behavior: auto !important;
+            }}
+        }}
     </style>
 </head>
 <body>

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.13.0b5"
+version = "4.13.0b6"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
Added `@media (prefers-reduced-motion: reduce)` media query to `credential_form.py` CSS to disable animations and transitions, respecting OS-level reduced motion accessibility settings.

---
*PR created automatically by Jules for task [4986988681517291052](https://jules.google.com/task/4986988681517291052) started by @n24q02m*