### PR TITLE
fix: give bot-mode download_media a real path via getFile

### DIFF
--- a/src/better_telegram_mcp/backends/base.py
+++ b/src/better_telegram_mcp/backends/base.py
@@ -139,6 +139,7 @@ class TelegramBackend(ABC):
         chat_id: str | int,
         message_id: int,
         *,
+        file_id: str | None = None,
         output_dir: str | None = None,
     ) -> str: ...
 

--- a/src/better_telegram_mcp/backends/bot_backend.py
+++ b/src/better_telegram_mcp/backends/bot_backend.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
 import asyncio
+import tempfile
+from pathlib import Path
 from typing import Any
 
 import httpx
 
 from ..relay_setup import redact_bot_token
 from .base import TelegramBackend
-from .security import fetch_url_safely, validate_file_path
+from .security import fetch_url_safely, validate_file_path, validate_output_dir
 
 API_BASE = "https://api.telegram.org/bot{}/"
+FILE_API_BASE = "https://api.telegram.org/file/bot{}/"
 
 
 class TelegramAPIError(Exception):
@@ -26,6 +29,7 @@ class BotBackend(TelegramBackend):
         super().__init__("bot")
         self._token = bot_token
         self._base_url = API_BASE.format(bot_token)
+        self._file_base_url = FILE_API_BASE.format(bot_token)
         self._client = httpx.AsyncClient(base_url=self._base_url, timeout=30.0)
         self._connected = False
         self._bot_info: dict[str, Any] = {}
@@ -291,12 +295,31 @@ class BotBackend(TelegramBackend):
         chat_id: str | int,
         message_id: int,
         *,
+        file_id: str | None = None,
         output_dir: str | None = None,
     ) -> str:
-        raise NotImplementedError(
-            "Bot API download requires file_id. "
-            "Use get_history to get message with file info first."
-        )
+        if not file_id:
+            raise ValueError(
+                "file_id is required in bot mode: the Bot API cannot look up a "
+                "message's media by (chat_id, message_id). Get file_id from a "
+                "message this bot received (message tool results include it), "
+                "then call media(action='download', file_id=...)."
+            )
+        info = await self._call("getFile", file_id=file_id)
+        file_path = info["file_path"]
+        target_dir = validate_output_dir(output_dir or tempfile.gettempdir())
+        # Bolt: Move blocking I/O to a background thread.
+        await asyncio.to_thread(target_dir.mkdir, parents=True, exist_ok=True)
+        target = target_dir / Path(file_path).name
+        try:
+            resp = await self._client.get(f"{self._file_base_url}{file_path}")
+            resp.raise_for_status()
+        except httpx.HTTPError as e:
+            # httpx exceptions include the request URL, which carries the bot
+            # token; redact before re-raising so it cannot leak into logs.
+            raise TelegramAPIError(str(e)) from None
+        await asyncio.to_thread(target.write_bytes, resp.content)
+        return str(target)
 
     # --- Contacts (user-only) ---
     async def list_contacts(self) -> list[dict[str, Any]]:

--- a/src/better_telegram_mcp/backends/bot_backend.py
+++ b/src/better_telegram_mcp/backends/bot_backend.py
@@ -317,7 +317,7 @@ class BotBackend(TelegramBackend):
         except httpx.HTTPError as e:
             # httpx exceptions include the request URL, which carries the bot
             # token; redact before re-raising so it cannot leak into logs.
-            raise TelegramAPIError(str(e)) from None
+            raise TelegramAPIError(redact_bot_token(str(e))) from None
         await asyncio.to_thread(target.write_bytes, resp.content)
         return str(target)
 

--- a/src/better_telegram_mcp/backends/user_backend.py
+++ b/src/better_telegram_mcp/backends/user_backend.py
@@ -551,8 +551,12 @@ class UserBackend(TelegramBackend):
         chat_id: str | int,
         message_id: int,
         *,
+        file_id: str | None = None,
         output_dir: str | None = None,
     ) -> str:
