### PR TITLE
fix: reject unauthenticated /mcp at the Worker edge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,17 @@ jobs:
         with:
           files: coverage.xml
 
+      - name: Setup Node.js 24
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "24"
+
+      - name: Install worker dependencies
+        run: npm ci
+
+      - name: Run worker tests
+        run: npm run test:worker
+
   dependency-review:
     name: Dependency Review
     if: github.event_name == 'pull_request'

--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,8 @@ JULES.md
 wrangler.deploy.jsonc
 wrangler.cf-deploy.tmp.jsonc
 .wrangler-dryrun/
+# Live CF OAuth self-test credential cache (scripts/cf_full_flow.py), never commit
+scripts/.telegram_cf_token
 docs/superpowers/
 # AI Assistant / Rules
 .jules/

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -94,8 +94,36 @@ const kvOutbound: OutboundHandler<Env> = async (request, env) => {
   return new Response('method not allowed', { status: 405 })
 }
 
+// Bearer credential presence check for the edge auth gate below. Structural
+// only -- validity is the container's job (mcp-core's OAuth AS runs inside it).
+const BEARER = /^Bearer\s+\S/i
+
+function unauthenticated(request: Request): Response {
+  const { origin } = new URL(request.url)
+  return new Response(null, {
+    status: 401,
+    headers: {
+      'WWW-Authenticate': `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource"`,
+    },
+  })
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
+    // Edge auth gate. mcp-core's OAuth AS runs INSIDE the container, so before
+    // this gate every anonymous /mcp request started the container and reset
+    // its 5m idle timer -- an unauthenticated caller could pin it awake and
+    // bill GiB-s around the clock. Verified 2026-07-09 on the sibling
+    // better-email-mcp deployment: a python-httpx client POSTed /mcp with no
+    // Authorization header every ~20s for 12h+. The check is STRUCTURAL: it
+    // rejects requests carrying no bearer credential at all and reproduces the
+    // container's own 401 (empty body + RFC 9728 WWW-Authenticate). Token
+    // VALIDITY is never judged here -- the container remains the sole
+    // authority, so no mcp-core auth logic is duplicated at the edge.
+    const url = new URL(request.url)
+    if (url.pathname === '/mcp' || url.pathname.startsWith('/mcp/')) {
+      if (!BEARER.test(request.headers.get('authorization') ?? '')) return unauthenticated(request)
+    }
     // Public entrypoint: ONLY routes inbound requests to the per-user container
     // DO. The kv.internal outbound handler is deliberately NOT dispatched here —
     // exposing it on the public fetch surface would let an external caller

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -70,8 +70,8 @@ describe('pickContainerEnv forwards security-critical secrets into the container
   })
 })
 
