### PR TITLE
🎨 Palette: [UX improvement] Disable password toggles during form submission

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -56,3 +56,7 @@
 ## 2024-05-19 - Use field-group and semantic labels for dynamic prompts
 **Learning:** For dynamic form inputs (like OTP steps), ensure visual consistency and accessibility by wrapping the input and label in a `.field-group` container, applying the `.field-label` class to the semantic `<label>`, and explicitly appending `<span class="required-badge" aria-hidden="true">Required</span>` to mandatory fields instead of rendering prompts as title headers.
 **Action:** Always maintain uniform visual hierarchy by matching the dynamic step form markup structure with the main form's styling pattern.
+
+## 2024-11-21 - Disable Associated Utility Controls During Form Submission
+**Learning:** Leaving auxiliary interactive elements (like password visibility toggles) enabled while the primary inputs and submit button are disabled in a loading state creates an inconsistent UI state and can lead to confusing behavior during async operations.
+**Action:** Always ensure that all interactive utility elements associated with a form are explicitly disabled alongside the main inputs and submit button when transitioning into a disabled/loading state, and properly re-enabled when the state resets.

--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -811,6 +811,11 @@ def render_telegram_credential_form(
                 buttonEl.textContent = "Verifying...";
                 inputEl.disabled = true;
 
+                var stepToggleBtn = document.getElementById("toggle-step-input");
+                if (stepToggleBtn) {{
+                    stepToggleBtn.disabled = true;
+                }}
+
                 var body = {{}};
                 body[fieldName] = value;
 
@@ -851,6 +856,9 @@ def render_telegram_credential_form(
                                 buttonEl.disabled = false;
                                 buttonEl.removeAttribute("aria-busy");
                                 buttonEl.textContent = "Verify";
+                                if (stepToggleBtn) {{
+                                    stepToggleBtn.disabled = false;
+                                }}
                                 inputEl.focus();
                             }}
                         }});
@@ -863,6 +871,9 @@ def render_telegram_credential_form(
                         buttonEl.disabled = false;
                         buttonEl.removeAttribute("aria-busy");
                         buttonEl.textContent = "Verify";
+                        if (stepToggleBtn) {{
+                            stepToggleBtn.disabled = false;
+                        }}
                         inputEl.focus();
                     }});
             }}
@@ -907,6 +918,7 @@ def render_telegram_credential_form(
                 statusBox.style.display = "none";
                 form.querySelectorAll(".field-input").forEach(function (i) {{ i.disabled = true; }});
                 tabs.forEach(function (t) {{ t.disabled = true; }});
+                form.querySelectorAll(".password-toggle").forEach(function (btn) {{ btn.disabled = true; }});
 
                 fetch(submitUrl, {{
                     method: "POST",
@@ -958,6 +970,7 @@ def render_telegram_credential_form(
                                 submitBtn.textContent = "Connect";
                                 form.querySelectorAll(".field-input").forEach(function (i) {{ i.disabled = false; }});
                                 tabs.forEach(function (t) {{ t.disabled = false; }});
+                                form.querySelectorAll(".password-toggle").forEach(function (btn) {{ btn.disabled = false; }});
 
                                 // Restore focus to the first visible input field so users can immediately correct it
                                 var activePanel = document.querySelector('.tab-panel.active');
@@ -977,6 +990,7 @@ def render_telegram_credential_form(
                         submitBtn.textContent = "Connect";
                         form.querySelectorAll(".field-input").forEach(function (i) {{ i.disabled = false; }});
                         tabs.forEach(function (t) {{ t.disabled = false; }});
+                        form.querySelectorAll(".password-toggle").forEach(function (btn) {{ btn.disabled = false; }});
 
                         // Restore focus to the first visible input field so users can immediately correct it
                         var activePanel = document.querySelector('.tab-panel.active');


### PR DESCRIPTION
**💡 What:** Disabled the `.password-toggle` and `#toggle-step-input` buttons in `credential_form.py` whenever a form is submitted (i.e. entering the `aria-busy` / disabled loading state). They are correctly re-enabled if the submission results in an error, network failure, or prompts the next step. A journal entry was also added to `.jules/palette.md`.

**🎯 Why:** Leaving auxiliary interactive elements (like Show/Hide buttons) enabled while the main inputs and submit button are disabled in a loading state creates an inconsistent user interface. If a user clicks them during the async process, it leads to confusing visual states and broken interactions.

**📸 Before/After:** Before, the Show/Hide toggle would remain clickable and responsive while the main form was locked and showing a spinner. Now, the toggle is completely disabled along with everything else in the `.field-group`.

**♿ Accessibility:** Prevents screen reader announcements for state toggles when the primary context of that toggle (the input field) is disabled.

---
*PR created automatically by Jules for task [4701271558768816920](https://jules.google.com/task/4701271558768816920) started by @n24q02m*