### PR TITLE
🎨 Palette: Disable auxiliary form inputs on submit

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -56,3 +56,7 @@
 ## 2024-05-19 - Use field-group and semantic labels for dynamic prompts
 **Learning:** For dynamic form inputs (like OTP steps), ensure visual consistency and accessibility by wrapping the input and label in a `.field-group` container, applying the `.field-label` class to the semantic `<label>`, and explicitly appending `<span class="required-badge" aria-hidden="true">Required</span>` to mandatory fields instead of rendering prompts as title headers.
 **Action:** Always maintain uniform visual hierarchy by matching the dynamic step form markup structure with the main form's styling pattern.
+
+## 2024-10-21 - Disable Auxiliary Elements During Async Form Submission
+**Learning:** UX/Accessibility Pattern: When transitioning a form into a loading or disabled state during async submissions, explicitly disable all associated auxiliary interactive elements (such as password visibility toggles) alongside the primary inputs and submit buttons to prevent inconsistent UI states.
+**Action:** Always verify all interactive elements are disabled during form submits, including toggle buttons.

--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -810,6 +810,10 @@ def render_telegram_credential_form(
                 buttonEl.setAttribute("aria-busy", "true");
                 buttonEl.textContent = "Verifying...";
                 inputEl.disabled = true;
+                var toggleBtn = document.getElementById("toggle-step-input");
+                if (toggleBtn) {{
+                    toggleBtn.disabled = true;
+                }}
 
                 var body = {{}};
                 body[fieldName] = value;
@@ -851,6 +855,10 @@ def render_telegram_credential_form(
                                 buttonEl.disabled = false;
                                 buttonEl.removeAttribute("aria-busy");
                                 buttonEl.textContent = "Verify";
+                                var toggleBtn = document.getElementById("toggle-step-input");
+                                if (toggleBtn) {{
+                                    toggleBtn.disabled = false;
+                                }}
                                 inputEl.focus();
                             }}
                         }});
@@ -863,6 +871,10 @@ def render_telegram_credential_form(
                         buttonEl.disabled = false;
                         buttonEl.removeAttribute("aria-busy");
                         buttonEl.textContent = "Verify";
+                        var toggleBtn = document.getElementById("toggle-step-input");
+                        if (toggleBtn) {{
+                            toggleBtn.disabled = false;
+                        }}
                         inputEl.focus();
                     }});
             }}
@@ -906,6 +918,7 @@ def render_telegram_credential_form(
                 submitBtn.textContent = "Connecting...";
                 statusBox.style.display = "none";
                 form.querySelectorAll(".field-input").forEach(function (i) {{ i.disabled = true; }});
+                form.querySelectorAll(".password-toggle").forEach(function (btn) {{ btn.disabled = true; }});
                 tabs.forEach(function (t) {{ t.disabled = true; }});
 
                 fetch(submitUrl, {{
@@ -957,6 +970,7 @@ def render_telegram_credential_form(
                                 submitBtn.removeAttribute("aria-busy");
                                 submitBtn.textContent = "Connect";
                                 form.querySelectorAll(".field-input").forEach(function (i) {{ i.disabled = false; }});
+                                form.querySelectorAll(".password-toggle").forEach(function (btn) {{ btn.disabled = false; }});
                                 tabs.forEach(function (t) {{ t.disabled = false; }});
 
                                 // Restore focus to the first visible input field so users can immediately correct it
@@ -976,6 +990,7 @@ def render_telegram_credential_form(
                         submitBtn.removeAttribute("aria-busy");
                         submitBtn.textContent = "Connect";
                         form.querySelectorAll(".field-input").forEach(function (i) {{ i.disabled = false; }});
+                        form.querySelectorAll(".password-toggle").forEach(function (btn) {{ btn.disabled = false; }});
                         tabs.forEach(function (t) {{ t.disabled = false; }});
 
                         // Restore focus to the first visible input field so users can immediately correct it

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.14.0"
+version = "4.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
💡 **What:** Added logic to explicit disable and enable all `.password-toggle` auxiliary elements during the form loading states in `src/better_telegram_mcp/credential_form.py`.
🎯 **Why:** To improve UX and prevent users from accidentally interacting with the toggles while the form is locked or connecting.
📸 **Before/After:** The toggles are now greyed out/faded with `opacity: 0.5` due to the `:disabled` class logic in CSS while the form is loading.
♿ **Accessibility:** This also correctly removes the ability to focus into the inputs via keyboard tabbing and screenreaders.

---
*PR created automatically by Jules for task [4919020168968320323](https://jules.google.com/task/4919020168968320323) started by @n24q02m*