### PR TITLE
fix: clear error when getFile response lacks file_path

### DIFF
--- a/src/better_telegram_mcp/backends/bot_backend.py
+++ b/src/better_telegram_mcp/backends/bot_backend.py
@@ -306,7 +306,11 @@ class BotBackend(TelegramBackend):
                 "then call media(action='download', file_id=...)."
             )
         info = await self._call("getFile", file_id=file_id)
-        file_path = info["file_path"]
+        file_path = info.get("file_path")
+        if not file_path:
+            raise TelegramAPIError(
+                "getFile returned no file_path (file may exceed bot API 20MB limit)"
+            )
         target_dir = validate_output_dir(output_dir or tempfile.gettempdir())
         # Bolt: Move blocking I/O to a background thread.
         await asyncio.to_thread(target_dir.mkdir, parents=True, exist_ok=True)

--- a/tests/test_backends/test_bot_backend.py
+++ b/tests/test_backends/test_bot_backend.py
@@ -238,6 +238,17 @@ async def test_download_media_with_file_id(tmp_path):
     assert Path(path).name == "file_1.jpg"
 
 
+async def test_download_media_getfile_response_missing_file_path():
+    """getFile can return {"ok": true} without file_path (Telegram omits it
+    for files exceeding the Bot API's 20MB limit). Accessing
+    info["file_path"] directly raises an opaque KeyError; assert a clear
+    TelegramAPIError is raised instead."""
+    bot = _make_bot(result={"file_id": "AAAqqq"}, ok=True)
+
+    with pytest.raises(TelegramAPIError, match="file_path"):
+        await bot.download_media(123, 1, file_id="AAAqqq")
+
+
 async def test_download_media_file_get_error_redacts_bot_token():
     """The file-GET error path must redact the bot token like the _call/
     _call_form paths already do (see test_transport_error_redacts_bot_token):


### PR DESCRIPTION
## Summary
- `download_media` (bot mode) accessed `info["file_path"]` directly after `getFile`, raising an opaque `KeyError` when Telegram omits `file_path` (e.g. files exceeding the Bot API's 20MB limit).
- Now raises a clear `TelegramAPIError("getFile returned no file_path (file may exceed bot API 20MB limit)")` instead.
- Does not touch the existing >20MB `TelegramAPIError("file is too big", 400)` path in `_call` — that already works.

## Test plan
- [x] New test `test_download_media_getfile_response_missing_file_path` — mocks `getFile` returning `{"ok": true}` without `file_path`, asserts `TelegramAPIError` with `file_path` in message (was `KeyError` before the fix).
- [x] Full suite: `uv run pytest` — 663 passed, 17 skipped, 144 deselected.
- [x] `ruff check .` / `ruff format --check .` / pre-commit hooks (gitleaks, ruff, ty, pytest, conventional commit) all passed.