### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF bypass via IPv6 unspecified address (::)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,3 +1,8 @@
+## 2025-02-28 - Fix SSRF Bypass via IPv6 Unspecified Address (`::`)
+**Vulnerability:** URL validation for SSRF protection failed to block the IPv6 unspecified address (`::`), which many systems route to `localhost`, potentially bypassing IPv4-only loopback checks (`127.0.0.1`, `0.0.0.0`).
+**Learning:** Checking for `0.0.0.0` or `127.0.0.0/8` is insufficient because systems with IPv6 enabled may resolve `::` locally, allowing an attacker to reach internal services.
+**Prevention:** Always explicitly block `::/128` in IP network blocklists and `"::"` in static hostname bypass checks alongside `0.0.0.0` and `localhost`.
+
 ## 2025-02-27 - Fix DoS via memory exhaustion in fetch_url_safely
 **Vulnerability:** fetch_url_safely used httpx.AsyncClient.get which loads the entire response into memory at once, creating a risk for Denial of Service (DoS) via Out-Of-Memory (OOM) attacks if a malicious or large file is fetched.
 **Learning:** External URLs should be fetched with size limits and streaming to prevent memory exhaustion, as even validated internal IPs/URLs can return massive payloads.

--- a/src/better_telegram_mcp/backends/security.py
+++ b/src/better_telegram_mcp/backends/security.py
@@ -31,6 +31,7 @@ _BLOCKED_NETWORKS = (
     ipaddress.ip_network("224.0.0.0/4"),  # Multicast
     ipaddress.ip_network("240.0.0.0/4"),  # Reserved
     ipaddress.ip_network("255.255.255.255/32"),  # Limited Broadcast
+    ipaddress.ip_network("::/128"),  # IPv6 Unspecified
     ipaddress.ip_network("::1/128"),
     ipaddress.ip_network("::ffff:0:0/96"),
     ipaddress.ip_network("fc00::/7"),
@@ -88,7 +89,7 @@ def validate_url(url: str) -> str:
     # Resolve and check IPs
     # Not an IP literal -- resolve to prevent SSRF via DNS like 127.0.0.1.nip.io
     # Block known dangerous hostnames as an early check
-    if hostname in {"localhost", "0.0.0.0"}:  # noqa: S104
+    if hostname in {"localhost", "0.0.0.0", "::"}:  # noqa: S104
         msg = f"Access to {hostname} is blocked"
         raise SecurityError(msg)
     try:

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.14.0"
+version = "4.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** URL validation for Server-Side Request Forgery (SSRF) protection failed to block the IPv6 unspecified address (`::`). In many operating systems, `::` is routed identically to `localhost` (similar to `0.0.0.0` in IPv4), allowing an attacker to bypass IPv4-only loopback checks and access internal services by supplying a URL like `http://[::]/`.
🎯 **Impact:** An attacker could bypass SSRF protections to interact with services running on `localhost`, potentially leading to unauthorized data access or local service exploitation.
🔧 **Fix:** 
- Added `ipaddress.ip_network("::/128")` to `_BLOCKED_NETWORKS` in `src/better_telegram_mcp/backends/security.py`.
- Updated the static hostname blocklist in `validate_url` to explicitly block `"::"` alongside `"localhost"` and `"0.0.0.0"`.
✅ **Verification:** 
1. Run `uv run pytest tests/test_backends/test_security.py`
2. Test manually: Attempting to resolve `validate_url("http://[::]/")` will now raise a `SecurityError` instead of resolving successfully.

---
*PR created automatically by Jules for task [8528178446424946139](https://jules.google.com/task/8528178446424946139) started by @n24q02m*