### PR TITLE
fix: align modes-overview link and tool count with current two-transport model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,7 @@ src/better_telegram_mcp/
     base.py                   # TelegramBackend ABC
     bot_backend.py            # httpx -> Telegram Bot API
     user_backend.py           # Telethon MTProto client
-  tools/                      # 6 mega-tools (action dispatch)
+  tools/                      # 7 tools: 6 domain mega-tools (action dispatch) + config__open_relay
     messages.py               # send, edit, delete, forward, pin, search
     chats.py                  # info, create, join, leave, settings
     media.py                  # send photo/file/voice/video, download

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ in the environment.
 Full docs at **[mcp.n24q02m.com/servers/better-telegram-mcp/setup/](https://mcp.n24q02m.com/servers/better-telegram-mcp/setup/)**:
 
 - [Setup](https://mcp.n24q02m.com/servers/better-telegram-mcp/setup/) -- install methods for Claude Code, Codex, Gemini CLI, Cursor, Windsurf, mcp.json
-- [Modes overview](https://mcp.n24q02m.com/get-started/modes-overview/) -- stdio / local-relay / remote-relay / remote-oauth
+- [Modes overview](https://mcp.n24q02m.com/get-started/modes-overview/) -- stdio (local, bot mode) and HTTP (remote, OAuth 2.1)
 - [Multi-user setup](https://mcp.n24q02m.com/get-started/multi-user/) -- per-JWT-sub credential model
 
 **Install with AI agent** -- paste this to your AI coding agent:


### PR DESCRIPTION
## What

Align two stale documentation references with the current architecture.

### 1. Modes-overview link text (README §Documentation)
The link still advertised the removed 4-mode taxonomy `stdio / local-relay / remote-relay / remote-oauth`. The real architecture (README §Status + `CLAUDE.md`) is two clean transports: stdio (local) and HTTP (remote, OAuth 2.1). Updated the link text to `stdio (local, bot mode) and HTTP (remote, OAuth 2.1)`, matching the sibling notion/email READMEs.

### 2. Tool count in AGENTS.md
`AGENTS.md` File Organization annotated `tools/` as "6 mega-tools", while line 146 of the same file and the README/CLAUDE say 7 tools. Verified against `src/better_telegram_mcp/server.py`: 6 `@mcp.tool` domain mega-tools (message, chat, media, contact, config, help) + `config__open_relay` (registered via mcp-core) = **7 tools**. Updated the annotation to "7 tools: 6 domain mega-tools (action dispatch) + config__open_relay" so it stays consistent with the 6-file listing directly below it.

Docs-only change.