-describe('fetch routes to per-user DO by JWT sub', () => {
-  it('uses sub from the Bearer token as the DO name', async () => {
+describe('fetch routes to the single reserved container DO', () => {
+  it('names the DO "default" regardless of the Bearer token sub (SINGLE-DO COLLAPSE, see extractUserId)', async () => {
     let namedWith = ''
     const env = {
       TELEGRAM: {
@@ -86,6 +86,58 @@ describe('fetch routes to per-user DO by JWT sub', () => {
     })
     const res = await worker.fetch(req, env)
     expect(await res.text()).toBe('ok')
-    expect(namedWith).toBe('user-xyz')
+    expect(namedWith).toBe('default')
+  })
+})
+
+describe('edge auth gate rejects anonymous /mcp before touching the container DO', () => {
+  function makeEnv() {
+    let stubCalls = 0
+    const env = {
+      TELEGRAM: {
+        idFromName(n: string) { return { n } },
+        get() { return { fetch: async () => { stubCalls++; return new Response('ok') } } },
+      },
+    } as any
+    return { env, calls: () => stubCalls }
+  }
+
+  it('POST /mcp with no Authorization -> 401, stub never called', async () => {
+    const { env, calls } = makeEnv()
+    const req = new Request('https://telegram.n24q02m.com/mcp', { method: 'POST' })
+    const res = await worker.fetch(req, env)
+    expect(res.status).toBe(401)
+    expect(res.headers.get('WWW-Authenticate')).toMatch(
+      /^Bearer resource_metadata="https:\/\/[^"]+\/\.well-known\/oauth-protected-resource"$/,
+    )
+    expect(await res.text()).toBe('')
+    expect(calls()).toBe(0)
+  })
+
+  it('OPTIONS /mcp with no Authorization -> 401, stub never called', async () => {
+    const { env, calls } = makeEnv()
+    const req = new Request('https://telegram.n24q02m.com/mcp', { method: 'OPTIONS' })
+    const res = await worker.fetch(req, env)
+    expect(res.status).toBe(401)
+    expect(calls()).toBe(0)
+  })
+
+  it('POST /mcp with Authorization: Bearer anything -> stub called exactly once', async () => {
+    const { env, calls } = makeEnv()
+    const req = new Request('https://telegram.n24q02m.com/mcp', {
+      method: 'POST',
+      headers: { authorization: 'Bearer anything' },
+    })
+    const res = await worker.fetch(req, env)
+    expect(res.status).toBe(200)
+    expect(calls()).toBe(1)
+  })
+
+  it('GET /authorize with no Authorization -> non-/mcp path passes through to the DO', async () => {
+    const { env, calls } = makeEnv()
+    const req = new Request('https://telegram.n24q02m.com/authorize?foo=1')
+    const res = await worker.fetch(req, env)
+    expect(res.status).toBe(200)
+    expect(calls()).toBe(1)
   })
 })


### PR DESCRIPTION
## The cost bug

mcp-core's OAuth Authorization Server runs INSIDE the container, so an anonymous
request to `/mcp` reaches the Durable Object, starts the container, and resets
its 5-minute idle timer. The container then answers 401 itself. Consequence:
any unauthenticated caller can keep the container awake indefinitely, and
Cloudflare bills container memory (GiB-s) around the clock.

Measured on the sibling `better-email-mcp` deployment (verified 2026-07-09): an
unauthenticated `python-httpx/0.28.1` client POSTed `/mcp` with NO
`Authorization` header roughly every 20 seconds for over 12 hours -- 1282 x
HTTP 401 in a 6-hour window -- pinning that container awake 24/7.
`better-telegram-mcp` happens to be asleep today only because nobody is
hammering it; the exposure is identical, and the endpoint is published
publicly on `telegram.n24q02m.com`. This PR preventively hardens it against
the same exposure.

## The fix

A purely structural edge gate in `src/worker.ts`: if the request path is
`/mcp` (or under it) and there is no bearer credential in the `Authorization`
header, answer 401 at the edge and never touch the Durable Object.

It does not judge token validity -- no JWT verification, no decoding, no
crypto import. The container stays the sole authority on whether a token is
good; a request carrying any `Bearer <something>` is forwarded exactly as
before. This keeps mcp-core's auth logic un-duplicated.

The 401 is byte-compatible with what the container returns today: status
401, empty body, header
`WWW-Authenticate: Bearer resource_metadata="<origin>/.well-known/oauth-protected-resource"`,
nothing else. The gate applies to every method (`POST`/`GET`/`HEAD`/`OPTIONS`)
since the container 401s all of them alike (no CORS preflight exemption).
Everything else (`/authorize`, `/token`, `/register`, `/.well-known/*`,
`/health`) keeps reaching the container unchanged.

## Stale assertion repaired

While extending `tests/worker.test.ts`, running the full suite surfaced one
pre-existing failing test unrelated to this change: `fetch routes to per-user
DO by JWT sub > uses sub from the Bearer token as the DO name` asserted
`namedWith === 'user-xyz'`. `extractUserId()` was collapsed to a single
reserved DO (`return 'default'`) on 2026-06-30 to resolve a `max_instances=1`
deadlock (see the `SINGLE-DO COLLAPSE` comment in `src/worker.ts`), and this
assertion was never updated to match. Verified pre-existing by stashing this
PR's changes and re-running against unmodified `origin/main` -- identical
failure. Fixed in the same commit since it lives in the file this PR already
owns; renamed the `describe`/`it` text to describe current behavior.

## CI now actually runs the worker suite

`package.json` has had a `test:worker` script (vitest) all along, but no
workflow ever invoked it -- `ci.yml` only runs the Python suite
(`uv run pytest`). That is exactly why the stale assertion above went
unnoticed: the worker suite has been dead weight. Added a `Setup Node.js 24`
+ `npm ci` + `npm run test:worker` step to the existing `lint-and-test` job
(matches the repo's actually-committed lockfile, `package-lock.json`; the
untracked `bun.lock` in this working tree is not part of this repo's git
history and is unrelated to this PR).

## Verification (real output)

- `npx vitest run tests/worker.test.ts` -- **10/10 passed** (6 pre-existing +
  4 new gate tests), after the stale-assertion fix.
- `npx tsc --noEmit` -- 7 pre-existing errors, all in the untouched
  `makeKv()`/`kvOutbound` test helper block (lines 16-44), verified identical
  against unmodified `origin/main` via `git stash`. No `typecheck` script is
  configured in `package.json` and no CI step runs `tsc`, so this has never
  been gated; out of scope for this PR (not caused by, and not fixed by, this
  change). Flagging for visibility.
- `npx wrangler deploy --dry-run --outdir .wrangler-dryrun` -- succeeds
  cleanly; worker still bundles (58.87 KiB / gzip 14.55 KiB), all bindings
  resolve.

Structural only -- the container remains the sole authority on token
validity; no mcp-core auth logic is duplicated at the edge.

## Untracked credential file, now gitignored

While verifying this PR, found `scripts/.telegram_cf_token` (341 bytes) sitting
in the working tree untracked AND un-ignored -- `git check-ignore` did not
match it, so a plain `git add -A` would have committed a real credential. It
is read by `scripts/cf_full_flow.py:254` (the live CF OAuth self-test), so the
file itself is left in place; added `scripts/.telegram_cf_token` to
`.gitignore` next to the repo's other Cloudflare deploy-time artifact
patterns. Contents were never read, printed, or copied.

DO NOT MERGE -- opening for review per work order.
