### PR TITLE
fix: resolve worker type-check errors and gate tsc in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,9 @@ jobs:
       - name: Run worker tests
         run: npm run test:worker
 
+      - name: Run worker type check
+        run: npm run type-check
+
   dependency-review:
     name: Dependency Review
     if: github.event_name == 'pull_request'

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "type-check": "tsc --noEmit",
     "test:worker": "vitest run tests/worker.test.ts",
     "cf:dryrun": "wrangler deploy --dry-run --outdir .wrangler-dryrun",
     "cf:deploy": "node scripts/cf-deploy.mjs"

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -3,14 +3,18 @@ import { describe, expect, it } from 'vitest'
 import worker, { TelegramContainer, pickContainerEnv } from '../src/worker'
 
 // Minimal in-memory KV that matches the Env.KV shape (arrayBuffer get/put/delete).
+// ArrayBufferLike (not ArrayBuffer): TypeScript's Uint8Array is generic since
+// TS 5.7, so `TextEncoder#encode(...).buffer` is typed ArrayBufferLike (the
+// ArrayBuffer | SharedArrayBuffer union), even though a real TextEncoder never
+// backs its output with a SharedArrayBuffer.
 function makeKv() {
-  const store = new Map<string, ArrayBuffer>()
+  const store = new Map<string, ArrayBufferLike>()
   return {
     store,
     async get(k: string, type?: string) {
       const v = store.get(k)
       if (v === undefined) return null
-      return type === 'arrayBuffer' ? v : new TextDecoder().decode(v)
+      return type === 'arrayBuffer' ? v : new TextDecoder().decode(v as ArrayBuffer)
     },
     async put(k: string, v: string | ArrayBuffer) {
       store.set(k, typeof v === 'string' ? new TextEncoder().encode(v).buffer : v)
@@ -19,29 +23,40 @@ function makeKv() {
   }
 }
 
+// OutboundHandlerContext<unknown> (the kvOutbound handler's ctx type): only
+// containerId/className are required, `params` stays optional -- see
+// @cloudflare/containers dist/lib/container.d.ts OutboundHandlerContext.
+const outboundCtx = { containerId: 'test-container', className: 'TelegramContainer' }
+
 describe('kvOutbound (via TelegramContainer.outboundByHost)', () => {
-  const handler = TelegramContainer.outboundByHost['kv.internal']
+  // outboundByHost is typed possibly-undefined by the library (it's only set
+  // once ../src/worker's module-level `TelegramContainer.outboundByHost = {...}`
+  // assignment runs) -- assert the invariant explicitly instead of `!`, so a
+  // future refactor that drops the assignment fails loudly here, not silently.
+  const outboundByHost = TelegramContainer.outboundByHost
+  if (!outboundByHost) throw new Error('TelegramContainer.outboundByHost not registered by ../src/worker import')
+  const handler = outboundByHost['kv.internal']
 
   it('returns 404 for a missing key', async () => {
     const env = { KV: makeKv() } as any
-    const res = await handler(new Request('http://kv.internal/telegram%2Fsubs%2Fu1%2Fsession'), env)
+    const res = await handler(new Request('http://kv.internal/telegram%2Fsubs%2Fu1%2Fsession'), env, outboundCtx)
     expect(res.status).toBe(404)
   })
 
   it('round-trips a binary blob via arrayBuffer (PUT then GET)', async () => {
     const env = { KV: makeKv() } as any
     const blob = new Uint8Array([0, 1, 2, 250, 251, 255]).buffer  // non-UTF8 bytes
-    await handler(new Request('http://kv.internal/telegram%2Fconfig', { method: 'PUT', body: blob }), env)
-    const res = await handler(new Request('http://kv.internal/telegram%2Fconfig'), env)
+    await handler(new Request('http://kv.internal/telegram%2Fconfig', { method: 'PUT', body: blob }), env, outboundCtx)
+    const res = await handler(new Request('http://kv.internal/telegram%2Fconfig'), env, outboundCtx)
     expect(res.status).toBe(200)
     expect(new Uint8Array(await res.arrayBuffer())).toEqual(new Uint8Array(blob))
   })
 
   it('DELETE removes the key', async () => {
     const env = { KV: makeKv() } as any
-    await handler(new Request('http://kv.internal/k', { method: 'PUT', body: new ArrayBuffer(1) }), env)
-    await handler(new Request('http://kv.internal/k', { method: 'DELETE' }), env)
-    const res = await handler(new Request('http://kv.internal/k'), env)
+    await handler(new Request('http://kv.internal/k', { method: 'PUT', body: new ArrayBuffer(1) }), env, outboundCtx)
+    await handler(new Request('http://kv.internal/k', { method: 'DELETE' }), env, outboundCtx)
+    const res = await handler(new Request('http://kv.internal/k'), env, outboundCtx)
     expect(res.status).toBe(404)
   })
 })


### PR DESCRIPTION
## Summary
Follow-up to #908. While verifying that repo, `npx tsc --noEmit` surfaced 7 type errors in `tests/worker.test.ts`. Confirmed these are **pre-existing** and unrelated to the workers-types v5 bump: running `tsc --noEmit` on unmodified `origin/main` (before #908) reproduces the exact same 7 errors (same file/line/message). Root cause of why nobody caught them: `ci.yml`'s "Run worker tests" step only runs `npm run test:worker` (vitest, which transpiles via esbuild and does not type-check), so the repo has had a type-check gap since these tests were written.

This PR:
1. Fixes all 7 pre-existing type errors in `tests/worker.test.ts`, each addressed at its root cause (not suppressed):
   - `Map<string, ArrayBuffer>` -> `Map<string, ArrayBufferLike>` in the `makeKv()` test helper -- `Uint8Array` is generic since TypeScript 5.7, so `TextEncoder#encode(...).buffer` is typed `ArrayBufferLike` (the `ArrayBuffer | SharedArrayBuffer` union), not plain `ArrayBuffer`.
   - Explicit invariant check (throw, not a bare `!` assertion) before indexing `TelegramContainer.outboundByHost`, since `@cloudflare/containers`' own types mark the static getter possibly-`undefined` (it's only populated by `src/worker.ts`'s module-level `TelegramContainer.outboundByHost = {...}` side effect).
   - Pass the required 3rd `ctx: OutboundHandlerContext` argument (`{ containerId, className }`) to every direct `handler(request, env)` call -- `OutboundHandler`'s signature is `(req, env, ctx) => ...`; calling with only 2 args always exceeded the declared signature (structural typing let the 2-arg `kvOutbound` *implementation* satisfy the 3-arg *type* in `src/worker.ts`, but explicit call sites in the test still needed all 3 params).
2. Adds a `type-check` npm script (`tsc --noEmit`) and wires it into `ci.yml` right after `npm run test:worker`, closing the gap so a future regression fails CI instead of going unnoticed.

## Verification (local, mirrors the new CI sequence)
- `npm ci` -- clean
- `npm run test:worker` -- 13/13 passed
- `npm run type-check` -- exit 0 (was exit 2 with 7 errors before this fix)

## Test plan
- [x] `npm ci` clean
- [x] `npm run test:worker` passing
- [x] `npm run type-check` passing
- [x] CI green on this PR (new "Run worker type check" step included)