### PR TITLE
feat: return structured content from domain tools

### DIFF
--- a/src/better_telegram_mcp/server.py
+++ b/src/better_telegram_mcp/server.py
@@ -4,6 +4,7 @@ import logging
 import os
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from typing import Any
 
 from loguru import logger
 from mcp.server.fastmcp import FastMCP
@@ -69,7 +70,7 @@ def get_settings() -> Settings:
     return _settings
 
 
-def _not_ready_response() -> str:
+def _not_ready_response() -> dict[str, Any]:
     if _unconfigured:
         return ok(
             {
@@ -246,7 +247,7 @@ async def message(
     query: str | None = None,
     limit: int = 20,
     offset_id: int | None = None,
-) -> str:
+) -> dict[str, Any]:
     """Send, edit, delete, forward, pin, react, search, and get message history.
 
     Actions (chat_id: "@username" | int):
@@ -301,7 +302,7 @@ async def chat(
     topic_action: str | None = None,
     topic_id: int | None = None,
     topic_name: str | None = None,
-) -> str:
+) -> dict[str, Any]:
     """List, create, join, leave, manage members, settings, and topics.
 
     Actions:
@@ -350,7 +351,7 @@ async def media(
     message_id: int | None = None,
     caption: str | None = None,
     output_dir: str | None = None,
-) -> str:
+) -> dict[str, Any]:
     """Send photos, files, voice, video, and download media from messages.
 
     Actions (file_path_or_url: local path or URL):
@@ -390,7 +391,7 @@ async def contact(
     last_name: str | None = None,
     user_id: int | None = None,
     unblock: bool = False,
-) -> str:
+) -> dict[str, Any]:
     """Manage contacts: list, search, add, and block/unblock users (user mode only).
 
     Actions:
