### PR TITLE
⚡ Bolt: skip redundant KV store writes in pending OTP cleanup

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2025-06-30 - Parallel KV Session Store Loading
 **Learning:** `load_all` on a credential backend with individual `load()` operations suffers from an N+1 query bottleneck. Since the underlying PBKDF2 key derivations using the `cryptography` library release the GIL, thread pools provide significant speedups even in Python, overlapping both I/O and heavy crypto compute.
 **Action:** Parallelize bulk load operations over single-item APIs using `ThreadPoolExecutor.map()` to avoid sequential blocking. Combine results with `zip(..., strict=True)`.
+## 2025-07-28 - Skip Unnecessary KV Store Writes
+**Learning:** In periodic cleanup operations (like `cleanup_expired` for OTP entries), checking all records without verifying modifications can lead to redundant, unconditional `store.save()` calls.
+**Action:** Always verify if state has actually changed (e.g., via early `if not stale_bearers: continue` checks) to bypass expensive I/O operations and avoid taxing KV stores unnecessarily.

--- a/src/better_telegram_mcp/auth/pending_otp_store.py
+++ b/src/better_telegram_mcp/auth/pending_otp_store.py
@@ -159,6 +159,10 @@ class PendingOtpStore:
                     and now - entry.get("created_at", 0) > _OTP_TTL
                 ):
                     stale_bearers.append(bearer)
+
+            if not stale_bearers:
+                continue
+
             for bearer in stale_bearers:
                 del existing[bearer]
                 removed += 1


### PR DESCRIPTION
💡 What: Added an early `if not stale_bearers: continue` check inside the `cleanup_expired` method in `src/better_telegram_mcp/auth/pending_otp_store.py`.

🎯 Why: Previously, the method iterated over all user entries and evaluated if any had expired. Even if zero modifications were made to the entries, it unconditionally called `store.save(existing)`. This caused continuous, redundant I/O Key-Value store writes on unmodified data.

📊 Impact: Significantly reduces I/O load and latency during the periodic cleanup task, particularly in environments with numerous active (but unexpired) OTP entries, by turning an O(1) write penalty per unmodified user into a clean early exit.

🔬 Measurement: Verified the early return properly kicks in via testing; all unit tests in `uv run pytest` pass successfully.

---
*PR created automatically by Jules for task [10208183412759562683](https://jules.google.com/task/10208183412759562683) started by @n24q02m*