### PR TITLE
fix: document public-by-design identifiers for secret scanners

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -1,0 +1,16 @@
+# Public-by-design app identifiers -- reviewed and deliberately kept.
+# Telegram's api_id/api_hash pair embedded in src/better_telegram_mcp/config.py
+# is the official embedded-app-credential pattern (my.telegram.org "App
+# configuration" -- every client using the Telegram API, official or third
+# party, ships an api_id/api_hash baked into the app). Scanner alerts on this
+# exact value are a false positive. Do NOT rotate, do NOT placeholder-ize.
+#
+# Note: api_id (37984984) is a bare integer with no distinguishing format, so
+# it is not expected to trip any secret detector and is intentionally left
+# out of ignored_matches below -- add it here if a scanner ever actually
+# flags it.
+version: 2
+secret:
+  ignored_matches:
+    - name: telegram-embedded-app-api-hash
+      match: "2f5f4c76c4de7c07302380c788390100"


### PR DESCRIPTION
## Summary
- Adds `.gitguardian.yaml` recording the Telegram `api_hash` in `src/better_telegram_mcp/config.py` as a reviewed, public-by-design identifier, using ggshield's `secret.ignored_matches` raw-string-equality format.
- Telegram's `api_id`/`api_hash` pair is the official embedded-app-credential pattern issued by my.telegram.org — every Telegram API client, official or third-party, ships one baked in. This is not a leak; do not rotate, do not placeholder-ize.
- `api_id` (a bare integer, no distinguishing format) is intentionally NOT added — it isn't expected to trip any secret detector; a comment in the file explains why and notes it can be added later if a scanner ever actually flags it.

## Scope note
- This file is read by ggshield (the CLI/pre-commit scanner) and silences the local/CI re-raise. The GitGuardian **dashboard** app keeps its own separate ignore list, so if a dashboard incident exists for this value it still needs a one-time manual "ignore" resolution there — this file only records the decision in-repo for the scanner tooling that reads it.

## Test plan
- [x] `pre-commit` (gitleaks + other hooks) passed locally on this commit, no allowlist changes needed
- [ ] CI green on this PR