### PR TITLE
🛡️ Sentinel: [HIGH] Fix DoS via memory exhaustion in download_media

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -11,3 +11,7 @@
 **Vulnerability:** The URL validation logic correctly blocked the IPv4 unspecified address `0.0.0.0` but failed to block its IPv6 equivalent `::`. This allowed SSRF requests to bypass the filter and target `localhost` on systems with IPv6 enabled.
 **Learning:** Hardcoded string checks (like `hostname in {"0.0.0.0"}`) and IPv4-only IP network blocks are insufficient when IPv6 is available, as attackers can use IPv6 variants (like `::`) to achieve the same routing behavior.
 **Prevention:** Always include the IPv6 equivalent `::/128` (unspecified) in blocked internal networks alongside `0.0.0.0/8`, and ensure string-based early filters catch `::`.
+## 2025-02-27 - Fix DoS via memory exhaustion in download_media
+**Vulnerability:** `download_media` in `BotBackend` used `httpx.AsyncClient.get` which loads the entire response into memory at once, creating a risk for Denial of Service (DoS) via Out-Of-Memory (OOM) attacks if a malicious or large file is fetched, similar to the previous `fetch_url_safely` vulnerability.
+**Learning:** External URLs or Bot API files should be fetched with size limits and streaming to prevent memory exhaustion, as even validated bot API URLs can return massive payloads that consume too much memory if read entirely at once.
+**Prevention:** Always use `httpx.stream` and iterate over chunks (`aiter_bytes`) while enforcing a strict `max_size` limit (e.g. 50MB) on the accumulated data and checking the Content-Length header, writing chunks explicitly to the target file.

--- a/src/better_telegram_mcp/backends/bot_backend.py
+++ b/src/better_telegram_mcp/backends/bot_backend.py
@@ -9,7 +9,12 @@ import httpx
 
 from ..relay_setup import redact_bot_token
 from .base import TelegramBackend
-from .security import fetch_url_safely, validate_file_path, validate_output_dir
+from .security import (
+    SecurityError,
+    fetch_url_safely,
+    validate_file_path,
+    validate_output_dir,
+)
 
 API_BASE = "https://api.telegram.org/bot{}/"
 FILE_API_BASE = "https://api.telegram.org/file/bot{}/"
@@ -311,14 +316,35 @@ class BotBackend(TelegramBackend):
         # Bolt: Move blocking I/O to a background thread.
         await asyncio.to_thread(target_dir.mkdir, parents=True, exist_ok=True)
         target = target_dir / Path(file_path).name
+
+        max_size = 50 * 1024 * 1024  # 50MB
         try:
-            resp = await self._client.get(f"{self._file_base_url}{file_path}")
-            resp.raise_for_status()
+            async with self._client.stream("GET", f"{self._file_base_url}{file_path}") as resp:
+                resp.raise_for_status()
+                content_length = resp.headers.get("Content-Length")
+                if content_length:
+                    try:
+                        if int(content_length) > max_size:
+                            raise SecurityError(f"File size exceeds maximum allowed ({max_size} bytes)")
+                    except ValueError:
+                        pass
+
+                downloaded_size = 0
+                def _write_chunk(f, chunk):
+                    f.write(chunk)
+
+                with target.open("wb") as f:
+                    async for chunk in resp.aiter_bytes():
+                        downloaded_size += len(chunk)
+                        if downloaded_size > max_size:
+                            raise SecurityError(f"File size exceeds maximum allowed ({max_size} bytes)")
+                        await asyncio.to_thread(_write_chunk, f, chunk)
+
         except httpx.HTTPError as e:
             # httpx exceptions include the request URL, which carries the bot
             # token; redact before re-raising so it cannot leak into logs.
             raise TelegramAPIError(redact_bot_token(str(e))) from None
-        await asyncio.to_thread(target.write_bytes, resp.content)
+
         return str(target)
 
     # --- Contacts (user-only) ---

--- a/src/better_telegram_mcp/backends/bot_backend.py
+++ b/src/better_telegram_mcp/backends/bot_backend.py
@@ -319,17 +319,22 @@ class BotBackend(TelegramBackend):
 
         max_size = 50 * 1024 * 1024  # 50MB
         try:
-            async with self._client.stream("GET", f"{self._file_base_url}{file_path}") as resp:
+            async with self._client.stream(
+                "GET", f"{self._file_base_url}{file_path}"
+            ) as resp:
                 resp.raise_for_status()
                 content_length = resp.headers.get("Content-Length")
                 if content_length:
                     try:
                         if int(content_length) > max_size:
-                            raise SecurityError(f"File size exceeds maximum allowed ({max_size} bytes)")
+                            raise SecurityError(
+                                f"File size exceeds maximum allowed ({max_size} bytes)"
+                            )
                     except ValueError:
                         pass
 
                 downloaded_size = 0
+
                 def _write_chunk(f, chunk):
                     f.write(chunk)
 
@@ -337,7 +342,9 @@ class BotBackend(TelegramBackend):
                     async for chunk in resp.aiter_bytes():
                         downloaded_size += len(chunk)
                         if downloaded_size > max_size:
-                            raise SecurityError(f"File size exceeds maximum allowed ({max_size} bytes)")
+                            raise SecurityError(
+                                f"File size exceeds maximum allowed ({max_size} bytes)"
+                            )
                         await asyncio.to_thread(_write_chunk, f, chunk)
 
         except httpx.HTTPError as e:

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.16.0b7"
+version = "4.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** `download_media` in `BotBackend` used `httpx.AsyncClient.get(url).content` which loads the entire response into memory. A malicious or massive file could trigger a Denial of Service (DoS) via memory exhaustion (OOM).
🎯 **Impact:** An attacker could cause the MCP server to crash by triggering it to download excessively large files.
🔧 **Fix:** Refactored `download_media` to stream the download using `httpx.AsyncClient.stream`, enforcing a 50MB maximum size limit and downloading chunk-by-chunk to the file directly without storing the full contents in memory.
✅ **Verification:** Verified that tests pass via `uv run pytest` and linting passed via `uv run ruff check`. Added a learning to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [5389931985401857056](https://jules.google.com/task/5389931985401857056) started by @n24q02m*