### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF bypass via IPv6 unspecified address

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,8 @@
 **Vulnerability:** Use of `os.urandom(32).hex()` for secret token generation.
 **Learning:** While `os.urandom` is cryptographically secure, using the explicit `secrets` module (e.g. `secrets.token_hex(32)`) conveys a clearer security intent, is less prone to misuse, and aligns with modern Python security best practices.
 **Prevention:** Use `secrets.token_hex()` or `secrets.token_urlsafe()` instead of raw `os.urandom` where appropriate.
+
+## 2024-05-18 - SSRF via IPv6 Unspecified Address (::)
+**Vulnerability:** The URL validation logic correctly blocked the IPv4 unspecified address `0.0.0.0` but failed to block its IPv6 equivalent `::`. This allowed SSRF requests to bypass the filter and target `localhost` on systems with IPv6 enabled.
+**Learning:** Hardcoded string checks (like `hostname in {"0.0.0.0"}`) and IPv4-only IP network blocks are insufficient when IPv6 is available, as attackers can use IPv6 variants (like `::`) to achieve the same routing behavior.
+**Prevention:** Always include the IPv6 equivalent `::/128` (unspecified) in blocked internal networks alongside `0.0.0.0/8`, and ensure string-based early filters catch `::`.

--- a/src/better_telegram_mcp/backends/security.py
+++ b/src/better_telegram_mcp/backends/security.py
@@ -31,6 +31,7 @@ _BLOCKED_NETWORKS = (
     ipaddress.ip_network("224.0.0.0/4"),  # Multicast
     ipaddress.ip_network("240.0.0.0/4"),  # Reserved
     ipaddress.ip_network("255.255.255.255/32"),  # Limited Broadcast
+    ipaddress.ip_network("::/128"),  # Unspecified (IPv6 equivalent of 0.0.0.0)
     ipaddress.ip_network("::1/128"),
     ipaddress.ip_network("::ffff:0:0/96"),
     ipaddress.ip_network("fc00::/7"),
@@ -88,7 +89,7 @@ def validate_url(url: str) -> str:
     # Resolve and check IPs
     # Not an IP literal -- resolve to prevent SSRF via DNS like 127.0.0.1.nip.io
     # Block known dangerous hostnames as an early check
-    if hostname in {"localhost", "0.0.0.0"}:  # noqa: S104
+    if hostname in {"localhost", "0.0.0.0", "::"}:  # noqa: S104
         msg = f"Access to {hostname} is blocked"
         raise SecurityError(msg)
     try:

--- a/tests/test_backends/test_security.py
+++ b/tests/test_backends/test_security.py
@@ -65,6 +65,18 @@ class TestValidateUrl:
         with pytest.raises(SecurityError, match="internal/private"):
             validate_url("http://[::1]/")
 
+    def test_ipv6_unspecified_blocked(self):
+        """Ensure IPv6 unspecified address (::) is blocked directly by string check."""
+        with pytest.raises(SecurityError, match="blocked"):
+            validate_url("http://[::]/")
+
+    @pytest.mark.asyncio
+    async def test_fetch_url_safely_ipv6_unspecified(self):
+        from better_telegram_mcp.backends.security import fetch_url_safely
+
+        with pytest.raises(SecurityError, match="blocked"):
+            await fetch_url_safely("http://[::]/")
+
     def test_ipv4_mapped_ipv6_loopback_blocked(self, monkeypatch):
         """IPv4-mapped IPv6 like ::ffff:127.0.0.1 must be blocked (issue #42)."""
         monkeypatch.setattr(


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: SSRF filter bypass using the IPv6 unspecified address `::`.
🎯 Impact: Attackers could bypass internal IP blocks to target `localhost` on systems where IPv6 is enabled.
🔧 Fix: Added `::/128` to `_BLOCKED_NETWORKS` and string `"::"` to `validate_url`'s early static check in `security.py`.
✅ Verification: Added tests in `tests/test_backends/test_security.py` and run full suite (`uv run pytest`) verifying the `::` address is blocked. Documented learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [13665496871673758997](https://jules.google.com/task/13665496871673758997) started by @n24q02m*