### PR TITLE
🎨 Palette: Fix fallback loading state for reduced motion

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -68,3 +68,7 @@
 ## 2024-11-21 - Synchronize ARIA Labels When Reusing DOM Containers
 **Learning:** Reusing DOM containers for dynamic form steps (e.g., OTP or password prompts) can lead to desynchronized accessibility states if all associated attributes are not reset. While visual properties like `textContent` might be reset when re-initializing the view, missing updates to attributes like `aria-label` can leave screen readers announcing stale and confusing states (e.g., a button displaying "Show" but announcing "Hide password").
 **Action:** When dynamically resetting or reusing stateful UI components, ensure that invisible attributes like `aria-label` are explicitly reset alongside their visible counterparts (like `textContent` and `aria-pressed`) to prevent out-of-sync UI states.
+
+## 2024-11-21 - Fallback Loading States for Reduced Motion
+**Learning:** When replacing interactive text with a CSS spinner (e.g., setting `color: transparent` to overlay a spinner with an animated pseudo-element), users with `prefers-reduced-motion: reduce` might end up seeing a blank button if the animation is merely disabled or paused without restoring the original text. This leads to a broken, confusing experience during asynchronous loading states.
+**Action:** Always define an override within `@media (prefers-reduced-motion: reduce)` that restores the original text (e.g., `color: inherit !important`) and hides the animated pseudo-element (e.g., `display: none !important`) for loading spinners that rely on hiding text.

--- a/src/better_telegram_mcp/credential_form.py
+++ b/src/better_telegram_mcp/credential_form.py
@@ -446,6 +446,12 @@ def render_telegram_credential_form(
             .status-box {{
                 animation: none !important;
             }}
+            .submit-btn[aria-busy="true"] {{
+                color: inherit !important;
+            }}
+            .submit-btn[aria-busy="true"]::after {{
+                display: none !important;
+            }}
         }}
     </style>
 </head>


### PR DESCRIPTION
💡 **What:** Added a fallback for the loading spinner state (`aria-busy="true"`) on the submit button within the `@media (prefers-reduced-motion: reduce)` block. It restores the original text color and explicitly hides the animated pseudo-element spinner. It also adds a journal entry to document this learning.

🎯 **Why:** Users who have reduced motion preferences enabled at the OS or browser level would see a blank button when submitting the form. The text was made transparent to make way for a spinning circle, but the animation block disabled the spin without restoring the text, leading to a confusing, broken UI state.

📸 **Before/After:** Before, the button was completely blank. After, the button clearly displays the "Connecting..." text for reduced motion users. Visual verification was performed via Playwright.

♿ **Accessibility:** This directly addresses an accessibility failure for users with vestibular disorders or those who prefer reduced animations, ensuring they receive the same functional feedback (loading state text) as other users.

---
*PR created automatically by Jules for task [9193267091651066312](https://jules.google.com/task/9193267091651066312) started by @n24q02m*