### PR TITLE
🎨 Palette: Ensure dual-channel validation on server errors

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -60,3 +60,7 @@
 ## 2024-11-21 - Disable Associated Utility Controls During Form Submission
 **Learning:** Leaving auxiliary interactive elements (like password visibility toggles) enabled while the primary inputs and submit button are disabled in a loading state creates an inconsistent UI state and can lead to confusing behavior during async operations.
 **Action:** Always ensure that all interactive utility elements associated with a form are explicitly disabled alongside the main inputs and submit button when transitioning into a disabled/loading state, and properly re-enabled when the state resets.
+
+## 2024-11-21 - Dual-Channel Validation for Server Errors
+**Learning:** While client-side validation correctly applied dual-channel feedback (color + shake animation) via `aria-invalid="true"`, server-side and network errors simply focused the input and showed a text error. This inconsistency meant users who bypassed client validation or hit server errors didn't receive the same robust accessibility feedback.
+**Action:** When handling server-side validation or network errors that relate to an input field, always apply `aria-invalid="true"` to that field before focusing it, ensuring consistent dual-channel feedback regardless of where the validation failed.

--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -771,6 +771,8 @@ def render_telegram_credential_form(
                 if (toggleBtn) {{
                     if (stepType === "password") {{
                         toggleBtn.style.display = "block";
+                        toggleBtn.textContent = "Show";
+                        toggleBtn.setAttribute("aria-pressed", "false");
                     }} else {{
                         toggleBtn.style.display = "none";
                     }}
@@ -977,6 +979,7 @@ def render_telegram_credential_form(
                                 if (activePanel) {{
                                     var firstInput = activePanel.querySelector('.field-input');
                                     if (firstInput) {{
+                                        firstInput.setAttribute("aria-invalid", "true");
                                         firstInput.focus();
                                     }}
                                 }}
@@ -997,6 +1000,7 @@ def render_telegram_credential_form(
                         if (activePanel) {{
                             var firstInput = activePanel.querySelector('.field-input');
                             if (firstInput) {{
+                                firstInput.setAttribute("aria-invalid", "true");
                                 firstInput.focus();
                             }}
                         }}


### PR DESCRIPTION
### 💡 What:
- Applied `aria-invalid="true"` to input fields when focusing them after a server-side authentication error or network failure.
- Explicitly resets the password visibility toggle button's state (`aria-pressed="false"`, text: `"Show"`) when rendering a new `password` step in the dynamic UI container.

### 🎯 Why:
- Client-side validation in this form utilizes a dual-channel feedback mechanism (a red border plus a horizontal CSS shake animation) via the `.field-input[aria-invalid="true"]` selector. Previously, server-side failures bypassed this entirely, resulting in inconsistent UI feedback where the field simply received focus.
- The step input UI container is reused across different auth stages (e.g., OTP -> 2FA Password). If a user toggled the password visibility to "Hide" in one step, a subsequent password step reusing the DOM nodes could end up visually out of sync with its ARIA attributes and text content.

### ♿ Accessibility:
- Ensures screen readers announce the invalid state for backend rejections.
- Ensures color-vision-deficient users still get motion-based validation cues (the shake animation) when backend requests fail.
- Keeps `aria-pressed` states synchronized with the actual visual state of toggle buttons across dynamic DOM updates.

---
*PR created automatically by Jules for task [10637041257717363245](https://jules.google.com/task/10637041257717363245) started by @n24q02m*