@@ -427,7 +428,7 @@ async def config(
     message_limit: int | None = None,
     timeout: int | None = None,
     key: str | None = None,
-) -> str:
+) -> dict[str, Any]:
     """Server configuration and runtime settings.
 
     Actions (required params):

--- a/src/better_telegram_mcp/tools/chats.py
+++ b/src/better_telegram_mcp/tools/chats.py
@@ -23,12 +23,16 @@ class ChatOptions(BaseModel):
     topic_name: str | None = Field(default=None, description="Topic name to create")
 
 
-async def _handle_list(backend: TelegramBackend, options: ChatOptions) -> str:
+async def _handle_list(
+    backend: TelegramBackend, options: ChatOptions
+) -> dict[str, Any]:
     results = await backend.list_chats(limit=options.limit)
     return ok({"chats": results, "count": len(results)})
 
 
-async def _handle_info(backend: TelegramBackend, options: ChatOptions) -> str:
+async def _handle_info(
+    backend: TelegramBackend, options: ChatOptions
+) -> dict[str, Any]:
     if not options.chat_id:
         return err(
             "'info' requires chat_id. "
@@ -38,35 +42,45 @@ async def _handle_info(backend: TelegramBackend, options: ChatOptions) -> str:
     return ok(result)
 
 
-async def _handle_create(backend: TelegramBackend, options: ChatOptions) -> str:
+async def _handle_create(
+    backend: TelegramBackend, options: ChatOptions
+) -> dict[str, Any]:
     if not options.title:
         return err("'create' requires title")
     result = await backend.create_chat(options.title, is_channel=options.is_channel)
     return ok(result)
 
 
-async def _handle_join(backend: TelegramBackend, options: ChatOptions) -> str:
+async def _handle_join(
+    backend: TelegramBackend, options: ChatOptions
+) -> dict[str, Any]:
     if not options.link_or_hash:
         return err("'join' requires link_or_hash")
     result = await backend.join_chat(options.link_or_hash)
     return ok({"joined": result})
 
 
-async def _handle_leave(backend: TelegramBackend, options: ChatOptions) -> str:
+async def _handle_leave(
+    backend: TelegramBackend, options: ChatOptions
+) -> dict[str, Any]:
     if not options.chat_id:
         return err("'leave' requires chat_id")
     result = await backend.leave_chat(options.chat_id)
     return ok({"left": result})
 
 
-async def _handle_members(backend: TelegramBackend, options: ChatOptions) -> str:
+async def _handle_members(
+    backend: TelegramBackend, options: ChatOptions
+) -> dict[str, Any]:
     if not options.chat_id:
         return err("'members' requires chat_id")
     results = await backend.get_members(options.chat_id, limit=options.limit)
     return ok({"members": results, "count": len(results)})
 
 
-async def _handle_admin(backend: TelegramBackend, options: ChatOptions) -> str:
+async def _handle_admin(
+    backend: TelegramBackend, options: ChatOptions
+) -> dict[str, Any]:
     if not options.chat_id or options.user_id is None:
         return err("'admin' requires chat_id and user_id")
     result = await backend.promote_admin(
@@ -76,7 +90,9 @@ async def _handle_admin(backend: TelegramBackend, options: ChatOptions) -> str:
     return ok({action_word: result})
 
 
-async def _handle_settings(backend: TelegramBackend, options: ChatOptions) -> str:
+async def _handle_settings(
+    backend: TelegramBackend, options: ChatOptions
+) -> dict[str, Any]:
     if not options.chat_id:
         return err("'settings' requires chat_id")
     kwargs: dict[str, Any] = {}
@@ -90,7 +106,9 @@ async def _handle_settings(backend: TelegramBackend, options: ChatOptions) -> st
     return ok({"updated": result})
 
 
-async def _handle_topics(backend: TelegramBackend, options: ChatOptions) -> str:
+async def _handle_topics(
+    backend: TelegramBackend, options: ChatOptions
+) -> dict[str, Any]:
     if not options.chat_id:
         return err("'topics' requires chat_id")
     if not options.topic_action:
@@ -107,7 +125,7 @@ async def _handle_topics(backend: TelegramBackend, options: ChatOptions) -> str:
 
 
 _ACTION_HANDLERS: dict[
-    str, Callable[[TelegramBackend, ChatOptions], Awaitable[str]]
+    str, Callable[[TelegramBackend, ChatOptions], Awaitable[dict[str, Any]]]
 ] = {
     "list": _handle_list,
     "info": _handle_info,
@@ -125,7 +143,7 @@ async def handle_chats(
     backend: TelegramBackend,
     action: str,
     options: ChatOptions,
-) -> str:
+) -> dict[str, Any]:
     try:
         handler = _ACTION_HANDLERS.get(action)
         if handler:

--- a/src/better_telegram_mcp/tools/config_tool.py
+++ b/src/better_telegram_mcp/tools/config_tool.py
@@ -5,7 +5,7 @@ from ..backends.base import TelegramBackend
 from ..utils.formatting import err, ok, safe_error
 
 
-async def _handle_status(backend: TelegramBackend, **kwargs: Any) -> str:
+async def _handle_status(backend: TelegramBackend, **kwargs: Any) -> dict[str, Any]:
     from ..server import _pending_auth, _runtime_config
 
     connected = await backend.is_connected()
@@ -20,7 +20,7 @@ async def _handle_status(backend: TelegramBackend, **kwargs: Any) -> str:
     return ok(result)
 
 
-async def _handle_set(backend: TelegramBackend, **kwargs: Any) -> str:
+async def _handle_set(backend: TelegramBackend, **kwargs: Any) -> dict[str, Any]:
     from ..server import _runtime_config
 
     updated: dict[str, int] = {}
@@ -33,12 +33,14 @@ async def _handle_set(backend: TelegramBackend, **kwargs: Any) -> str:
     return ok({"updated": updated, "current": _runtime_config})
 
 
-async def _handle_cache_clear(backend: TelegramBackend, **kwargs: Any) -> str:
+async def _handle_cache_clear(
+    backend: TelegramBackend, **kwargs: Any
+) -> dict[str, Any]:
     await backend.clear_cache()
     return ok({"message": "Cache cleared."})
 
 
-_HANDLERS: dict[str, Callable[..., Awaitable[str]]] = {
+_HANDLERS: dict[str, Callable[..., Awaitable[dict[str, Any]]]] = {
     "status": _handle_status,
     "set": _handle_set,
     "cache_clear": _handle_cache_clear,
@@ -49,7 +51,7 @@ async def handle_config(
     backend: TelegramBackend,
     action: str,
     **kwargs: Any,
-) -> str:
+) -> dict[str, Any]:
     try:
         handler = _HANDLERS.get(action)
         if not handler:

--- a/src/better_telegram_mcp/tools/contacts.py
+++ b/src/better_telegram_mcp/tools/contacts.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from pydantic import BaseModel, Field
 
 from ..backends.base import ModeError, TelegramBackend
@@ -19,7 +21,7 @@ async def handle_contacts(
     backend: TelegramBackend,
     action: str,
     options: ContactsOptions | None = None,
-) -> str:
+) -> dict[str, Any]:
     if options is None:
         options = ContactsOptions()
     try:

--- a/src/better_telegram_mcp/tools/help_tool.py
+++ b/src/better_telegram_mcp/tools/help_tool.py
@@ -1,14 +1,20 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from pathlib import Path
-
-from ..utils.formatting import err
 
 _DOCS_DIR = Path(__file__).resolve().parent.parent / "docs"
 
 _VALID_TOPICS = {"messages", "chats", "media", "contacts"}
 _DOC_CACHE: dict[str, str] = {}
+
+
+def _err(message: str) -> str:
+    # help stays a str-returning tool (markdown/text by design); this repo's
+    # shared ok()/err() now return dict for the structured domain+config
+    # tools, so help keeps its own JSON-string error formatting.
+    return json.dumps({"error": message}, ensure_ascii=False)
 
 
 async def handle_help(topic: str | None = None) -> str:
@@ -19,7 +25,7 @@ async def handle_help(topic: str | None = None) -> str:
         parts = [doc for doc in results if doc]
         if parts:
             return "\n\n---\n\n".join(parts)
-        return err("No documentation found.")
+        return _err("No documentation found.")
 
     if topic not in _VALID_TOPICS:
         import difflib
@@ -28,7 +34,7 @@ async def handle_help(topic: str | None = None) -> str:
             topic, [*_VALID_TOPICS, "all", "telegram"], n=1
         )
         suggestion = f" Did you mean '{closest[0]}'?" if closest else ""
-        return err(
+        return _err(
             f"Unknown topic '{topic}'.{suggestion} "
             "Valid: telegram|messages|chats|media|contacts|all"
         )
@@ -36,7 +42,7 @@ async def handle_help(topic: str | None = None) -> str:
     doc = await _load_doc(topic)
     if doc:
         return doc
-    return err(f"Documentation for '{topic}' not found.")
+    return _err(f"Documentation for '{topic}' not found.")
 
 
 async def _load_doc(topic: str) -> str | None:

--- a/src/better_telegram_mcp/tools/media.py
+++ b/src/better_telegram_mcp/tools/media.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from pydantic import BaseModel, Field
 
 from ..backends.base import ModeError, TelegramBackend
@@ -32,7 +34,7 @@ async def handle_media(
     backend: TelegramBackend,
     action: str,
     options: MediaOptions,
-) -> str:
+) -> dict[str, Any]:
     try:
         if action in _ACTION_TO_MEDIA_TYPE:
             if not options.chat_id or not options.file_path_or_url:

--- a/src/better_telegram_mcp/tools/messages.py
+++ b/src/better_telegram_mcp/tools/messages.py
@@ -22,7 +22,7 @@ class MessagesArgs(BaseModel):
     offset_id: int | None = None
 
 
-async def _handle_send(backend: TelegramBackend, args: MessagesArgs) -> str:
+async def _handle_send(backend: TelegramBackend, args: MessagesArgs) -> dict[str, Any]:
     if not args.chat_id or not args.text:
         return err(
             "'send' requires chat_id and text. "
@@ -38,7 +38,7 @@ async def _handle_send(backend: TelegramBackend, args: MessagesArgs) -> str:
     return ok(result)
 
 
-async def _handle_edit(backend: TelegramBackend, args: MessagesArgs) -> str:
+async def _handle_edit(backend: TelegramBackend, args: MessagesArgs) -> dict[str, Any]:
     if not args.chat_id or args.message_id is None or not args.text:
         return err(
             "'edit' requires chat_id, message_id, and text. "
@@ -50,14 +50,18 @@ async def _handle_edit(backend: TelegramBackend, args: MessagesArgs) -> str:
     return ok(result)
 
 
-async def _handle_delete(backend: TelegramBackend, args: MessagesArgs) -> str:
+async def _handle_delete(
+    backend: TelegramBackend, args: MessagesArgs
+) -> dict[str, Any]:
     if not args.chat_id or args.message_id is None:
         return err("'delete' requires chat_id and message_id")
     result = await backend.delete_message(args.chat_id, args.message_id)
     return ok({"deleted": result})
 
 
-async def _handle_forward(backend: TelegramBackend, args: MessagesArgs) -> str:
+async def _handle_forward(
+    backend: TelegramBackend, args: MessagesArgs
+) -> dict[str, Any]:
     if not args.from_chat or not args.to_chat or args.message_id is None:
         return err("'forward' requires from_chat, to_chat, and message_id")
     result = await backend.forward_message(
@@ -66,21 +70,23 @@ async def _handle_forward(backend: TelegramBackend, args: MessagesArgs) -> str:
     return ok(result)
 
 
-async def _handle_pin(backend: TelegramBackend, args: MessagesArgs) -> str:
+async def _handle_pin(backend: TelegramBackend, args: MessagesArgs) -> dict[str, Any]:
     if not args.chat_id or args.message_id is None:
         return err("'pin' requires chat_id and message_id")
     result = await backend.pin_message(args.chat_id, args.message_id)
     return ok({"pinned": result})
 
 
-async def _handle_react(backend: TelegramBackend, args: MessagesArgs) -> str:
+async def _handle_react(backend: TelegramBackend, args: MessagesArgs) -> dict[str, Any]:
     if not args.chat_id or args.message_id is None or not args.emoji:
         return err("'react' requires chat_id, message_id, and emoji")
     result = await backend.react_to_message(args.chat_id, args.message_id, args.emoji)
     return ok({"reacted": result})
 
 
-async def _handle_search(backend: TelegramBackend, args: MessagesArgs) -> str:
+async def _handle_search(
+    backend: TelegramBackend, args: MessagesArgs
+) -> dict[str, Any]:
     if not args.query:
         return err("'search' requires query")
     results = await backend.search_messages(
@@ -89,7 +95,9 @@ async def _handle_search(backend: TelegramBackend, args: MessagesArgs) -> str:
     return ok({"messages": results, "count": len(results)})
 
 
-async def _handle_history(backend: TelegramBackend, args: MessagesArgs) -> str:
+async def _handle_history(
+    backend: TelegramBackend, args: MessagesArgs
+) -> dict[str, Any]:
     if not args.chat_id:
         return err("'history' requires chat_id")
     results = await backend.get_history(
@@ -99,7 +107,7 @@ async def _handle_history(backend: TelegramBackend, args: MessagesArgs) -> str:
 
 
 _ACTION_HANDLERS: dict[
-    str, Callable[[TelegramBackend, MessagesArgs], Coroutine[Any, Any, str]]
+    str, Callable[[TelegramBackend, MessagesArgs], Coroutine[Any, Any, dict[str, Any]]]
 ] = {
     "send": _handle_send,
     "edit": _handle_edit,
@@ -115,7 +123,7 @@ _ACTION_HANDLERS: dict[
 async def handle_messages(
     backend: TelegramBackend,
     args: MessagesArgs,
-) -> str:
+) -> dict[str, Any]:
     try:
         handler = _ACTION_HANDLERS.get(args.action)
         if handler is None:

--- a/src/better_telegram_mcp/utils/formatting.py
+++ b/src/better_telegram_mcp/utils/formatting.py
@@ -1,16 +1,15 @@
-import json
 from typing import Any
 
 
-def ok(data: Any) -> str:
-    return json.dumps(data, ensure_ascii=False, default=str)
+def ok(data: dict[str, Any]) -> dict[str, Any]:
+    return data
 
 
-def err(message: str) -> str:
-    return json.dumps({"error": message}, ensure_ascii=False)
+def err(message: str) -> dict[str, Any]:
+    return {"error": message}
 
 
-def safe_error(e: Exception) -> str:
+def safe_error(e: Exception) -> dict[str, Any]:
     """Return sanitized error without leaking internal details."""
     from ..backends.base import ModeError
     from ..backends.security import SecurityError

--- a/tests/integration/test_bot_live.py
+++ b/tests/integration/test_bot_live.py
@@ -179,8 +179,7 @@ async def test_clear_cache_noop(bot: BotBackend):
 
 async def test_config_status_connected(bot: BotBackend):
     """config status action returns connected=True for a live bot."""
-    result_str = await handle_config(bot, "status")
-    result = json.loads(result_str)
+    result = await handle_config(bot, "status")
     assert result["mode"] == "bot"
     assert result["connected"] is True
     assert "config" in result
@@ -192,8 +191,7 @@ async def test_config_set_and_read_back(bot: BotBackend):
 
     original_limit = _runtime_config["message_limit"]
     try:
-        result_str = await handle_config(bot, "set", message_limit=42)
-        result = json.loads(result_str)
+        result = await handle_config(bot, "set", message_limit=42)
         assert result["updated"]["message_limit"] == 42
         assert result["current"]["message_limit"] == 42
     finally:
@@ -202,15 +200,13 @@ async def test_config_set_and_read_back(bot: BotBackend):
 
 async def test_config_cache_clear(bot: BotBackend):
     """config cache_clear action succeeds."""
-    result_str = await handle_config(bot, "cache_clear")
-    result = json.loads(result_str)
+    result = await handle_config(bot, "cache_clear")
     assert result["message"] == "Cache cleared."
 
 
 async def test_config_unknown_action(bot: BotBackend):
     """config with unknown action returns error."""
-    result_str = await handle_config(bot, "nonexistent")
-    result = json.loads(result_str)
+    result = await handle_config(bot, "nonexistent")
     assert "error" in result
 
 

--- a/tests/integration/test_user_live.py
+++ b/tests/integration/test_user_live.py
@@ -8,7 +8,6 @@ They only exercise read-only operations — no sending, deleting, or destructive
 
 from __future__ import annotations
 
-import json
 import os
 
 import pytest
@@ -190,8 +189,7 @@ async def test_clear_cache_no_error(user: UserBackend):
 
 async def test_config_status_user_mode(user: UserBackend):
     """config status reports mode=user, connected=True, authorized=True."""
-    result_str = await handle_config(user, "status")
-    result = json.loads(result_str)
+    result = await handle_config(user, "status")
     assert result["mode"] == "user"
     assert result["connected"] is True
     assert result["authorized"] is True
@@ -200,15 +198,13 @@ async def test_config_status_user_mode(user: UserBackend):
 
 async def test_config_cache_clear(user: UserBackend):
     """config cache_clear action succeeds in user mode."""
-    result_str = await handle_config(user, "cache_clear")
-    result = json.loads(result_str)
+    result = await handle_config(user, "cache_clear")
     assert result["message"] == "Cache cleared."
 
 
 async def test_config_unknown_action(user: UserBackend):
     """config with unknown action returns error in user mode."""
-    result_str = await handle_config(user, "nonexistent")
-    result = json.loads(result_str)
+    result = await handle_config(user, "nonexistent")
     assert "error" in result
 
 

--- a/tests/test_not_ready_response.py
+++ b/tests/test_not_ready_response.py
@@ -1,5 +1,3 @@
-import json
-
 import better_telegram_mcp.server as srv
 
 
@@ -8,8 +6,7 @@ def test_not_ready_response_unconfigured():
     old_unconfigured = srv._unconfigured
     try:
         srv._unconfigured = True
-        response = srv._not_ready_response()
-        data = json.loads(response)
+        data = srv._not_ready_response()
         assert data["error"] == "Not configured"
         assert "setup" in data
         assert "relay" in data["setup"]
@@ -22,8 +19,7 @@ def test_not_ready_response_authenticated_error():
     old_unconfigured = srv._unconfigured
     try:
         srv._unconfigured = False
-        response = srv._not_ready_response()
-        data = json.loads(response)
+        data = srv._not_ready_response()
         assert "error" in data
         assert "not authenticated" in data["error"].lower()
     finally:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -89,7 +88,7 @@ async def test_message_send(mock_backend):
 
 @pytest.mark.asyncio
 async def test_message_backend_exception(mock_backend):
-    """message tool returns error string when backend raises an exception."""
+    """message tool returns error dict when backend raises an exception."""
     import better_telegram_mcp.server as srv
     from better_telegram_mcp.server import message
 
@@ -100,8 +99,7 @@ async def test_message_backend_exception(mock_backend):
         srv._pending_auth = False
         mock_backend.send_message.side_effect = RuntimeError("Backend failure")
 
-        result_str = await message(action="send", chat_id=123, text="hi")
-        result = json.loads(result_str)
+        result = await message(action="send", chat_id=123, text="hi")
         assert "error" in result
         assert "RuntimeError" in result["error"]
         assert "Operation failed" in result["error"]
@@ -158,7 +156,7 @@ async def test_contact_list(mock_backend):
     try:
         srv._backend = mock_backend
         srv._pending_auth = False
-        result = json.loads(await contact(action="list"))
+        result = await contact(action="list")
         assert "contacts" in result
         mock_backend.list_contacts.assert_awaited_once()
     finally:
@@ -253,7 +251,7 @@ async def test_contact_error(mock_backend):
         srv._backend = mock_backend
         srv._pending_auth = False
         mock_backend.list_contacts.side_effect = Exception("test error")
-        result = json.loads(await contact(action="list"))
+        result = await contact(action="list")
         assert "error" in result
         assert "Operation failed" in result["error"]
     finally:
@@ -271,7 +269,7 @@ async def test_contact_unknown_action(mock_backend):
     try:
         srv._backend = mock_backend
         srv._pending_auth = False
-        result = json.loads(await contact(action="invalid_action"))
+        result = await contact(action="invalid_action")
         assert "error" in result
         assert "Unknown action" in result["error"]
     finally:
@@ -303,7 +301,7 @@ async def test_message_unknown_action(mock_backend):
     try:
         srv._backend = mock_backend
         srv._pending_auth = False
-        result = json.loads(await message(action="nonexistent"))
+        result = await message(action="nonexistent")
         assert "error" in result
         assert "Unknown action" in result["error"]
     finally:
@@ -424,7 +422,7 @@ async def test_message_blocked_during_pending_auth(mock_backend):
     try:
         srv._backend = mock_backend
         srv._pending_auth = True
-        result = json.loads(await message(action="send", chat_id=123, text="hi"))
+        result = await message(action="send", chat_id=123, text="hi")
         assert "error" in result
         assert "not authenticated" in result["error"].lower()
     finally:
@@ -442,7 +440,7 @@ async def test_chat_blocked_during_pending_auth(mock_backend):
     try:
         srv._backend = mock_backend
         srv._pending_auth = True
-        result = json.loads(await chat(action="list"))
+        result = await chat(action="list")
         assert "error" in result
         assert "not authenticated" in result["error"].lower()
     finally:
@@ -460,12 +458,10 @@ async def test_media_blocked_during_pending_auth(mock_backend):
     try:
         srv._backend = mock_backend
         srv._pending_auth = True
-        result = json.loads(
-            await media(
-                action="send_photo",
-                chat_id=123,
-                file_path_or_url="https://example.com/photo.jpg",
-            )
+        result = await media(
+            action="send_photo",
+            chat_id=123,
+            file_path_or_url="https://example.com/photo.jpg",
         )
         assert "error" in result
         assert "not authenticated" in result["error"].lower()
@@ -484,7 +480,7 @@ async def test_contact_blocked_during_pending_auth(mock_backend):
     try:
         srv._backend = mock_backend
         srv._pending_auth = True
-        result = json.loads(await contact(action="list"))
+        result = await contact(action="list")
         assert "error" in result
         assert "not authenticated" in result["error"].lower()
     finally:
@@ -503,7 +499,7 @@ async def test_config_works_during_pending_auth(mock_backend):
     try:
         srv._backend = mock_backend
         srv._pending_auth = True
-        result = json.loads(await config(action="status"))
+        result = await config(action="status")
         assert "mode" in result
         assert result["pending_auth"] is True
     finally:
@@ -644,7 +640,7 @@ async def test_message_returns_setup_hint_when_unconfigured():
     try:
         srv._unconfigured = True
         srv._pending_auth = False
-        result = json.loads(await message(action="send", chat_id=123, text="hi"))
+        result = await message(action="send", chat_id=123, text="hi")
         assert "error" in result
         assert result["error"] == "Not configured"
         assert "setup" in result
@@ -665,7 +661,7 @@ async def test_chat_returns_setup_hint_when_unconfigured():
     old = srv._unconfigured
     try:
         srv._unconfigured = True
-        result = json.loads(await chat(action="list"))
+        result = await chat(action="list")
         assert result["error"] == "Not configured"
         assert "setup" in result
     finally:
@@ -679,8 +675,7 @@ async def test_not_ready_response_unconfigured():
     old = server._unconfigured
     try:
         server._unconfigured = True
-        response = server._not_ready_response()
-        data = json.loads(response)
+        data = server._not_ready_response()
         assert data["error"] == "Not configured"
         assert "bot_mode" in data["setup"]
         assert "user_mode" in data["setup"]
@@ -697,8 +692,7 @@ async def test_not_ready_response_pending_auth():
     try:
         server._unconfigured = False
         server._pending_auth = True
-        response = server._not_ready_response()
-        data = json.loads(response)
+        data = server._not_ready_response()
         assert "error" in data
         assert "not authenticated" in data["error"].lower()
     finally:
@@ -715,12 +709,10 @@ async def test_media_returns_setup_hint_when_unconfigured():
     old = srv._unconfigured
     try:
         srv._unconfigured = True
-        result = json.loads(
-            await media(
-                action="send_photo",
-                chat_id=123,
-                file_path_or_url="https://example.com/photo.jpg",
-            )
+        result = await media(
+            action="send_photo",
+            chat_id=123,
+            file_path_or_url="https://example.com/photo.jpg",
         )
         assert result["error"] == "Not configured"
         assert "setup" in result
@@ -737,7 +729,7 @@ async def test_contact_returns_setup_hint_when_unconfigured():
     old = srv._unconfigured
     try:
         srv._unconfigured = True
-        result = json.loads(await contact(action="list"))
+        result = await contact(action="list")
         assert result["error"] == "Not configured"
         assert "setup" in result
     finally:
@@ -753,7 +745,7 @@ async def test_config_status_works_when_unconfigured():
     old = srv._unconfigured
     try:
         srv._unconfigured = True
-        result = json.loads(await config(action="status"))
+        result = await config(action="status")
         assert result["configured"] is False
         assert result["connected"] is False
         assert "setup" in result
@@ -770,7 +762,7 @@ async def test_config_set_blocked_when_unconfigured():
     old = srv._unconfigured
     try:
         srv._unconfigured = True
-        result = json.loads(await config(action="set", message_limit=42))
+        result = await config(action="set", message_limit=42)
         assert result["error"] == "Not configured"
     finally:
         srv._unconfigured = old
@@ -831,7 +823,7 @@ async def test_config_setup_status():
                 return_value=None,
             ),
         ):
-            result = json.loads(await config(action="setup_status"))
+            result = await config(action="setup_status")
             assert result["state"] == "configured"
             assert "setup_url" in result
             assert "configured" in result
@@ -851,7 +843,7 @@ async def test_config_setup_start_already_configured():
         "better_telegram_mcp.credential_state.get_state",
         return_value=CredentialState.CONFIGURED,
     ):
-        result = json.loads(await config(action="setup_start"))
+        result = await config(action="setup_start")
         assert result["status"] == "already_configured"
         assert "force" in result["message"].lower()
 
@@ -871,7 +863,7 @@ async def test_config_setup_start_force_returns_stdio_unsupported():
         "better_telegram_mcp.credential_state.get_state",
         return_value=CredentialState.CONFIGURED,
     ):
-        result = json.loads(await config(action="setup_start", key="force"))
+        result = await config(action="setup_start", key="force")
         assert result["status"] == "stdio_unsupported"
         assert "TELEGRAM_BOT_TOKEN" in result["message"]
 
@@ -886,7 +878,7 @@ async def test_config_setup_start_awaiting_returns_stdio_unsupported():
         "better_telegram_mcp.credential_state.get_state",
         return_value=CredentialState.AWAITING_SETUP,
     ):
-        result = json.loads(await config(action="setup_start"))
+        result = await config(action="setup_start")
         assert result["status"] == "stdio_unsupported"
         assert "HTTP mode" in result["message"]
 
@@ -897,7 +889,7 @@ async def test_config_setup_reset():
     from better_telegram_mcp.server import config
 
     with patch("better_telegram_mcp.credential_state.reset_state") as mock_reset:
-        result = json.loads(await config(action="setup_reset"))
+        result = await config(action="setup_reset")
         assert result["status"] == "ok"
         assert "cleared" in result["message"].lower()
         mock_reset.assert_called_once()
@@ -919,7 +911,7 @@ async def test_config_setup_complete():
             return_value=CredentialState.CONFIGURED,
         ),
     ):
-        result = json.loads(await config(action="setup_complete"))
+        result = await config(action="setup_complete")
         assert result["status"] == "ok"
         assert result["state"] == "configured"
 
@@ -943,7 +935,7 @@ async def test_config_setup_status_works_when_unconfigured():
                 return_value=None,
             ),
         ):
-            result = json.loads(await config(action="setup_status"))
+            result = await config(action="setup_status")
             assert result["state"] == "awaiting_setup"
     finally:
         srv._unconfigured = old
@@ -959,7 +951,7 @@ async def test_config_setup_reset_works_when_unconfigured():
     try:
         srv._unconfigured = True
         with patch("better_telegram_mcp.credential_state.reset_state"):
-            result = json.loads(await config(action="setup_reset"))
+            result = await config(action="setup_reset")
             assert result["status"] == "ok"
     finally:
         srv._unconfigured = old

--- a/tests/test_tools/test_chats.py
+++ b/tests/test_tools/test_chats.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import json
-
 import pytest
 
 from better_telegram_mcp.backends.base import ModeError
@@ -10,7 +8,7 @@ from better_telegram_mcp.tools.chats import ChatOptions, handle_chats
 
 @pytest.mark.asyncio
 async def test_list(mock_backend):
-    result = json.loads(await handle_chats(mock_backend, "list", ChatOptions(limit=10)))
+    result = await handle_chats(mock_backend, "list", ChatOptions(limit=10))
     assert result["chats"] == []
     assert result["count"] == 0
 
@@ -18,67 +16,61 @@ async def test_list(mock_backend):
 @pytest.mark.asyncio
 async def test_info(mock_backend):
     mock_backend.get_chat_info.return_value = {"id": 123, "title": "Test"}
-    result = json.loads(
-        await handle_chats(mock_backend, "info", ChatOptions(chat_id=123))
-    )
+    result = await handle_chats(mock_backend, "info", ChatOptions(chat_id=123))
     assert result["id"] == 123
 
 
 @pytest.mark.asyncio
 async def test_info_missing_params(mock_backend):
-    result = json.loads(await handle_chats(mock_backend, "info", ChatOptions()))
+    result = await handle_chats(mock_backend, "info", ChatOptions())
     assert "error" in result
 
 
 @pytest.mark.asyncio
 async def test_create(mock_backend):
     mock_backend.create_chat.return_value = {"id": 456, "title": "New"}
-    result = json.loads(
-        await handle_chats(
-            mock_backend, "create", ChatOptions(title="New", is_channel=True)
-        )
+    result = await handle_chats(
+        mock_backend, "create", ChatOptions(title="New", is_channel=True)
     )
     assert result["id"] == 456
 
 
 @pytest.mark.asyncio
 async def test_create_missing_params(mock_backend):
-    result = json.loads(await handle_chats(mock_backend, "create", ChatOptions()))
+    result = await handle_chats(mock_backend, "create", ChatOptions())
     assert "error" in result
 
 
 @pytest.mark.asyncio
 async def test_join(mock_backend):
-    result = json.loads(
-        await handle_chats(mock_backend, "join", ChatOptions(link_or_hash="abc123"))
+    result = await handle_chats(
+        mock_backend, "join", ChatOptions(link_or_hash="abc123")
     )
     assert result["joined"] is True
 
 
 @pytest.mark.asyncio
 async def test_join_missing_params(mock_backend):
-    result = json.loads(await handle_chats(mock_backend, "join", ChatOptions()))
+    result = await handle_chats(mock_backend, "join", ChatOptions())
     assert "error" in result
 
 
 @pytest.mark.asyncio
 async def test_leave(mock_backend):
-    result = json.loads(
-        await handle_chats(mock_backend, "leave", ChatOptions(chat_id=123))
-    )
+    result = await handle_chats(mock_backend, "leave", ChatOptions(chat_id=123))
     assert result["left"] is True
 
 
 @pytest.mark.asyncio
 async def test_leave_missing_params(mock_backend):
-    result = json.loads(await handle_chats(mock_backend, "leave", ChatOptions()))
+    result = await handle_chats(mock_backend, "leave", ChatOptions())
     assert "error" in result
 
 
 @pytest.mark.asyncio
 async def test_members(mock_backend):
-    result = json.loads(
-        await handle_chats(mock_backend, "members", ChatOptions(chat_id=123, limit=10))
+    result = await handle_chats(
+        mock_backend, "members", ChatOptions(chat_id=123, limit=10)
     )
     assert result["members"] == []
     assert result["count"] == 0
@@ -86,75 +78,63 @@ async def test_members(mock_backend):
 
 @pytest.mark.asyncio
 async def test_members_missing_params(mock_backend):
-    result = json.loads(await handle_chats(mock_backend, "members", ChatOptions()))
+    result = await handle_chats(mock_backend, "members", ChatOptions())
     assert "error" in result
 
 
 @pytest.mark.asyncio
 async def test_admin_promote(mock_backend):
-    result = json.loads(
-        await handle_chats(mock_backend, "admin", ChatOptions(chat_id=123, user_id=456))
+    result = await handle_chats(
+        mock_backend, "admin", ChatOptions(chat_id=123, user_id=456)
     )
     assert result["promoted"] is True
 
 
 @pytest.mark.asyncio
 async def test_admin_demote(mock_backend):
-    result = json.loads(
-        await handle_chats(
-            mock_backend, "admin", ChatOptions(chat_id=123, user_id=456, demote=True)
-        )
+    result = await handle_chats(
+        mock_backend, "admin", ChatOptions(chat_id=123, user_id=456, demote=True)
     )
     assert result["demoted"] is True
 
 
 @pytest.mark.asyncio
 async def test_admin_missing_params(mock_backend):
-    result = json.loads(
-        await handle_chats(mock_backend, "admin", ChatOptions(chat_id=123))
-    )
+    result = await handle_chats(mock_backend, "admin", ChatOptions(chat_id=123))
     assert "error" in result
 
 
 @pytest.mark.asyncio
 async def test_settings(mock_backend):
-    result = json.loads(
-        await handle_chats(
-            mock_backend,
-            "settings",
-            ChatOptions(
-                chat_id=123,
-                title="New Title",
-                description="New Desc",
-            ),
-        )
+    result = await handle_chats(
+        mock_backend,
+        "settings",
+        ChatOptions(
+            chat_id=123,
+            title="New Title",
+            description="New Desc",
+        ),
     )
     assert result["updated"] is True
 
 
 @pytest.mark.asyncio
 async def test_settings_missing_chat_id(mock_backend):
-    result = json.loads(
-        await handle_chats(mock_backend, "settings", ChatOptions(title="X"))
-    )
+    result = await handle_chats(mock_backend, "settings", ChatOptions(title="X"))
     assert "error" in result
 
 
 @pytest.mark.asyncio
 async def test_settings_no_fields(mock_backend):
-    result = json.loads(
-        await handle_chats(mock_backend, "settings", ChatOptions(chat_id=123))
-    )
+    result = await handle_chats(mock_backend, "settings", ChatOptions(chat_id=123))
     assert "error" in result
 
 
 @pytest.mark.asyncio
 async def test_topics(mock_backend):
     mock_backend.manage_topics.return_value = {"topics": []}
-    result = json.loads(
-        await handle_chats(
-            mock_backend, "topics", ChatOptions(chat_id=123, topic_action="list")
-        )
+    result = await handle_chats(
+        mock_backend, "topics", ChatOptions(chat_id=123, topic_action="list")
     )
     assert "topics" in result
 
@@ -162,16 +142,14 @@ async def test_topics(mock_backend):
 @pytest.mark.asyncio
 async def test_topics_create(mock_backend):
     mock_backend.manage_topics.return_value = {"topic_id": 1}
-    result = json.loads(
-        await handle_chats(
-            mock_backend,
-            "topics",
-            ChatOptions(
-                chat_id=123,
-                topic_action="create",
-                topic_name="General",
-            ),
-        )
+    result = await handle_chats(
+        mock_backend,
+        "topics",
+        ChatOptions(
+            chat_id=123,
+            topic_action="create",
+            topic_name="General",
+        ),
     )
     assert result["topic_id"] == 1
 
@@ -179,16 +157,14 @@ async def test_topics_create(mock_backend):
 @pytest.mark.asyncio
 async def test_topics_close_with_id(mock_backend):
     mock_backend.manage_topics.return_value = {"closed": True}
-    result = json.loads(
-        await handle_chats(
-            mock_backend,
-            "topics",
-            ChatOptions(
-                chat_id=123,
-                topic_action="close",
-                topic_id=42,
-            ),
-        )
+    result = await handle_chats(
+        mock_backend,
+        "topics",
+        ChatOptions(
+            chat_id=123,
+            topic_action="close",
+            topic_id=42,
+        ),
     )
     assert result["closed"] is True
     mock_backend.manage_topics.assert_awaited_once_with(123, "close", topic_id=42)
@@ -196,23 +172,21 @@ async def test_topics_close_with_id(mock_backend):
 
 @pytest.mark.asyncio
 async def test_topics_missing_chat_id(mock_backend):
-    result = json.loads(
-        await handle_chats(mock_backend, "topics", ChatOptions(topic_action="list"))
+    result = await handle_chats(
+        mock_backend, "topics", ChatOptions(topic_action="list")
     )
     assert "error" in result
 
 
 @pytest.mark.asyncio
 async def test_topics_missing_action(mock_backend):
-    result = json.loads(
-        await handle_chats(mock_backend, "topics", ChatOptions(chat_id=123))
-    )
+    result = await handle_chats(mock_backend, "topics", ChatOptions(chat_id=123))
     assert "error" in result
 
 
 @pytest.mark.asyncio
 async def test_unknown_action(mock_backend):
-    result = json.loads(await handle_chats(mock_backend, "unknown", ChatOptions()))
+    result = await handle_chats(mock_backend, "unknown", ChatOptions())
     assert "error" in result
     assert "Unknown action" in result["error"]
 
@@ -220,7 +194,7 @@ async def test_unknown_action(mock_backend):
 @pytest.mark.asyncio
 async def test_mode_error(mock_backend):
     mock_backend.list_chats.side_effect = ModeError("user")
-    result = json.loads(await handle_chats(mock_backend, "list", ChatOptions()))
+    result = await handle_chats(mock_backend, "list", ChatOptions())
     assert "error" in result
     assert "user mode" in result["error"]
 
@@ -228,28 +202,24 @@ async def test_mode_error(mock_backend):
 @pytest.mark.asyncio
 async def test_general_exception(mock_backend):
     mock_backend.get_chat_info.side_effect = RuntimeError("fail")
-    result = json.loads(
-        await handle_chats(mock_backend, "info", ChatOptions(chat_id=123))
-    )
+    result = await handle_chats(mock_backend, "info", ChatOptions(chat_id=123))
     assert "error" in result
     assert "RuntimeError" in result["error"]
 
 
 @pytest.mark.asyncio
 async def test_unknown_action_suggestion(mock_backend):
-    result = json.loads(await handle_chats(mock_backend, "lisst", ChatOptions()))
+    result = await handle_chats(mock_backend, "lisst", ChatOptions())
     assert "error" in result
     assert "Did you mean 'list'?" in result["error"]
 
 
 @pytest.mark.asyncio
 async def test_settings_title_only(mock_backend):
-    result = json.loads(
-        await handle_chats(
-            mock_backend,
-            "settings",
-            ChatOptions(chat_id=123, title="Only Title"),
-        )
+    result = await handle_chats(
+        mock_backend,
+        "settings",
+        ChatOptions(chat_id=123, title="Only Title"),
     )
     assert result["updated"] is True
     mock_backend.update_chat_settings.assert_awaited_once_with(123, title="Only Title")
@@ -257,12 +227,10 @@ async def test_settings_title_only(mock_backend):
 
 @pytest.mark.asyncio
 async def test_settings_description_only(mock_backend):
-    result = json.loads(
-        await handle_chats(
-            mock_backend,
-            "settings",
-            ChatOptions(chat_id=123, description="Only Desc"),
-        )
+    result = await handle_chats(
+        mock_backend,
+        "settings",
+        ChatOptions(chat_id=123, description="Only Desc"),
     )
     assert result["updated"] is True
     mock_backend.update_chat_settings.assert_awaited_once_with(
@@ -273,17 +241,15 @@ async def test_settings_description_only(mock_backend):
 @pytest.mark.asyncio
 async def test_topics_complex(mock_backend):
     mock_backend.manage_topics.return_value = {"ok": True}
-    result = json.loads(
-        await handle_chats(
-            mock_backend,
-            "topics",
-            ChatOptions(
-                chat_id=123,
-                topic_action="rename",
-                topic_id=42,
-                topic_name="New Name",
-            ),
-        )
+    result = await handle_chats(
+        mock_backend,
+        "topics",
+        ChatOptions(
+            chat_id=123,
+            topic_action="rename",
+            topic_id=42,
+            topic_name="New Name",
+        ),
     )
     assert result["ok"] is True
     mock_backend.manage_topics.assert_awaited_once_with(

--- a/tests/test_tools/test_config_tool.py
+++ b/tests/test_tools/test_config_tool.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import json
-
 import pytest
 
 from better_telegram_mcp.tools.config_tool import handle_config
@@ -9,7 +7,7 @@ from better_telegram_mcp.tools.config_tool import handle_config
 
 @pytest.mark.asyncio
 async def test_status(mock_backend):
-    result = json.loads(await handle_config(mock_backend, "status"))
+    result = await handle_config(mock_backend, "status")
     assert result["mode"] == "bot"
     assert result["connected"] is True
     assert result["authorized"] is True
@@ -20,7 +18,7 @@ async def test_status(mock_backend):
 
 @pytest.mark.asyncio
 async def test_status_user_mode(mock_user_backend):
-    result = json.loads(await handle_config(mock_user_backend, "status"))
+    result = await handle_config(mock_user_backend, "status")
     assert result["mode"] == "user"
     assert result["connected"] is True
     assert result["authorized"] is True
@@ -33,7 +31,7 @@ async def test_status_shows_pending_auth(mock_backend):
     old = srv._pending_auth
     try:
         srv._pending_auth = True
-        result = json.loads(await handle_config(mock_backend, "status"))
+        result = await handle_config(mock_backend, "status")
         assert result["pending_auth"] is True
     finally:
         srv._pending_auth = old
@@ -41,39 +39,35 @@ async def test_status_shows_pending_auth(mock_backend):
 
 @pytest.mark.asyncio
 async def test_set_message_limit(mock_backend):
-    result = json.loads(await handle_config(mock_backend, "set", message_limit=50))
+    result = await handle_config(mock_backend, "set", message_limit=50)
     assert result["updated"]["message_limit"] == 50
     assert result["current"]["message_limit"] == 50
 
 
 @pytest.mark.asyncio
 async def test_set_timeout(mock_backend):
-    result = json.loads(await handle_config(mock_backend, "set", timeout=60))
+    result = await handle_config(mock_backend, "set", timeout=60)
     assert result["updated"]["timeout"] == 60
     assert result["current"]["timeout"] == 60
 
 
 @pytest.mark.asyncio
 async def test_set_both(mock_backend):
-    result = json.loads(
-        await handle_config(mock_backend, "set", message_limit=100, timeout=90)
-    )
+    result = await handle_config(mock_backend, "set", message_limit=100, timeout=90)
     assert result["updated"]["message_limit"] == 100
     assert result["updated"]["timeout"] == 90
 
 
 @pytest.mark.asyncio
 async def test_set_no_params(mock_backend):
-    result = json.loads(await handle_config(mock_backend, "set"))
+    result = await handle_config(mock_backend, "set")
     assert "error" in result
     assert "set requires" in result["error"]
 
 
 @pytest.mark.asyncio
 async def test_set_none_params(mock_backend):
-    result = json.loads(
-        await handle_config(mock_backend, "set", message_limit=None, timeout=None)
-    )
+    result = await handle_config(mock_backend, "set", message_limit=None, timeout=None)
     assert "error" in result
     assert "set requires" in result["error"]
 
@@ -81,13 +75,13 @@ async def test_set_none_params(mock_backend):
 @pytest.mark.asyncio
 async def test_set_persists_across_calls(mock_backend):
     await handle_config(mock_backend, "set", message_limit=42)
-    result = json.loads(await handle_config(mock_backend, "status"))
+    result = await handle_config(mock_backend, "status")
     assert result["config"]["message_limit"] == 42
 
 
 @pytest.mark.asyncio
 async def test_cache_clear(mock_backend):
-    result = json.loads(await handle_config(mock_backend, "cache_clear"))
+    result = await handle_config(mock_backend, "cache_clear")
     assert "message" in result
     assert "Cache cleared" in result["message"]
     mock_backend.clear_cache.assert_awaited_once()
@@ -95,14 +89,14 @@ async def test_cache_clear(mock_backend):
 
 @pytest.mark.asyncio
 async def test_cache_clear_user_mode(mock_user_backend):
-    result = json.loads(await handle_config(mock_user_backend, "cache_clear"))
+    result = await handle_config(mock_user_backend, "cache_clear")
     assert "Cache cleared" in result["message"]
     mock_user_backend.clear_cache.assert_awaited_once()
 
 
 @pytest.mark.asyncio
 async def test_unknown_action(mock_backend):
-    result = json.loads(await handle_config(mock_backend, "unknown"))
+    result = await handle_config(mock_backend, "unknown")
     assert "error" in result
     assert "Unknown action" in result["error"]
 
@@ -110,7 +104,7 @@ async def test_unknown_action(mock_backend):
 @pytest.mark.asyncio
 async def test_general_exception(mock_backend):
     mock_backend.is_connected.side_effect = RuntimeError("fail")
-    result = json.loads(await handle_config(mock_backend, "status"))
+    result = await handle_config(mock_backend, "status")
     assert "error" in result
     assert "RuntimeError" in result["error"]
 

--- a/tests/test_tools/test_contacts.py
+++ b/tests/test_tools/test_contacts.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import json
-
 from better_telegram_mcp.backends.base import ModeError
 from better_telegram_mcp.backends.security import SecurityError
 from better_telegram_mcp.tools.contacts import ContactsOptions, handle_contacts
@@ -9,7 +7,7 @@ from better_telegram_mcp.tools.contacts import ContactsOptions, handle_contacts
 
 async def test_list(mock_backend):
     mock_backend.list_contacts.return_value = [{"user_id": 123, "first_name": "John"}]
-    result = json.loads(await handle_contacts(mock_backend, "list"))
+    result = await handle_contacts(mock_backend, "list")
     assert result["contacts"] == [{"user_id": 123, "first_name": "John"}]
     assert result["count"] == 1
     mock_backend.list_contacts.assert_awaited_once_with()
@@ -17,8 +15,8 @@ async def test_list(mock_backend):
 
 async def test_search(mock_backend):
     mock_backend.search_contacts.return_value = [{"user_id": 123, "first_name": "John"}]
-    result = json.loads(
-        await handle_contacts(mock_backend, "search", ContactsOptions(query="John"))
+    result = await handle_contacts(
+        mock_backend, "search", ContactsOptions(query="John")
     )
     assert result["contacts"] == [{"user_id": 123, "first_name": "John"}]
     assert result["count"] == 1
@@ -26,21 +24,19 @@ async def test_search(mock_backend):
 
 
 async def test_search_missing_params(mock_backend):
-    result = json.loads(await handle_contacts(mock_backend, "search"))
+    result = await handle_contacts(mock_backend, "search")
     assert "error" in result
 
 
 async def test_add(mock_backend):
-    result = json.loads(
-        await handle_contacts(
-            mock_backend,
-            "add",
-            ContactsOptions(
-                phone="+1234567890",
-                first_name="John",
-                last_name="Doe",
-            ),
-        )
+    result = await handle_contacts(
+        mock_backend,
+        "add",
+        ContactsOptions(
+            phone="+1234567890",
+            first_name="John",
+            last_name="Doe",
+        ),
     )
     assert result["added"] is True
     mock_backend.add_contact.assert_awaited_once_with(
@@ -49,15 +45,13 @@ async def test_add(mock_backend):
 
 
 async def test_add_no_last_name(mock_backend):
-    result = json.loads(
-        await handle_contacts(
-            mock_backend,
-            "add",
-            ContactsOptions(
-                phone="+1234567890",
-                first_name="John",
-            ),
-        )
+    result = await handle_contacts(
+        mock_backend,
+        "add",
+        ContactsOptions(
+            phone="+1234567890",
+            first_name="John",
+        ),
     )
     assert result["added"] is True
     mock_backend.add_contact.assert_awaited_once_with(
@@ -67,96 +61,84 @@ async def test_add_no_last_name(mock_backend):
 
 async def test_add_failure(mock_backend):
     mock_backend.add_contact.return_value = False
-    result = json.loads(
-        await handle_contacts(
-            mock_backend,
-            "add",
-            ContactsOptions(
-                phone="+1234567890",
-                first_name="John",
-            ),
-        )
+    result = await handle_contacts(
+        mock_backend,
+        "add",
+        ContactsOptions(
+            phone="+1234567890",
+            first_name="John",
+        ),
     )
     assert result["added"] is False
 
 
 async def test_add_missing_params(mock_backend):
-    result = json.loads(
-        await handle_contacts(mock_backend, "add", ContactsOptions(phone="+123"))
-    )
+    result = await handle_contacts(mock_backend, "add", ContactsOptions(phone="+123"))
     assert "error" in result
 
-    result = json.loads(
-        await handle_contacts(mock_backend, "add", ContactsOptions(first_name="John"))
+    result = await handle_contacts(
+        mock_backend, "add", ContactsOptions(first_name="John")
     )
     assert "error" in result
 
 
 async def test_block(mock_backend):
-    result = json.loads(
-        await handle_contacts(mock_backend, "block", ContactsOptions(user_id=123))
-    )
+    result = await handle_contacts(mock_backend, "block", ContactsOptions(user_id=123))
     assert result["blocked"] is True
     mock_backend.block_user.assert_awaited_once_with(123, unblock=False)
 
 
 async def test_block_explicit_false(mock_backend):
-    result = json.loads(
-        await handle_contacts(
-            mock_backend, "block", ContactsOptions(user_id=123, unblock=False)
-        )
+    result = await handle_contacts(
+        mock_backend, "block", ContactsOptions(user_id=123, unblock=False)
     )
     assert result["blocked"] is True
     mock_backend.block_user.assert_awaited_once_with(123, unblock=False)
 
 
 async def test_unblock(mock_backend):
-    result = json.loads(
-        await handle_contacts(
-            mock_backend, "block", ContactsOptions(user_id=123, unblock=True)
-        )
+    result = await handle_contacts(
+        mock_backend, "block", ContactsOptions(user_id=123, unblock=True)
     )
     assert result["unblocked"] is True
     mock_backend.block_user.assert_awaited_once_with(123, unblock=True)
 
 
 async def test_block_missing_params(mock_backend):
-    result = json.loads(await handle_contacts(mock_backend, "block"))
+    result = await handle_contacts(mock_backend, "block")
     assert "error" in result
 
 
 async def test_unknown_action(mock_backend):
-    result = json.loads(await handle_contacts(mock_backend, "unknown"))
+    result = await handle_contacts(mock_backend, "unknown")
     assert "error" in result
     assert "Unknown action" in result["error"]
 
 
 async def test_mode_error(mock_backend):
     mock_backend.list_contacts.side_effect = ModeError("user")
-    result = json.loads(await handle_contacts(mock_backend, "list"))
+    result = await handle_contacts(mock_backend, "list")
     assert "error" in result
     assert "user mode" in result["error"]
 
 
 async def test_general_exception(mock_backend):
     mock_backend.add_contact.side_effect = RuntimeError("network error")
-    result = json.loads(
-        await handle_contacts(
-            mock_backend, "add", ContactsOptions(phone="+1", first_name="X")
-        )
+    result = await handle_contacts(
+        mock_backend, "add", ContactsOptions(phone="+1", first_name="X")
     )
     assert "error" in result
     assert "RuntimeError" in result["error"]
 
 
 async def test_unknown_action_suggestion(mock_backend):
-    result = json.loads(await handle_contacts(mock_backend, "lisst"))
+    result = await handle_contacts(mock_backend, "lisst")
     assert "error" in result
     assert "Did you mean 'list'?" in result["error"]
 
 
 async def test_security_error(mock_backend):
     mock_backend.list_contacts.side_effect = SecurityError("Blocked")
-    result = json.loads(await handle_contacts(mock_backend, "list"))
+    result = await handle_contacts(mock_backend, "list")
     assert "error" in result
     assert "Blocked" in result["error"]

--- a/tests/test_tools/test_media.py
+++ b/tests/test_tools/test_media.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import json
-
 import pytest
 
 from better_telegram_mcp.backends.base import ModeError
@@ -11,16 +9,14 @@ from better_telegram_mcp.tools.media import MediaOptions, handle_media
 
 @pytest.mark.asyncio
 async def test_send_photo(mock_backend):
-    result = json.loads(
-        await handle_media(
-            mock_backend,
-            "send_photo",
-            MediaOptions(
-                chat_id=123,
-                file_path_or_url="https://example.com/photo.jpg",
-                caption="Nice photo",
-            ),
-        )
+    result = await handle_media(
+        mock_backend,
+        "send_photo",
+        MediaOptions(
+            chat_id=123,
+            file_path_or_url="https://example.com/photo.jpg",
+            caption="Nice photo",
+        ),
     )
     assert result["message_id"] == 3
     mock_backend.send_media.assert_awaited_once_with(
@@ -30,15 +26,13 @@ async def test_send_photo(mock_backend):
 
 @pytest.mark.asyncio
 async def test_send_file(mock_backend):
-    result = json.loads(
-        await handle_media(
-            mock_backend,
-            "send_file",
-            MediaOptions(
-                chat_id=123,
-                file_path_or_url="/tmp/doc.pdf",
-            ),
-        )
+    result = await handle_media(
+        mock_backend,
+        "send_file",
+        MediaOptions(
+            chat_id=123,
+            file_path_or_url="/tmp/doc.pdf",
+        ),
     )
     assert result["message_id"] == 3
     mock_backend.send_media.assert_awaited_once_with(
@@ -48,16 +42,14 @@ async def test_send_file(mock_backend):
 
 @pytest.mark.asyncio
 async def test_send_file_with_caption(mock_backend):
-    result = json.loads(
-        await handle_media(
-            mock_backend,
-            "send_file",
-            MediaOptions(
-                chat_id=123,
-                file_path_or_url="/tmp/doc.pdf",
-                caption="Document caption",
-            ),
-        )
+    result = await handle_media(
+        mock_backend,
+        "send_file",
+        MediaOptions(
+            chat_id=123,
+            file_path_or_url="/tmp/doc.pdf",
+            caption="Document caption",
+        ),
     )
     assert result["message_id"] == 3
     mock_backend.send_media.assert_awaited_once_with(
@@ -67,15 +59,13 @@ async def test_send_file_with_caption(mock_backend):
 
 @pytest.mark.asyncio
 async def test_send_voice(mock_backend):
-    result = json.loads(
-        await handle_media(
-            mock_backend,
-            "send_voice",
-            MediaOptions(
-                chat_id=123,
-                file_path_or_url="/tmp/voice.ogg",
-            ),
-        )
+    result = await handle_media(
+        mock_backend,
+        "send_voice",
+        MediaOptions(
+            chat_id=123,
+            file_path_or_url="/tmp/voice.ogg",
+        ),
     )
     assert result["message_id"] == 3
     mock_backend.send_media.assert_awaited_once_with(
@@ -85,16 +75,14 @@ async def test_send_voice(mock_backend):
 
 @pytest.mark.asyncio
 async def test_send_voice_with_caption(mock_backend):
-    result = json.loads(
-        await handle_media(
-            mock_backend,
-            "send_voice",
-            MediaOptions(
-                chat_id=123,
-                file_path_or_url="/tmp/voice.ogg",
-                caption="Voice caption",
-            ),
-        )
+    result = await handle_media(
+        mock_backend,
+        "send_voice",
+        MediaOptions(
+            chat_id=123,
+            file_path_or_url="/tmp/voice.ogg",
+            caption="Voice caption",
+        ),
     )
     assert result["message_id"] == 3
     mock_backend.send_media.assert_awaited_once_with(
@@ -104,15 +92,13 @@ async def test_send_voice_with_caption(mock_backend):
 
 @pytest.mark.asyncio
 async def test_send_video(mock_backend):
-    result = json.loads(
-        await handle_media(
-            mock_backend,
-            "send_video",
-            MediaOptions(
-                chat_id=123,
-                file_path_or_url="/tmp/video.mp4",
-            ),
-        )
+    result = await handle_media(
+        mock_backend,
+        "send_video",
+        MediaOptions(
+            chat_id=123,
+            file_path_or_url="/tmp/video.mp4",
+        ),
     )
     assert result["message_id"] == 3
     mock_backend.send_media.assert_awaited_once_with(
@@ -122,16 +108,14 @@ async def test_send_video(mock_backend):
 
 @pytest.mark.asyncio
 async def test_send_video_with_caption(mock_backend):
-    result = json.loads(
-        await handle_media(
-            mock_backend,
-            "send_video",
-            MediaOptions(
-                chat_id=123,
-                file_path_or_url="/tmp/video.mp4",
-                caption="Video caption",
-            ),
-        )
+    result = await handle_media(
+        mock_backend,
+        "send_video",
+        MediaOptions(
+            chat_id=123,
+            file_path_or_url="/tmp/video.mp4",
+            caption="Video caption",
+        ),
     )
     assert result["message_id"] == 3
     mock_backend.send_media.assert_awaited_once_with(
@@ -141,20 +125,16 @@ async def test_send_video_with_caption(mock_backend):
 
 @pytest.mark.asyncio
 async def test_send_photo_missing_params(mock_backend):
-    result = json.loads(
-        await handle_media(mock_backend, "send_photo", MediaOptions(chat_id=123))
-    )
+    result = await handle_media(mock_backend, "send_photo", MediaOptions(chat_id=123))
     assert "error" in result
     assert "requires chat_id and file_path_or_url" in result["error"]
 
-    result = json.loads(
-        await handle_media(
-            mock_backend,
-            "send_photo",
-            MediaOptions(
-                file_path_or_url="https://example.com/photo.jpg",
-            ),
-        )
+    result = await handle_media(
+        mock_backend,
+        "send_photo",
+        MediaOptions(
+            file_path_or_url="https://example.com/photo.jpg",
+        ),
     )
     assert "error" in result
     assert "requires chat_id and file_path_or_url" in result["error"]
@@ -162,38 +142,32 @@ async def test_send_photo_missing_params(mock_backend):
 
 @pytest.mark.asyncio
 async def test_download(mock_backend):
-    result = json.loads(
-        await handle_media(
-            mock_backend,
-            "download",
-            MediaOptions(
-                chat_id=123,
-                message_id=10,
-                output_dir="/tmp",
-            ),
-        )
+    result = await handle_media(
+        mock_backend,
+        "download",
+        MediaOptions(
+            chat_id=123,
+            message_id=10,
+            output_dir="/tmp",
+        ),
     )
     assert result["path"] == "/tmp/file.jpg"
 
 
 @pytest.mark.asyncio
 async def test_download_missing_params(mock_backend):
-    result = json.loads(
-        await handle_media(mock_backend, "download", MediaOptions(chat_id=123))
-    )
+    result = await handle_media(mock_backend, "download", MediaOptions(chat_id=123))
     assert "error" in result
     assert "requires chat_id and message_id" in result["error"]
 
-    result = json.loads(
-        await handle_media(mock_backend, "download", MediaOptions(message_id=10))
-    )
+    result = await handle_media(mock_backend, "download", MediaOptions(message_id=10))
     assert "error" in result
     assert "requires chat_id and message_id" in result["error"]
 
 
 @pytest.mark.asyncio
 async def test_unknown_action(mock_backend):
-    result = json.loads(await handle_media(mock_backend, "unknown", MediaOptions()))
+    result = await handle_media(mock_backend, "unknown", MediaOptions())
     assert "error" in result
     assert "Unknown action 'unknown'" in result["error"]
 
@@ -201,15 +175,13 @@ async def test_unknown_action(mock_backend):
 @pytest.mark.asyncio
 async def test_mode_error(mock_backend):
     mock_backend.send_media.side_effect = ModeError("user")
-    result = json.loads(
-        await handle_media(
-            mock_backend,
-            "send_photo",
-            MediaOptions(
-                chat_id=123,
-                file_path_or_url="https://example.com/photo.jpg",
-            ),
-        )
+    result = await handle_media(
+        mock_backend,
+        "send_photo",
+        MediaOptions(
+            chat_id=123,
+            file_path_or_url="https://example.com/photo.jpg",
+        ),
     )
     assert "error" in result
     assert "user mode" in result["error"]
@@ -218,15 +190,13 @@ async def test_mode_error(mock_backend):
 @pytest.mark.asyncio
 async def test_security_error(mock_backend):
     mock_backend.send_media.side_effect = SecurityError("Blocked path")
-    result = json.loads(
-        await handle_media(
-            mock_backend,
-            "send_photo",
-            MediaOptions(
-                chat_id=123,
-                file_path_or_url="/etc/passwd",
-            ),
-        )
+    result = await handle_media(
+        mock_backend,
+        "send_photo",
+        MediaOptions(
+            chat_id=123,
+            file_path_or_url="/etc/passwd",
+        ),
     )
     assert "error" in result
     assert "Blocked path" in result["error"]
@@ -235,15 +205,13 @@ async def test_security_error(mock_backend):
 @pytest.mark.asyncio
 async def test_value_error(mock_backend):
     mock_backend.send_media.side_effect = ValueError("Invalid chat_id")
-    result = json.loads(
-        await handle_media(
-            mock_backend,
-            "send_photo",
-            MediaOptions(
-                chat_id="invalid",
-                file_path_or_url="https://example.com/photo.jpg",
-            ),
-        )
+    result = await handle_media(
+        mock_backend,
+        "send_photo",
+        MediaOptions(
+            chat_id="invalid",
+            file_path_or_url="https://example.com/photo.jpg",
+        ),
     )
     assert "error" in result
     assert "Invalid chat_id" in result["error"]
@@ -252,15 +220,13 @@ async def test_value_error(mock_backend):
 @pytest.mark.asyncio
 async def test_file_not_found_error(mock_backend):
     mock_backend.send_media.side_effect = FileNotFoundError("File not found")
-    result = json.loads(
-        await handle_media(
-            mock_backend,
-            "send_photo",
-            MediaOptions(
-                chat_id=123,
-                file_path_or_url="/tmp/missing.jpg",
-            ),
-        )
+    result = await handle_media(
+        mock_backend,
+        "send_photo",
+        MediaOptions(
+            chat_id=123,
+            file_path_or_url="/tmp/missing.jpg",
+        ),
     )
     assert "error" in result
     assert "File not found" in result["error"]
@@ -269,10 +235,8 @@ async def test_file_not_found_error(mock_backend):
 @pytest.mark.asyncio
 async def test_general_exception(mock_backend):
     mock_backend.download_media.side_effect = RuntimeError("disk full")
-    result = json.loads(
-        await handle_media(
-            mock_backend, "download", MediaOptions(chat_id=123, message_id=10)
-        )
+    result = await handle_media(
+        mock_backend, "download", MediaOptions(chat_id=123, message_id=10)
     )
     assert "error" in result
     assert "RuntimeError" in result["error"]
@@ -280,26 +244,24 @@ async def test_general_exception(mock_backend):
 
 @pytest.mark.asyncio
 async def test_unknown_action_suggestion(mock_backend):
-    result = json.loads(await handle_media(mock_backend, "send_phot", MediaOptions()))
+    result = await handle_media(mock_backend, "send_phot", MediaOptions())
     assert "error" in result
     assert "Did you mean 'send_photo'?" in result["error"]
 
-    result = json.loads(await handle_media(mock_backend, "downlo", MediaOptions()))
+    result = await handle_media(mock_backend, "downlo", MediaOptions())
     assert "error" in result
     assert "Did you mean 'download'?" in result["error"]
 
 
 @pytest.mark.asyncio
 async def test_download_no_output_dir(mock_backend):
-    result = json.loads(
-        await handle_media(
-            mock_backend,
-            "download",
-            MediaOptions(
-                chat_id=123,
-                message_id=10,
-            ),
-        )
+    result = await handle_media(
+        mock_backend,
+        "download",
+        MediaOptions(
+            chat_id=123,
+            message_id=10,
+        ),
     )
     assert result["path"] == "/tmp/file.jpg"
     mock_backend.download_media.assert_awaited_once_with(123, 10, output_dir=None)
@@ -307,15 +269,13 @@ async def test_download_no_output_dir(mock_backend):
 
 @pytest.mark.asyncio
 async def test_send_photo_string_chat_id(mock_backend):
-    result = json.loads(
-        await handle_media(
-            mock_backend,
-            "send_photo",
-            MediaOptions(
-                chat_id="@username",
-                file_path_or_url="https://example.com/photo.jpg",
-            ),
-        )
+    result = await handle_media(
+        mock_backend,
+        "send_photo",
+        MediaOptions(
+            chat_id="@username",
+            file_path_or_url="https://example.com/photo.jpg",
+        ),
     )
     assert result["message_id"] == 3
     mock_backend.send_media.assert_awaited_once_with(

--- a/tests/test_tools/test_messages.py
+++ b/tests/test_tools/test_messages.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import json
-
 import pytest
 
 from better_telegram_mcp.backends.base import ModeError
@@ -10,10 +8,8 @@ from better_telegram_mcp.tools.messages import MessagesArgs, handle_messages
 
 @pytest.mark.asyncio
 async def test_send(mock_backend):
-    result = json.loads(
-        await handle_messages(
-            mock_backend, MessagesArgs(action="send", chat_id=123, text="hello")
-        )
+    result = await handle_messages(
+        mock_backend, MessagesArgs(action="send", chat_id=123, text="hello")
     )
     assert result["message_id"] == 1
     mock_backend.send_message.assert_awaited_once_with(
@@ -23,17 +19,15 @@ async def test_send(mock_backend):
 
 @pytest.mark.asyncio
 async def test_send_with_reply_and_parse_mode(mock_backend):
-    result = json.loads(
-        await handle_messages(
-            mock_backend,
-            MessagesArgs(
-                action="send",
-                chat_id=123,
-                text="hi",
-                reply_to=5,
-                parse_mode="HTML",
-            ),
-        )
+    result = await handle_messages(
+        mock_backend,
+        MessagesArgs(
+            action="send",
+            chat_id=123,
+            text="hi",
+            reply_to=5,
+            parse_mode="HTML",
+        ),
     )
     assert result["message_id"] == 1
     mock_backend.send_message.assert_awaited_once_with(
@@ -43,24 +37,20 @@ async def test_send_with_reply_and_parse_mode(mock_backend):
 
 @pytest.mark.asyncio
 async def test_send_missing_params(mock_backend):
-    result = json.loads(
-        await handle_messages(mock_backend, MessagesArgs(action="send"))
-    )
+    result = await handle_messages(mock_backend, MessagesArgs(action="send"))
     assert "error" in result
 
-    result = json.loads(
-        await handle_messages(mock_backend, MessagesArgs(action="send", chat_id=123))
+    result = await handle_messages(
+        mock_backend, MessagesArgs(action="send", chat_id=123)
     )
     assert "error" in result
 
 
 @pytest.mark.asyncio
 async def test_edit(mock_backend):
-    result = json.loads(
-        await handle_messages(
-            mock_backend,
-            MessagesArgs(action="edit", chat_id=123, message_id=1, text="edited"),
-        )
+    result = await handle_messages(
+        mock_backend,
+        MessagesArgs(action="edit", chat_id=123, message_id=1, text="edited"),
     )
     assert result["message_id"] == 1
     mock_backend.edit_message.assert_awaited_once_with(
@@ -70,110 +60,92 @@ async def test_edit(mock_backend):
 
 @pytest.mark.asyncio
 async def test_edit_missing_params(mock_backend):
-    result = json.loads(
-        await handle_messages(
-            mock_backend, MessagesArgs(action="edit", chat_id=123, text="x")
-        )
+    result = await handle_messages(
+        mock_backend, MessagesArgs(action="edit", chat_id=123, text="x")
     )
     assert "error" in result
 
-    result = json.loads(
-        await handle_messages(
-            mock_backend, MessagesArgs(action="edit", chat_id=123, message_id=1)
-        )
+    result = await handle_messages(
+        mock_backend, MessagesArgs(action="edit", chat_id=123, message_id=1)
     )
     assert "error" in result
 
 
 @pytest.mark.asyncio
 async def test_delete(mock_backend):
-    result = json.loads(
-        await handle_messages(
-            mock_backend, MessagesArgs(action="delete", chat_id=123, message_id=1)
-        )
+    result = await handle_messages(
+        mock_backend, MessagesArgs(action="delete", chat_id=123, message_id=1)
     )
     assert result["deleted"] is True
 
 
 @pytest.mark.asyncio
 async def test_delete_missing_params(mock_backend):
-    result = json.loads(
-        await handle_messages(mock_backend, MessagesArgs(action="delete", chat_id=123))
+    result = await handle_messages(
+        mock_backend, MessagesArgs(action="delete", chat_id=123)
     )
     assert "error" in result
 
 
 @pytest.mark.asyncio
 async def test_forward(mock_backend):
-    result = json.loads(
-        await handle_messages(
-            mock_backend,
-            MessagesArgs(
-                action="forward",
-                from_chat=1,
-                to_chat=2,
-                message_id=10,
-            ),
-        )
+    result = await handle_messages(
+        mock_backend,
+        MessagesArgs(
+            action="forward",
+            from_chat=1,
+            to_chat=2,
+            message_id=10,
+        ),
     )
     assert result["message_id"] == 2
 
 
 @pytest.mark.asyncio
 async def test_forward_missing_params(mock_backend):
-    result = json.loads(
-        await handle_messages(
-            mock_backend, MessagesArgs(action="forward", from_chat=1, to_chat=2)
-        )
+    result = await handle_messages(
+        mock_backend, MessagesArgs(action="forward", from_chat=1, to_chat=2)
     )
     assert "error" in result
 
 
 @pytest.mark.asyncio
 async def test_pin(mock_backend):
-    result = json.loads(
-        await handle_messages(
-            mock_backend, MessagesArgs(action="pin", chat_id=123, message_id=1)
-        )
+    result = await handle_messages(
+        mock_backend, MessagesArgs(action="pin", chat_id=123, message_id=1)
     )
     assert result["pinned"] is True
 
 
 @pytest.mark.asyncio
 async def test_pin_missing_params(mock_backend):
-    result = json.loads(
-        await handle_messages(mock_backend, MessagesArgs(action="pin", chat_id=123))
+    result = await handle_messages(
+        mock_backend, MessagesArgs(action="pin", chat_id=123)
     )
     assert "error" in result
 
 
 @pytest.mark.asyncio
 async def test_react(mock_backend):
-    result = json.loads(
-        await handle_messages(
-            mock_backend,
-            MessagesArgs(action="react", chat_id=123, message_id=1, emoji="👍"),
-        )
+    result = await handle_messages(
+        mock_backend,
+        MessagesArgs(action="react", chat_id=123, message_id=1, emoji="👍"),
     )
     assert result["reacted"] is True
 
 
 @pytest.mark.asyncio
 async def test_react_missing_params(mock_backend):
-    result = json.loads(
-        await handle_messages(
-            mock_backend, MessagesArgs(action="react", chat_id=123, message_id=1)
-        )
+    result = await handle_messages(
+        mock_backend, MessagesArgs(action="react", chat_id=123, message_id=1)
     )
     assert "error" in result
 
 
 @pytest.mark.asyncio
 async def test_search(mock_backend):
-    result = json.loads(
-        await handle_messages(
-            mock_backend, MessagesArgs(action="search", query="test", limit=10)
-        )
+    result = await handle_messages(
+        mock_backend, MessagesArgs(action="search", query="test", limit=10)
     )
     assert result["messages"] == []
     assert result["count"] == 0
@@ -181,19 +153,15 @@ async def test_search(mock_backend):
 
 @pytest.mark.asyncio
 async def test_search_missing_params(mock_backend):
-    result = json.loads(
-        await handle_messages(mock_backend, MessagesArgs(action="search"))
-    )
+    result = await handle_messages(mock_backend, MessagesArgs(action="search"))
     assert "error" in result
 
 
 @pytest.mark.asyncio
 async def test_history(mock_backend):
-    result = json.loads(
-        await handle_messages(
-            mock_backend,
-            MessagesArgs(action="history", chat_id=123, limit=5, offset_id=100),
-        )
+    result = await handle_messages(
+        mock_backend,
+        MessagesArgs(action="history", chat_id=123, limit=5, offset_id=100),
     )
     assert result["messages"] == []
     assert result["count"] == 0
@@ -201,17 +169,13 @@ async def test_history(mock_backend):
 
 @pytest.mark.asyncio
 async def test_history_missing_params(mock_backend):
-    result = json.loads(
-        await handle_messages(mock_backend, MessagesArgs(action="history"))
-    )
+    result = await handle_messages(mock_backend, MessagesArgs(action="history"))
     assert "error" in result
 
 
 @pytest.mark.asyncio
 async def test_unknown_action(mock_backend):
-    result = json.loads(
-        await handle_messages(mock_backend, MessagesArgs(action="unknown"))
-    )
+    result = await handle_messages(mock_backend, MessagesArgs(action="unknown"))
     assert "error" in result
     assert "Unknown action" in result["error"]
 
@@ -219,8 +183,8 @@ async def test_unknown_action(mock_backend):
 @pytest.mark.asyncio
 async def test_mode_error(mock_backend):
     mock_backend.search_messages.side_effect = ModeError("user")
-    result = json.loads(
-        await handle_messages(mock_backend, MessagesArgs(action="search", query="test"))
+    result = await handle_messages(
+        mock_backend, MessagesArgs(action="search", query="test")
     )
     assert "error" in result
     assert "user mode" in result["error"]
@@ -229,10 +193,8 @@ async def test_mode_error(mock_backend):
 @pytest.mark.asyncio
 async def test_general_exception(mock_backend):
     mock_backend.send_message.side_effect = RuntimeError("boom")
-    result = json.loads(
-        await handle_messages(
-            mock_backend, MessagesArgs(action="send", chat_id=1, text="x")
-        )
+    result = await handle_messages(
+        mock_backend, MessagesArgs(action="send", chat_id=1, text="x")
     )
     assert "error" in result
     assert "RuntimeError" in result["error"]
@@ -241,9 +203,7 @@ async def test_general_exception(mock_backend):
 @pytest.mark.asyncio
 async def test_unknown_action_suggestion(mock_backend):
     # 'sendd' should suggest 'send'
-    result = json.loads(
-        await handle_messages(mock_backend, MessagesArgs(action="sendd"))
-    )
+    result = await handle_messages(mock_backend, MessagesArgs(action="sendd"))
     assert "error" in result
     assert "Unknown action 'sendd'." in result["error"]
     assert "Did you mean 'send'?" in result["error"]

--- a/tests/test_utils/test_formatting.py
+++ b/tests/test_utils/test_formatting.py
@@ -1,89 +1,49 @@
-import json
-from datetime import datetime
+from __future__ import annotations
 
 from better_telegram_mcp.backends.base import ModeError
 from better_telegram_mcp.backends.security import SecurityError
 from better_telegram_mcp.utils.formatting import err, ok, safe_error
 
 
-def test_ok_basic_serialization():
+def test_ok_basic_passthrough():
     data = {"key": "value", "number": 42}
-    result = ok(data)
-    assert result == '{"key": "value", "number": 42}'
-    assert json.loads(result) == data
+    assert ok(data) == data
 
 
-def test_ok_unicode_handling():
+def test_ok_unicode_passthrough():
     data = {"emoji": "😊", "cyrillic": "Привет", "chinese": "你好"}
     result = ok(data)
-    # Ensure Unicode characters are NOT escaped (ensure_ascii=False)
-    assert "😊" in result
-    assert "Привет" in result
-    assert "你好" in result
-    assert json.loads(result) == data
+    assert result["emoji"] == "😊"
+    assert result["cyrillic"] == "Привет"
+    assert result["chinese"] == "你好"
 
 
-def test_ok_unserializable_objects():
-    # Objects that aren't natively JSON serializable should fallback to str
-    class CustomObject:
-        def __str__(self):
-            return "CustomObjectString"
+def test_ok_empty_dict():
+    assert ok({}) == {}
 
-    dt = datetime(2024, 1, 1, 12, 0, 0)
-    data = {"date": dt, "custom": CustomObject()}
 
+def test_ok_nested_mixed_types():
+    data = {
+        "str": "text",
+        "nested": {"val": 1},
+        "list": [1, {"a": 1}],
+    }
     result = ok(data)
-    assert '"date": "2024-01-01 12:00:00"' in result
-    assert '"custom": "CustomObjectString"' in result
-
-    parsed = json.loads(result)
-    assert parsed["date"] == "2024-01-01 12:00:00"
-    assert parsed["custom"] == "CustomObjectString"
+    assert result is data
+    assert result["nested"]["val"] == 1
+    assert result["list"][1] == {"a": 1}
 
 
-def test_ok_edge_cases():
-    assert ok(None) == "null"
-    assert ok([]) == "[]"
-    assert ok({}) == "{}"
-
-
-def test_ok_collections():
-    # set is not JSON serializable, should use str() via default=str
-    data = {"s": {1, 2, 3}}
-    result = ok(data)
-    parsed = json.loads(result)
-    # set str representation contains 1, 2, 3 and is wrapped in {}
-    assert isinstance(parsed["s"], str)
-    assert "1" in parsed["s"]
-    assert "2" in parsed["s"]
-    assert "3" in parsed["s"]
-    assert parsed["s"].startswith("{")
-    assert parsed["s"].endswith("}")
-
-
-def test_err_basic_serialization():
+def test_err_basic():
     message = "Something went wrong"
     result = err(message)
-    assert result == '{"error": "Something went wrong"}'
-
-    parsed = json.loads(result)
-    assert parsed["error"] == message
+    assert result == {"error": message}
 
 
-def test_err_unicode_handling():
+def test_err_unicode():
     message = "Ошибка: ❌"
     result = err(message)
-    # Ensure Unicode characters are NOT escaped
-    assert "Ошибка: ❌" in result
-
-    parsed = json.loads(result)
-    assert parsed["error"] == message
-
-
-def test_err_non_string_input():
-    # err() expects a str, but json.dumps handles other types too
-    result = err(123)
-    assert json.loads(result) == {"error": 123}
+    assert result == {"error": message}
 
 
 def test_safe_error_allowed_exceptions():
@@ -101,8 +61,7 @@ def test_safe_error_allowed_exceptions():
 
     for exc, expected_msg in allowed_exceptions:
         result = safe_error(exc)
-        parsed = json.loads(result)
-        assert parsed["error"] == expected_msg
+        assert result == {"error": expected_msg}
 
 
 def test_safe_error_generic_exceptions():
@@ -116,28 +75,27 @@ def test_safe_error_generic_exceptions():
 
     for exc in generic_exceptions:
         result = safe_error(exc)
-        parsed = json.loads(result)
 
         # Format should be: "{ExceptionName}: Operation failed. Check server logs for details."
         expected_msg = (
             f"{type(exc).__name__}: Operation failed. Check server logs for details."
         )
-        assert parsed["error"] == expected_msg
+        assert result == {"error": expected_msg}
 
         # Ensure internal details are NOT leaked
-        assert str(exc) not in result
+        assert str(exc) not in result["error"]
 
 
 def test_safe_error_empty_message():
     # Allowed exception with empty message
     exc = ValueError("")
     result = safe_error(exc)
-    assert json.loads(result) == {"error": ""}
+    assert result == {"error": ""}
 
     # Generic exception with empty message
     exc = Exception("")
     result = safe_error(exc)
-    assert json.loads(result) == {
+    assert result == {
         "error": "Exception: Operation failed. Check server logs for details."
     }
 
@@ -148,19 +106,18 @@ def test_safe_error_subclasses_allowed():
 
     exc = CustomValueError("custom message")
     result = safe_error(exc)
-    assert json.loads(result) == {"error": "custom message"}
+    assert result == {"error": "custom message"}
 
 
 def test_safe_error_disallowed_oserror():
     # PermissionError is an OSError but not FileNotFoundError
     exc = PermissionError("access denied")
     result = safe_error(exc)
-    parsed = json.loads(result)
     assert (
-        parsed["error"]
+        result["error"]
         == "PermissionError: Operation failed. Check server logs for details."
     )
-    assert "access denied" not in result
+    assert "access denied" not in result["error"]
 
 
 def test_safe_error_base_exception():
@@ -170,24 +127,8 @@ def test_safe_error_base_exception():
     # KeyboardInterrupt is NOT a subclass of Exception, it's a sibling.
     # The code uses isinstance(e, (...)) and it doesn't match, so it falls through.
     result = safe_error(exc)
-    parsed = json.loads(result)
     assert (
-        parsed["error"]
+        result["error"]
         == "KeyboardInterrupt: Operation failed. Check server logs for details."
     )
-    assert "stop" not in result
-
-
-def test_ok_nested_mixed_types():
-    data = {
-        "str": "text",
-        "nested": {"val": 1, "exc": ValueError("nested error")},
-        "list": [1, {"a": 1}],
-    }
-    result = ok(data)
-    parsed = json.loads(result)
-    assert parsed["str"] == "text"
-    assert parsed["nested"]["val"] == 1
-    assert parsed["nested"]["exc"] == "nested error"
-    assert parsed["list"][0] == 1
-    assert parsed["list"][1]["a"] == 1
+    assert "stop" not in result["error"]


### PR DESCRIPTION
## S13 / WS-D X1 (telegram)

`message`/`chat`/`media`/`contact`/`config` tools now return `-> dict[str, Any]` → FastMCP auto-derives `outputSchema` ({type:object, additionalProperties:true}) + emits `structuredContent` alongside dual TextContent per MCP spec 2025-11-25. `ok()`/`err()`/`safe_error()` return dicts (same key shape as old json.dumps, no data loss). `help` keeps `-> str` via local `_err()` (shared `err()` now dict-returning).

Test json.loads unwrap migrated (content assertions preserved); dual-emit smoke confirmed at runtime.

Evidence: 644 passed / 17 skipped (platform) / 144 deselected; ruff + ty + pre-commit clean. Task-reviewed: Approved.