### PR TITLE
🎨 Palette: Improve dynamic form label styling and accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -53,3 +53,6 @@
 ## 2024-11-20 - Dual-Channel Validation Feedback
 **Learning:** Relying solely on color (like `#f87171` red borders) for `aria-invalid` states is insufficient for users with color vision deficiencies and can be easily missed. Providing dual-channel feedback by combining color with a subtle, non-disruptive motion animation (like a short horizontal `@keyframes shake`) significantly improves error discoverability and accessibility.
 **Action:** When implementing client-side validation, always apply a subtle motion animation (e.g., `shake 0.4s ease-in-out`) alongside color changes to `.field-input[aria-invalid="true"]` elements to provide robust, dual-channel error feedback, while ensuring it respects `prefers-reduced-motion: reduce`.
+## 2024-05-19 - Use field-group and semantic labels for dynamic prompts
+**Learning:** For dynamic form inputs (like OTP steps), ensure visual consistency and accessibility by wrapping the input and label in a `.field-group` container, applying the `.field-label` class to the semantic `<label>`, and explicitly appending `<span class="required-badge" aria-hidden="true">Required</span>` to mandatory fields instead of rendering prompts as title headers.
+**Action:** Always maintain uniform visual hierarchy by matching the dynamic step form markup structure with the main form's styling pattern.

--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -142,15 +142,6 @@ def render_telegram_credential_form(
             margin-top: 0.5rem;
         }}
 
-        .form-title {{
-            font-size: 0.875rem;
-            font-weight: 500;
-            color: #aaa;
-            text-transform: uppercase;
-            letter-spacing: 0.05em;
-            margin-bottom: 1.25rem;
-        }}
-
         .tabs {{
             display: flex;
             gap: 0;
@@ -690,14 +681,15 @@ def render_telegram_credential_form(
                     container = document.createElement("div");
                     container.id = "step-container";
 
+                    var fieldGroup = document.createElement("div");
+                    fieldGroup.className = "field-group";
+                    container.appendChild(fieldGroup);
+
                     promptEl = document.createElement("label");
                     promptEl.id = "step-prompt";
                     promptEl.setAttribute("for", "step-input");
-                    promptEl.className = "form-title";
-                    container.appendChild(promptEl);
-
-                    var fieldGroup = document.createElement("div");
-                    fieldGroup.className = "field-group";
+                    promptEl.className = "field-label";
+                    fieldGroup.appendChild(promptEl);
 
                     var passwordWrapper = document.createElement("div");
                     passwordWrapper.className = "password-wrapper";
@@ -726,7 +718,6 @@ def render_telegram_credential_form(
                     passwordWrapper.appendChild(inputEl);
                     passwordWrapper.appendChild(toggleBtn);
                     fieldGroup.appendChild(passwordWrapper);
-                    container.appendChild(fieldGroup);
 
                     buttonEl = document.createElement("button");
                     buttonEl.type = "button";
@@ -741,7 +732,7 @@ def render_telegram_credential_form(
                     errorEl.setAttribute("role", "alert");
                     errorEl.setAttribute("aria-live", "assertive");
                     errorEl.style.display = "none";
-                    container.appendChild(errorEl);
+                    fieldGroup.appendChild(errorEl);
 
                     card.appendChild(container);
 
@@ -764,6 +755,13 @@ def render_telegram_credential_form(
                 }}
 
                 promptEl.textContent = ns.text || "";
+                var requiredBadge = document.createElement("span");
+                requiredBadge.className = "required-badge";
+                requiredBadge.setAttribute("aria-hidden", "true");
+                requiredBadge.textContent = "Required";
+                promptEl.appendChild(document.createTextNode(" "));
+                promptEl.appendChild(requiredBadge);
+
                 var stepType = ns.input_type || "text";
                 inputEl.setAttribute("type", stepType);
                 inputEl.setAttribute("placeholder", ns.placeholder || "");


### PR DESCRIPTION
**💡 What:** Improved the layout and accessibility of dynamic step input forms (like OTP and password fields) by matching the HTML structure and styling of the main form.
**🎯 Why:** The previous implementation used a generic `form-title` heading class for labels which felt disjointed from the rest of the UI. Wrapping inputs in `.field-group` elements and utilizing standard `.field-label` classes enforces visual hierarchy and consistency. Additionally, the missing "Required" badges have been appended.
**📸 Before/After:** The step prompt now uses standard label styling and includes a red "Required" badge next to the text.
**♿ Accessibility:** Maintained existing semantic labels while ensuring screen readers correctly ignore the visual "Required" text via `aria-hidden="true"`.

---
*PR created automatically by Jules for task [6857129975908144259](https://jules.google.com/task/6857129975908144259) started by @n24q02m*