### PR TITLE
fix: decline standing GET /mcp SSE stream at the edge

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -124,6 +124,17 @@ export default {
     if (url.pathname === '/mcp' || url.pathname.startsWith('/mcp/')) {
       if (!BEARER.test(request.headers.get('authorization') ?? '')) return unauthenticated(request)
     }
+    // Standing GET /mcp = the streamable-HTTP server-push SSE stream. On a
+    // scale-to-zero container this is pure idle cost: @cloudflare/containers
+    // counts an open stream as an in-flight request forever (inflight > 0 =>
+    // activity never expires), so a single idle client pins the container
+    // awake 24/7. None of this stack's servers send server-initiated
+    // messages; request-scoped notifications ride the POST's own SSE
+    // response. The spec allows declining the stream: both official SDKs
+    // treat 405 as the optional-feature path and continue POST-only.
+    if (request.method === 'GET' && (url.pathname === '/mcp' || url.pathname.startsWith('/mcp/'))) {
+      return new Response(null, { status: 405, headers: { Allow: 'POST, DELETE' } })
+    }
     // Public entrypoint: ONLY routes inbound requests to the per-user container
     // DO. The kv.internal outbound handler is deliberately NOT dispatched here —
     // exposing it on the public fetch surface would let an external caller

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -81,7 +81,11 @@ describe('fetch routes to the single reserved container DO', () => {
     } as any
     // JWT with payload {"sub":"user-xyz"} (header.payload.sig; only payload is read)
     const payload = btoa(JSON.stringify({ sub: 'user-xyz' }))
+    // POST, not GET: the edge now declines the standing GET /mcp SSE stream
+    // with 405 (see "edge declines the standing GET /mcp SSE stream" below),
+    // so DO-routing is exercised via POST here.
     const req = new Request('https://telegram.n24q02m.com/mcp', {
+      method: 'POST',
       headers: { authorization: `Bearer h.${payload}.s` },
     })
     const res = await worker.fetch(req, env)
@@ -139,5 +143,49 @@ describe('edge auth gate rejects anonymous /mcp before touching the container DO
     const res = await worker.fetch(req, env)
     expect(res.status).toBe(200)
     expect(calls()).toBe(1)
+  })
+})
+
+describe('edge declines the standing GET /mcp SSE stream (container never pinned awake by an idle stream)', () => {
+  function makeEnv() {
+    let stubCalls = 0
+    const env = {
+      TELEGRAM: {
+        idFromName(n: string) { return { n } },
+        get() { return { fetch: async () => { stubCalls++; return new Response('ok') } } },
+      },
+    } as any
+    return { env, calls: () => stubCalls }
+  }
+
+  it('GET /mcp with Authorization -> 405, Allow: POST, DELETE, stub never called', async () => {
+    const { env, calls } = makeEnv()
+    const req = new Request('https://telegram.n24q02m.com/mcp', {
+      method: 'GET',
+      headers: { authorization: 'Bearer x' },
+    })
+    const res = await worker.fetch(req, env)
+    expect(res.status).toBe(405)
+    expect(res.headers.get('Allow')).toBe('POST, DELETE')
+    expect(calls()).toBe(0)
+  })
+
+  it('GET /mcp/sub with Authorization -> 405', async () => {
+    const { env, calls } = makeEnv()
+    const req = new Request('https://telegram.n24q02m.com/mcp/sub', {
+      method: 'GET',
+      headers: { authorization: 'Bearer x' },
+    })
+    const res = await worker.fetch(req, env)
+    expect(res.status).toBe(405)
+    expect(calls()).toBe(0)
+  })
+
+  it('GET /mcp with no Authorization -> still 401 (bearer gate runs first)', async () => {
+    const { env, calls } = makeEnv()
+    const req = new Request('https://telegram.n24q02m.com/mcp', { method: 'GET' })
+    const res = await worker.fetch(req, env)
+    expect(res.status).toBe(401)
+    expect(calls()).toBe(0)
   })
 })


### PR DESCRIPTION
## Summary
- The GET /mcp streamable-HTTP server-push stream is now declined at the edge worker with 405 (Allow: POST, DELETE) instead of being forwarded to the container.
- `@cloudflare/containers` counts an open proxied stream as an in-flight request forever (inflight > 0 => activity never expires), so a single idle client holding that GET stream open pins the container awake and billing 24/7, even with zero real traffic.
- Neither this stack's servers nor its clients need the server-push channel: request-scoped notifications already ride the POST request's own SSE response. Declining the GET stream loses nothing.
- Both official MCP SDKs treat a 405 on the GET stream as the expected/optional-feature case and continue operating POST-only (TS client: client/streamableHttp.js:100-104; Python client: retries a couple of times then gives up quietly).

## Test plan
- [x] `bunx vitest run tests/worker.test.ts` — 13/13 passed
- [x] New tests: GET /mcp (and /mcp/sub) with a Bearer token -> 405 with `Allow: POST, DELETE`, container stub never invoked
- [x] Existing test: GET /mcp with no Authorization -> still 401 (edge bearer gate runs before the new GET check)
- [x] Existing DO-routing test updated to POST (it previously relied on GET reaching the container, which the new 405 now correctly intercepts)