### PR TITLE
fix: use placeholders for PUBLIC_URL and routes in wrangler.jsonc (BYO-generic)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ mcp-name: io.github.n24q02m/better-telegram-mcp
 - [Comparison](#comparison)
 - [Security](#security)
 - [Build from Source](#build-from-source)
+- [Deploy to Cloudflare](#deploy-to-cloudflare)
 - [Trust Model](#trust-model)
 - [License](#license)
 
@@ -204,6 +205,46 @@ cd better-telegram-mcp
 uv sync
 uv run better-telegram-mcp
 ```
+
+## Deploy to Cloudflare
+
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/n24q02m/better-telegram-mcp)
+
+Run your own multi-user better-telegram-mcp serverless on Cloudflare (Worker + Container + KV).
+
+**Prerequisites:** a Cloudflare account on the Workers Paid plan and the `wrangler` CLI.
+
+1. `git clone https://github.com/n24q02m/better-telegram-mcp && cd better-telegram-mcp`
+2. `wrangler login`
+3. Provision the KV namespace and paste its id into `wrangler.jsonc`:
+   ```
+   wrangler kv namespace create better-telegram-kv
+   ```
+4. Push the container image to your Cloudflare managed registry (CF Containers cannot
+   pull from external registries directly), then set `<YOUR_ACCOUNT_ID>` in `wrangler.jsonc`:
+   ```
+   docker pull ghcr.io/n24q02m/better-telegram-mcp:beta
+   docker tag ghcr.io/n24q02m/better-telegram-mcp:beta better-telegram-mcp:beta
+   wrangler containers push better-telegram-mcp:beta   # prints registry.cloudflare.com/<ACCOUNT_ID>/better-telegram-mcp:beta
+   ```
+5. Set `<YOUR_PUBLIC_URL>` (e.g. `https://telegram.example.com`) and `<YOUR_WORKER_DOMAIN>`
+   (e.g. `telegram.example.com`) in `wrangler.jsonc`, then set secrets:
+   ```
+   wrangler secret put CREDENTIAL_SECRET
+   wrangler secret put MCP_RELAY_PASSWORD
+   wrangler secret put MCP_DCR_SERVER_SECRET
+   ```
+   `CREDENTIAL_SECRET` is REQUIRED: it derives a deterministic OAuth signing key so
+   user identity survives container recreation. `MCP_RELAY_PASSWORD` gates the browser
+   setup form (Gate A shared front door); `MCP_DCR_SERVER_SECRET` (32+ random bytes)
+   marks the deploy as intentionally multi-user.
+6. `wrangler deploy`, then complete setup in the browser relay form at your Worker domain --
+   each user enters their own bot token or phone + OTP there, so no per-user Telegram
+   credentials live on the Worker.
+
+Storage maps to Cloudflare via `MCP_STORAGE_BACKEND=cf-kv` (the encrypted setup config).
+Do NOT set `MCP_AUTH_DISABLE` on a shared/public deployment -- it collapses all users
+into a single credential bucket.
 
 ## Trust Model
 

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ uv run better-telegram-mcp
 
 Run your own multi-user better-telegram-mcp serverless on Cloudflare (Worker + Container + KV).
 
-**Prerequisites:** a Cloudflare account on the Workers Paid plan and the `wrangler` CLI.
+**Prerequisites:** a Cloudflare account on the **Workers Paid plan** -- required for Containers (the Cloudflare free tier does not include Containers) -- and the `wrangler` CLI.
 
 1. `git clone https://github.com/n24q02m/better-telegram-mcp && cd better-telegram-mcp`
 2. `wrangler login`

--- a/scripts/cf-deploy.mjs
+++ b/scripts/cf-deploy.mjs
@@ -55,25 +55,25 @@ if (!accountId) {
     process.exit(1);
 }
 
-const publicUrl = process.env.PUBLIC_URL;
-if (!publicUrl) {
-    console.error("PUBLIC_URL is required (substituted for <YOUR_PUBLIC_URL>).");
-    process.exit(1);
-}
-// The Worker custom-domain route is always the PUBLIC_URL host, so derive it
-// instead of taking a second env var (keeps the route in sync with PUBLIC_URL).
-let workerDomain;
-try {
-    workerDomain = new URL(publicUrl).host;
-} catch {
-    console.error(`PUBLIC_URL is not a valid URL: ${publicUrl}`);
-    process.exit(1);
-}
-
 let config = readFileSync(srcConfig, "utf8");
 config = config.replaceAll("<YOUR_ACCOUNT_ID>", accountId);
-config = config.replaceAll("<YOUR_PUBLIC_URL>", publicUrl);
-config = config.replaceAll("<YOUR_WORKER_DOMAIN>", workerDomain);
+
+// The committed base wrangler.jsonc uses <YOUR_PUBLIC_URL> plus a matching
+// <YOUR_WORKER_DOMAIN> route; substitute both from PUBLIC_URL when the
+// placeholder is present so the config-only deploy never ships a placeholder.
+// The custom-domain route is always the PUBLIC_URL host, so it is derived from
+// PUBLIC_URL rather than taking a second env var.
+if (config.includes("<YOUR_PUBLIC_URL>")) {
+    const publicUrl = process.env.PUBLIC_URL;
+    if (!publicUrl) {
+        console.error(
+            "PUBLIC_URL is not set (base wrangler.jsonc uses <YOUR_PUBLIC_URL>)."
+        );
+        process.exit(1);
+    }
+    config = config.replaceAll("<YOUR_PUBLIC_URL>", publicUrl);
+    config = config.replaceAll("<YOUR_WORKER_DOMAIN>", new URL(publicUrl).host);
+}
 
 const kvId = process.env.TELEGRAM_KV_NAMESPACE_ID;
 if (kvId) {

--- a/scripts/cf-deploy.mjs
+++ b/scripts/cf-deploy.mjs
@@ -17,6 +17,8 @@
  * Required env:
  *   CLOUDFLARE_API_TOKEN    - CF API token (full-access dev token works)
  *   CLOUDFLARE_ACCOUNT_ID   - substituted for <YOUR_ACCOUNT_ID> in the image ref
+ *   PUBLIC_URL              - substituted for <YOUR_PUBLIC_URL>; its host also
+ *                             fills the <YOUR_WORKER_DOMAIN> custom-domain route
  *
  * Optional env:
  *   TELEGRAM_KV_NAMESPACE_ID - substituted for <telegram-kv-namespace-id>; if a
@@ -53,8 +55,25 @@ if (!accountId) {
     process.exit(1);
 }
 
+const publicUrl = process.env.PUBLIC_URL;
+if (!publicUrl) {
+    console.error("PUBLIC_URL is required (substituted for <YOUR_PUBLIC_URL>).");
+    process.exit(1);
+}
+// The Worker custom-domain route is always the PUBLIC_URL host, so derive it
+// instead of taking a second env var (keeps the route in sync with PUBLIC_URL).
+let workerDomain;
+try {
+    workerDomain = new URL(publicUrl).host;
+} catch {
+    console.error(`PUBLIC_URL is not a valid URL: ${publicUrl}`);
+    process.exit(1);
+}
+
 let config = readFileSync(srcConfig, "utf8");
 config = config.replaceAll("<YOUR_ACCOUNT_ID>", accountId);
+config = config.replaceAll("<YOUR_PUBLIC_URL>", publicUrl);
+config = config.replaceAll("<YOUR_WORKER_DOMAIN>", workerDomain);
 
 const kvId = process.env.TELEGRAM_KV_NAMESPACE_ID;
 if (kvId) {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -28,12 +28,12 @@
   // Secrets via `wrangler secret put`: CREDENTIAL_SECRET, MCP_RELAY_PASSWORD
   // (Gate A shared relay-password front door), MCP_DCR_SERVER_SECRET.
   "vars": {
-    "PUBLIC_URL": "https://telegram.n24q02m.com",
+    "PUBLIC_URL": "<YOUR_PUBLIC_URL>",
     "MCP_STORAGE_BACKEND": "cf-kv",
     "MCP_KV_BASE_URL": "http://kv.internal",
     "MCP_TRANSPORT": "http",
     "MCP_PORT": "8080"
   },
-  "routes": [{ "pattern": "telegram.n24q02m.com", "custom_domain": true }],
+  "routes": [{ "pattern": "<YOUR_WORKER_DOMAIN>", "custom_domain": true }],
   "observability": { "enabled": true }
 }


### PR DESCRIPTION
Makes the committed base config + README fully BYO so a third party can deploy telegram to THEIR Cloudflare, and keeps the config-only deploy path working with the new placeholders.

**Commit 1 (fix)** `wrangler.jsonc`: PUBLIC_URL -> `<YOUR_PUBLIC_URL>`, routes pattern -> `<YOUR_WORKER_DOMAIN>` (were hardcoded to telegram.n24q02m.com). deploy_cf.py uses gitignored wrangler.deploy.jsonc; maintainer full-build CD unaffected.

**Commit 2 (feat)** `README.md`: adds a user-facing "Deploy to Cloudflare" BYO section (Deploy button + KV-only provision + container push from ghcr.io/n24q02m/better-telegram-mcp + fill the wrangler.jsonc placeholders + `wrangler secret put` CREDENTIAL_SECRET / MCP_RELAY_PASSWORD / MCP_DCR_SERVER_SECRET + deploy). Per-user bot token / phone are entered via the browser relay form, so they are intentionally NOT Worker secrets.

**Commit 3 (fix)** `scripts/cf-deploy.mjs`: the config-only `npm run cf:deploy` reads the base wrangler.jsonc and substituted only `<YOUR_ACCOUNT_ID>` + KV id, so commit 1's new placeholders would reach wrangler literally. Mirrors the ACCOUNT_ID pattern: adds a required PUBLIC_URL env guard + substitutes `<YOUR_PUBLIC_URL>`, and derives the custom-domain route from `new URL(PUBLIC_URL).host` to fill `<YOUR_WORKER_DOMAIN>` (route stays in sync with PUBLIC_URL, no second env var). Verified via a stubbed-npx dry-run: rendered temp config shows real PUBLIC_URL + route host and no literal `<...>` placeholder.