+        # file_id is a bot-mode-only concept (Bot API cannot look up a
+        # message's media by chat_id/message_id); user mode always resolves
+        # media via the Telethon chat/message lookup below, so it is ignored.
         client = self._ensure_client()
         messages = await client.get_messages(chat_id, ids=message_id)
         msg = (

--- a/src/better_telegram_mcp/server.py
+++ b/src/better_telegram_mcp/server.py
@@ -383,6 +383,7 @@ async def media(
     message_id: int | None = None,
     caption: str | None = None,
     output_dir: str | None = None,
+    file_id: str | None = None,
 ) -> dict[str, Any]:
     """Send photos, files, voice, video, and download media from messages.
 
@@ -391,7 +392,7 @@ async def media(
     - send_file (chat_id, file_path_or_url -> caption)
     - send_voice (chat_id, file_path_or_url -> caption)
     - send_video (chat_id, file_path_or_url -> caption)
-    - download (chat_id, message_id -> output_dir)
+    - download (chat_id, message_id -> output_dir; bot mode also requires file_id)
     """
     if _unconfigured or _pending_auth:
         return _not_ready_response()
@@ -402,6 +403,7 @@ async def media(
         message_id=message_id,
         caption=caption,
         output_dir=output_dir,
+        file_id=file_id,
     )
     return await handle_media(get_backend(), action, opts)
 

--- a/src/better_telegram_mcp/tools/media.py
+++ b/src/better_telegram_mcp/tools/media.py
@@ -20,6 +20,10 @@ class MediaOptions(BaseModel):
     output_dir: str | None = Field(
         default=None, description="Output directory for download"
     )
+    file_id: str | None = Field(
+        default=None,
+        description="Telegram file_id to download (required in bot mode)",
+    )
 
 
 _ACTION_TO_MEDIA_TYPE = {
@@ -56,7 +60,10 @@ async def handle_media(
             if not options.chat_id or options.message_id is None:
                 return err("'download' requires chat_id and message_id")
             path = await backend.download_media(
-                options.chat_id, options.message_id, output_dir=options.output_dir
+                options.chat_id,
+                options.message_id,
+                file_id=options.file_id,
+                output_dir=options.output_dir,
             )
             return ok({"path": path})
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,7 +103,12 @@ class MockBackend(TelegramBackend):
         caption: str | None = None,
     ) -> dict[str, Any]: ...
     async def download_media(
-        self, chat_id: str | int, message_id: int, *, output_dir: str | None = None
+        self,
+        chat_id: str | int,
+        message_id: int,
+        *,
+        file_id: str | None = None,
+        output_dir: str | None = None,
     ) -> str: ...
     async def list_contacts(self) -> list[dict[str, Any]]: ...
     async def search_contacts(self, query: str) -> list[dict[str, Any]]: ...

--- a/tests/integration/test_bot_live.py
+++ b/tests/integration/test_bot_live.py
@@ -163,9 +163,10 @@ async def test_get_history_returns_empty(bot: BotBackend, bot_id: int):
     assert result == []
 
 
-async def test_download_media_not_implemented(bot: BotBackend):
-    """download_media raises NotImplementedError in bot mode."""
-    with pytest.raises(NotImplementedError, match="Bot API download requires"):
+async def test_download_media_without_file_id_errors_honestly(bot: BotBackend):
+    """download_media requires file_id in bot mode (Bot API cannot look up
+    a message's media by chat_id/message_id alone)."""
+    with pytest.raises(ValueError, match="file_id is required in bot mode"):
         await bot.download_media(123, 42)
 
 

--- a/tests/test_backends/test_bot_backend.py
+++ b/tests/test_backends/test_bot_backend.py
@@ -238,6 +238,36 @@ async def test_download_media_with_file_id(tmp_path):
     assert Path(path).name == "file_1.jpg"
 
 
+async def test_download_media_file_get_error_redacts_bot_token():
+    """The file-GET error path must redact the bot token like the _call/
+    _call_form paths already do (see test_transport_error_redacts_bot_token):
+    the file URL is https://api.telegram.org/file/bot<token>/<path>, and
+    httpx.HTTPStatusError's message embeds that URL verbatim."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/getFile"):
+            return httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "result": {"file_id": "CCCqqq", "file_path": "photos/f.jpg"},
+                },
+            )
+        return httpx.Response(404, content=b"Not Found")
+
+    bot = BotBackend(_FAKE_TOKEN)
+    bot._client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url=bot._base_url
+    )
+
+    with pytest.raises(TelegramAPIError) as exc_info:
+        await bot.download_media(123, 1, file_id="CCCqqq")
+
+    message = str(exc_info.value)
+    assert _FAKE_SECRET not in message
+    assert f"{_FAKE_TOKEN.split(':')[0]}:<redacted>" in message
+
+
 async def test_download_media_no_output_dir_uses_tempdir(monkeypatch, tmp_path):
     """Without output_dir, bot mode falls back to the system temp dir."""
     monkeypatch.setattr(

--- a/tests/test_backends/test_bot_backend.py
+++ b/tests/test_backends/test_bot_backend.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from unittest.mock import AsyncMock
 
 import httpx
@@ -204,10 +205,77 @@ async def test_get_history_returns_empty():
     assert result == []
 
 
-async def test_download_media_raises_not_implemented():
+async def test_download_media_without_file_id_errors_honestly():
     bot = _make_bot()
-    with pytest.raises(NotImplementedError, match="Bot API download requires"):
+    with pytest.raises(ValueError, match="file_id is required in bot mode"):
         await bot.download_media(123, 42)
+
+
+async def test_download_media_with_file_id(tmp_path):
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/getFile"):
+            body = json.loads(request.content)
+            assert body["file_id"] == "AAAqqq"
+            return httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "result": {"file_id": "AAAqqq", "file_path": "photos/file_1.jpg"},
+                },
+            )
+        assert request.url.path.endswith("photos/file_1.jpg")
+        return httpx.Response(200, content=b"JPEGDATA")
+
+    bot = BotBackend("123456:AAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+    bot._client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url=bot._base_url
+    )
+
+    path = await bot.download_media(
+        "123", 45, file_id="AAAqqq", output_dir=str(tmp_path)
+    )
+    assert Path(path).read_bytes() == b"JPEGDATA"
+    assert Path(path).name == "file_1.jpg"
+
+
+async def test_download_media_no_output_dir_uses_tempdir(monkeypatch, tmp_path):
+    """Without output_dir, bot mode falls back to the system temp dir."""
+    monkeypatch.setattr(
+        "better_telegram_mcp.backends.bot_backend.tempfile.gettempdir",
+        lambda: str(tmp_path),
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/getFile"):
+            return httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "result": {"file_id": "BBBqqq", "file_path": "docs/note.txt"},
+                },
+            )
+        return httpx.Response(200, content=b"DATA")
+
+    bot = BotBackend("123456:AAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+    bot._client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url=bot._base_url
+    )
+
+    path = await bot.download_media(123, 1, file_id="BBBqqq")
+    assert Path(path).parent == tmp_path
+    assert Path(path).read_bytes() == b"DATA"
+
+
+async def test_forward_message_media_result_includes_file_id():
+    """Bot mode passes the raw Telegram Message JSON through untouched, so a
+    forwarded media message's file_id is available for media(action='download')."""
+    msg = {
+        "message_id": 99,
+        "photo": [{"file_id": "AAAqqq", "file_unique_id": "u1", "width": 90}],
+    }
+    bot = _make_bot(msg)
+    result = await bot.forward_message(123, 456, 42)
+    assert result["photo"][0]["file_id"] == "AAAqqq"
 
 
 # --- Chat operations ---

--- a/tests/test_backends/test_user_backend.py
+++ b/tests/test_backends/test_user_backend.py
@@ -1124,6 +1124,26 @@ class TestDownloadMedia:
         with pytest.raises(ValueError, match="Failed to download"):
             await backend.download_media(123, 1)
 
+    async def test_download_media_ignores_file_id(
+        self, tmp_path, mock_client, mock_client_class
+    ):
+        """user mode uses the Telethon chat/message lookup; file_id is a
+        bot-mode-only concept and is accepted but ignored here."""
+        from better_telegram_mcp.backends.user_backend import UserBackend
+
+        msg = _mock_message()
+        msg.media = MagicMock()
+        mock_client.get_messages = AsyncMock(return_value=msg)
+        mock_client.download_media = AsyncMock(return_value="/tmp/photo.jpg")
+
+        settings = _make_settings(tmp_path)
+        backend = UserBackend(settings)
+        await backend.connect()
+
+        result = await backend.download_media(123, 1, file_id="unused-in-user-mode")
+
+        assert result == "/tmp/photo.jpg"
+
 
 class TestListContacts:
     async def test_list_contacts_returns_list(

--- a/tests/test_tools/test_media.py
+++ b/tests/test_tools/test_media.py
@@ -264,7 +264,27 @@ async def test_download_no_output_dir(mock_backend):
         ),
     )
     assert result["path"] == "/tmp/file.jpg"
-    mock_backend.download_media.assert_awaited_once_with(123, 10, output_dir=None)
+    mock_backend.download_media.assert_awaited_once_with(
+        123, 10, file_id=None, output_dir=None
+    )
+
+
+@pytest.mark.asyncio
+async def test_download_with_file_id(mock_backend):
+    result = await handle_media(
+        mock_backend,
+        "download",
+        MediaOptions(
+            chat_id=123,
+            message_id=10,
+            file_id="AAAqqq",
+            output_dir="/tmp",
+        ),
+    )
+    assert result["path"] == "/tmp/file.jpg"
+    mock_backend.download_media.assert_awaited_once_with(
+        123, 10, file_id="AAAqqq", output_dir="/tmp"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Bug (S14 Task 1, Wave 1)

`BotBackend.download_media` raised `NotImplementedError` pointing at `get_history` for a file_id — but bot-mode `get_history` always returns `[]`, so the suggested escape hatch was unreachable, and no layer had a `file_id` parameter to pass one through even if you had it.

## Fix

Bot API download works via `getFile(file_id)` → GET `.../file/bot<token>/<file_path>`. Thread an optional `file_id` through every layer (base signature → both backends → MediaOptions → handle_media → media tool). Bot mode + file_id downloads for real; bot mode without file_id raises a truthful error (file_id comes from a message this bot received — `message(action='forward'/...)` results surface it). user mode accepts+ignores file_id (Telethon path unchanged).

Token never appears in the returned path, errors (redacted), or logs. The downloaded path (sender-controlled filename) flows through the existing `@_wrap_tool("media")` XPIA wrapper on both channels — not bypassed.

## Tests

661 passed / 0 failed. New: real getFile→download via httpx MockTransport, tempdir fallback, and a regression pinning that forward results expose file_id. ruff + ty clean.

Reviewed (opus, adversarial): SPEC met, CODE QUALITY approved, no Critical/Important. Minor follow-ups tracked (>20MB getFile has no file_path → clearer error; cross-mode output_dir default note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)