### PR TITLE
⚡ Bolt: Parallelize KvSessionStore load_all to resolve N+1 bottleneck

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2025-05-15 - Concurrent Session Revocation
 **Learning:** Sequential async calls for disconnecting multiple backends (e.g., Telethon clients) can cause significant delays because each disconnect involves an MTProto roundtrip. Using `asyncio.gather` reduces this latency to a single roundtrip.
 **Action:** Always use `asyncio.gather` when performing bulk operations that involve network I/O or other awaitable tasks, especially for cleanup or shutdown procedures.
+## 2025-06-30 - Parallel KV Session Store Loading
+**Learning:** `load_all` on a credential backend with individual `load()` operations suffers from an N+1 query bottleneck. Since the underlying PBKDF2 key derivations using the `cryptography` library release the GIL, thread pools provide significant speedups even in Python, overlapping both I/O and heavy crypto compute.
+**Action:** Parallelize bulk load operations over single-item APIs using `ThreadPoolExecutor.map()` to avoid sequential blocking. Combine results with `zip(..., strict=True)`.

--- a/src/better_telegram_mcp/auth/kv_session_store.py
+++ b/src/better_telegram_mcp/auth/kv_session_store.py
@@ -9,6 +9,7 @@ is ephemeral on Cloudflare containers.
 
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING
 
 from mcp_core.storage.per_plugin_store import PerPluginStore
@@ -88,13 +89,22 @@ class KvSessionStore:
         return SessionInfo.from_dict(data)
 
     def load_all(self) -> dict[str, SessionInfo]:
-        """Load all stored sessions from the index."""
+        """Load all stored sessions from the index.
+
+        Optimized to parallelize individual `load()` calls across all session subjects.
+        This resolves an N+1 query bottleneck and overlaps KV store I/O and
+        heavy PBKDF2 key derivations, as cryptography releases the GIL.
+        """
         subs = self._load_index()
         result: dict[str, SessionInfo] = {}
-        for sub in subs:
-            info = self.load(sub)
+
+        with ThreadPoolExecutor() as executor:
+            infos = executor.map(self.load, subs)
+
+        for sub, info in zip(subs, infos, strict=True):
             if info is not None:
                 result[sub] = info
+
         return result
 
     def delete(self, bearer: str) -> bool:

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.13.0b6"
+version = "4.13.0b7"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
💡 What: Parallelized the `KvSessionStore.load_all` method to use `ThreadPoolExecutor.map()` for concurrent individual `load()` calls across all session subjects.
🎯 Why: Resolves an N+1 query bottleneck. Because `self.load()` relies on `cryptography`'s PBKDF2 derivations (which release the Python GIL) and underlying KV I/O, sequential calls resulted in significant latency.
📊 Impact: Expected to significantly reduce total load time for multiple sessions by overlapping KV store I/O and heavy crypto computations.
🔬 Measurement: Verify improvement by benchmarking `KvSessionStore.load_all` with multiple mock sessions stored.

---
*PR created automatically by Jules for task [14610029332500464774](https://jules.google.com/task/14610029332500464774) started by @n24q02m*