### PR TITLE
🎨 Palette: Synchronize aria-label on dynamic form reuse

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -64,3 +64,7 @@
 ## 2024-11-21 - Dual-Channel Validation for Server Errors
 **Learning:** While client-side validation correctly applied dual-channel feedback (color + shake animation) via `aria-invalid="true"`, server-side and network errors simply focused the input and showed a text error. This inconsistency meant users who bypassed client validation or hit server errors didn't receive the same robust accessibility feedback.
 **Action:** When handling server-side validation or network errors that relate to an input field, always apply `aria-invalid="true"` to that field before focusing it, ensuring consistent dual-channel feedback regardless of where the validation failed.
+
+## 2024-11-21 - Synchronize ARIA Labels When Reusing DOM Containers
+**Learning:** Reusing DOM containers for dynamic form steps (e.g., OTP or password prompts) can lead to desynchronized accessibility states if all associated attributes are not reset. While visual properties like `textContent` might be reset when re-initializing the view, missing updates to attributes like `aria-label` can leave screen readers announcing stale and confusing states (e.g., a button displaying "Show" but announcing "Hide password").
+**Action:** When dynamically resetting or reusing stateful UI components, ensure that invisible attributes like `aria-label` are explicitly reset alongside their visible counterparts (like `textContent` and `aria-pressed`) to prevent out-of-sync UI states.

--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -773,6 +773,7 @@ def render_telegram_credential_form(
                         toggleBtn.style.display = "block";
                         toggleBtn.textContent = "Show";
                         toggleBtn.setAttribute("aria-pressed", "false");
+                        toggleBtn.setAttribute("aria-label", "Show password");
                     }} else {{
                         toggleBtn.style.display = "none";
                     }}


### PR DESCRIPTION
💡 What: Explicitly reset the `aria-label` of the password visibility toggle when dynamically reusing the step input container.
🎯 Why: Reusing the container reset visual states (text 'Show') and ARIA states (`aria-pressed`) but left `aria-label` stale. This caused screen readers to announce "Hide password" for a button that visually said "Show", causing severe confusion for assistive technology users.
📸 Before/After: Visuals are unchanged; ARIA state is corrected under the hood.
♿ Accessibility: Ensures that `aria-label` remains strictly in sync with the visual state and `aria-pressed` state across asynchronous form resets.

---
*PR created automatically by Jules for task [7632518228537732773](https://jules.google.com/task/7632518228537732773) started by @n24q02m*