### PR TITLE
🎨 Palette: [Fallback Loading States] Restore submit button text under reduced motion

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -68,3 +68,7 @@
 ## 2024-11-21 - Synchronize ARIA Labels When Reusing DOM Containers
 **Learning:** Reusing DOM containers for dynamic form steps (e.g., OTP or password prompts) can lead to desynchronized accessibility states if all associated attributes are not reset. While visual properties like `textContent` might be reset when re-initializing the view, missing updates to attributes like `aria-label` can leave screen readers announcing stale and confusing states (e.g., a button displaying "Show" but announcing "Hide password").
 **Action:** When dynamically resetting or reusing stateful UI components, ensure that invisible attributes like `aria-label` are explicitly reset alongside their visible counterparts (like `textContent` and `aria-pressed`) to prevent out-of-sync UI states.
+
+## 2024-11-21 - Fallback Loading States
+**Learning:** When replacing interactive text with a CSS spinner (e.g., setting color: transparent to overlay a spinner), failing to explicitly override this for reduced motion leaves users with a broken, blank button during asynchronous loading states.
+**Action:** Always explicitly define an override within `@media (prefers-reduced-motion: reduce)` that restores the original text (e.g., `color: inherit !important`) and hides the animated pseudo-element (e.g., `display: none !important`).

--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -446,6 +446,12 @@ def render_telegram_credential_form(
             .status-box {{
                 animation: none !important;
             }}
+            .submit-btn[aria-busy="true"] {{
+                color: inherit !important;
+            }}
+            .submit-btn[aria-busy="true"]::after {{
+                display: none !important;
+            }}
         }}
     </style>
 </head>


### PR DESCRIPTION
💡 What: Added CSS overrides to `.submit-btn[aria-busy="true"]` within `@media (prefers-reduced-motion: reduce)` to set `color: inherit` and hide the animated spinner pseudo-element. Also recorded this insight in `.jules/palette.md`.
🎯 Why: Previously, during form submission, the button text was hidden (`color: transparent`) and replaced with a CSS spinner. For users with reduced motion, the animation was removed but the text was not restored, leaving them with a broken, blank button.
📸 Before/After: Visuals via frontend validation.
♿ Accessibility: Ensures users who rely on reduced motion do not lose context during asynchronous form loading states.

---
*PR created automatically by Jules for task [5374508877384410844](https://jules.google.com/task/5374508877384410844) started by @n24q02m*