### PR TITLE
🎨 Palette: [UX improvement] Fallback loading states for reduced motion & Semantic Landmarks

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -68,3 +68,11 @@
 ## 2024-11-21 - Synchronize ARIA Labels When Reusing DOM Containers
 **Learning:** Reusing DOM containers for dynamic form steps (e.g., OTP or password prompts) can lead to desynchronized accessibility states if all associated attributes are not reset. While visual properties like `textContent` might be reset when re-initializing the view, missing updates to attributes like `aria-label` can leave screen readers announcing stale and confusing states (e.g., a button displaying "Show" but announcing "Hide password").
 **Action:** When dynamically resetting or reusing stateful UI components, ensure that invisible attributes like `aria-label` are explicitly reset alongside their visible counterparts (like `textContent` and `aria-pressed`) to prevent out-of-sync UI states.
+
+## 2024-11-21 - Fallback Loading States for Reduced Motion
+**Learning:** Hiding text and applying a CSS spinner (e.g., using `color: transparent` and a spinning pseudo-element) creates a completely blank, broken-looking button when `prefers-reduced-motion: reduce` freezes the animation. This leaves motion-sensitive users with no indication that the system is processing their request.
+**Action:** Always provide an explicit fallback within `@media (prefers-reduced-motion: reduce)` to restore the original text (e.g., `color: inherit`) and hide the animated pseudo-element (e.g., `display: none`) when replacing text with a loading spinner.
+
+## 2024-11-21 - Semantic Landmarks for Screen Readers
+**Learning:** Using a generic `<div class="container">` for the primary content of a page (like a login or credential form) prevents screen reader users from using semantic landmark navigation to jump directly to the core functionality, forcing them to tab through potentially repetitive header content.
+**Action:** Always use semantic ARIA landmarks, such as replacing a generic wrapper `<div>` with `<main>`, to properly identify the primary content region of a page and improve navigability.

--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -446,11 +446,17 @@ def render_telegram_credential_form(
             .status-box {{
                 animation: none !important;
             }}
+            .submit-btn[aria-busy="true"] {{
+                color: inherit !important;
+            }}
+            .submit-btn[aria-busy="true"]::after {{
+                display: none !important;
+            }}
         }}
     </style>
 </head>
 <body>
-    <div class="container">
+    <main class="container">
         <div class="card">
             <div class="server-header">
                 <h1 class="server-name">{display_name}</h1>
@@ -522,7 +528,7 @@ def render_telegram_credential_form(
                 <div class="status-box" id="status-box" role="alert"></div>
             </form>
         </div>
-    </div>
+    </main>
 
     <script>
         (function () {{


### PR DESCRIPTION
💡 **What:**
1. Added a fallback loading state for the submit button when `prefers-reduced-motion: reduce` is enabled. Instead of freezing the spinner animation and leaving the text transparent (which results in a blank, broken-looking button), it now correctly hides the spinner and restores the button text (`color: inherit`).
2. Swapped the generic `<div class="container">` layout wrapper in the credential form with a semantic `<main class="container">` tag.
3. Updated the `.jules/palette.md` journal with these critical learnings.

🎯 **Why:** 
1. When OS-level motion reduction is enabled, CSS animations freeze. Our previous styling relied on the `color: transparent` trick to overlay a spinner on the button text, which failed entirely under reduced motion conditions, leaving users with no feedback that their action was being processed.
2. Relying solely on generic `div` tags for major layout regions forces screen reader users to linearly navigate through the DOM instead of utilizing shortcut semantic landmarks to jump directly to the primary form content.

📸 **Before/After:**
The visual layout remains identical, but the `aria-busy` state now correctly falls back to displaying text on reduced-motion profiles, and screen readers will now announce the "main" landmark correctly upon entering the credential page. (Playwright tests and visual screenshot verification confirmed no styling regressions).

♿ **Accessibility:**
- Significantly improves navigability for screen reader users via the `<main>` ARIA landmark.
- Removes a jarring lack of feedback for users with vestibular disorders or motion sensitivities.

---
*PR created automatically by Jules for task [15792302127310342114](https://jules.google.com/task/15792302127310342114) started by @n24q02m*