### PR TITLE
fix: load credentials without os.environ mutation

### DIFF
--- a/src/better_telegram_mcp/credential_state.py
+++ b/src/better_telegram_mcp/credential_state.py
@@ -185,9 +185,6 @@ def resolve_credential_state() -> CredentialState:
             has_bot = bool(saved.get("TELEGRAM_BOT_TOKEN"))
             has_user = bool(saved.get("TELEGRAM_PHONE"))
             if has_bot or has_user:
-                for key, value in saved.items():
-                    if value and key not in os.environ:
-                        os.environ[key] = value
                 logger.info("Config loaded from encrypted file")
                 _state = CredentialState.CONFIGURED
                 return _state
@@ -291,10 +288,6 @@ async def save_credentials(
 
     # ----- Single-user branch: shared config.enc (local) / KV (CF) + global backend -----
     _write_single_user_config(config)
-
-    for key, value in config.items():
-        if value and key not in os.environ:
-            os.environ[key] = value
 
     logger.info("Credentials saved via local OAuth form")
 

--- a/src/better_telegram_mcp/server.py
+++ b/src/better_telegram_mcp/server.py
@@ -101,12 +101,21 @@ def _ensure_settings() -> Settings:
     """Initialize settings and resolve credential state."""
     settings = Settings()
     if not settings.is_configured:
-        from .credential_state import resolve_credential_state
+        from .credential_state import (
+            _read_single_user_config,
+            resolve_credential_state,
+        )
 
         state = resolve_credential_state()
-        # If config was loaded from file, re-create Settings to pick up env vars
         if state.value == "configured":
-            settings = Settings()
+            # Load the saved config explicitly rather than relying on os.environ
+            # injection: exporting credentials into the process environment
+            # leaks them to every subprocess and third-party dependency,
+            # defeating the encrypted store. _read_single_user_config honours the
+            # active backend (local config.enc or CF KV).
+            saved_config = _read_single_user_config()
+            if saved_config:
+                settings = Settings.from_relay_config(saved_config)
     return settings
 
 
@@ -649,8 +658,9 @@ def main() -> None:
         # Universal MCP client compatibility (Claude Code, Cursor, VS Code Copilot, etc.).
         # Credentials come from env, the encrypted single-user config, or a saved
         # Telethon session (bot token OR phone+session). resolve_credential_state
-        # consults all three and hydrates os.environ from a saved config so the
-        # lifespan below picks it up; only a truly unconfigured stdio server exits.
+        # consults all three; the lifespan's _ensure_settings loads a saved
+        # config explicitly (Settings.from_relay_config) without mutating
+        # os.environ. Only a truly unconfigured stdio server exits.
         from .credential_state import CredentialState, resolve_credential_state
 
         if resolve_credential_state() != CredentialState.CONFIGURED:

--- a/tests/test_credential_state.py
+++ b/tests/test_credential_state.py
@@ -159,7 +159,7 @@ def test_resolve_phone_from_env():
 
 
 def test_resolve_from_config_file_bot():
-    """Config file has bot token -> CONFIGURED, env var applied."""
+    """Config file has bot token -> CONFIGURED, without env injection."""
     saved = {"TELEGRAM_BOT_TOKEN": "token_from_file"}
 
     with patch.dict(os.environ, {}, clear=False):
@@ -170,7 +170,8 @@ def test_resolve_from_config_file_bot():
             state = resolve_credential_state()
 
         assert state == CredentialState.CONFIGURED
-        assert os.environ.get("TELEGRAM_BOT_TOKEN") == "token_from_file"
+        # Credentials must not leak into os.environ (subprocess exposure).
+        assert os.environ.get("TELEGRAM_BOT_TOKEN") is None
 
     os.environ.pop("TELEGRAM_BOT_TOKEN", None)
 

--- a/tests/test_relay_setup.py
+++ b/tests/test_relay_setup.py
@@ -143,7 +143,7 @@ async def test_lifespan_tries_credential_state_when_unconfigured():
     mock_bot = AsyncMock()
     mock_bot.is_authorized = AsyncMock(return_value=True)
 
-    # First Settings() returns unconfigured, second (after resolve) returns configured
+    # Bare Settings() -> unconfigured; explicit from_relay_config -> configured.
     unconfigured_settings = MagicMock(is_configured=False)
     configured_settings = MagicMock(
         is_configured=True,
@@ -151,21 +151,18 @@ async def test_lifespan_tries_credential_state_when_unconfigured():
         bot_token="relay:TOKEN",
     )
 
-    call_count = 0
-
-    def settings_factory(*args, **kwargs):
-        nonlocal call_count
-        call_count += 1
-        return unconfigured_settings if call_count == 1 else configured_settings
-
     def mock_resolve():
         return CredentialState.CONFIGURED
 
     with (
-        patch.object(srv, "Settings", side_effect=settings_factory),
+        patch.object(srv, "Settings") as mock_settings_cls,
         patch(
             "better_telegram_mcp.credential_state.resolve_credential_state",
             side_effect=mock_resolve,
+        ),
+        patch(
+            "better_telegram_mcp.credential_state._read_single_user_config",
+            return_value={"TELEGRAM_BOT_TOKEN": "relay:TOKEN"},
         ),
         patch.dict(
             "sys.modules",
@@ -176,6 +173,9 @@ async def test_lifespan_tries_credential_state_when_unconfigured():
             },
         ),
     ):
+        mock_settings_cls.return_value = unconfigured_settings
+        mock_settings_cls.from_relay_config.return_value = configured_settings
+
         async with _lifespan(mcp):
             assert srv._backend is mock_bot
             mock_bot.connect.assert_awaited_once()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -574,8 +574,8 @@ def test_main_stdio_missing_credentials_exits_1(capsys):
 def test_main_stdio_config_bot_token_no_env_runs():
     """Stdio: a bot token in the single-user config (not env) resolves CONFIGURED.
 
-    The gate hydrates env from the saved config via resolve_credential_state and
-    starts the server -- no exit, even though TELEGRAM_BOT_TOKEN is unset in env.
+    resolve_credential_state reports CONFIGURED from the saved config so the
+    server starts -- no exit, even though TELEGRAM_BOT_TOKEN is unset in env.
     """
     import better_telegram_mcp.server as srv
 
@@ -969,12 +969,43 @@ async def test_config_setup_reset_works_when_unconfigured():
         srv._unconfigured = old
 
 
+# --- _ensure_settings: explicit config load without env injection ---
+
+
+def test_ensure_settings_loads_config_without_env_injection():
+    """_ensure_settings loads the saved single-user config via
+    Settings.from_relay_config and must NOT mutate os.environ.
+
+    Exporting credentials into the process environment leaks them to every
+    subprocess and third-party dependency, defeating the encrypted store. The
+    saved config must be read explicitly instead.
+    """
+    import better_telegram_mcp.server as srv
+
+    token = "123456:ABCdefGHIjklMNOpqrsTUVwxyz0123456789"
+
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        patch(
+            "better_telegram_mcp.credential_state._read_single_user_config",
+            return_value={"TELEGRAM_BOT_TOKEN": token},
+        ),
+    ):
+        settings = srv._ensure_settings()
+
+        assert settings.is_configured
+        assert settings.bot_token == token
+        # Security: credentials must not leak into the process environment.
+        assert "TELEGRAM_BOT_TOKEN" not in os.environ
+
+
 # --- lifespan: resolve_credential_state integration ---
 
 
 @pytest.mark.asyncio
 async def test_lifespan_resolves_credentials_when_unconfigured():
-    """Lifespan calls resolve_credential_state and re-creates Settings if configured."""
+    """Lifespan calls resolve_credential_state and, when configured, loads the
+    saved config via Settings.from_relay_config (not a second bare Settings())."""
     import better_telegram_mcp.server as srv
     from better_telegram_mcp.server import _lifespan
 
@@ -989,22 +1020,17 @@ async def test_lifespan_resolves_credentials_when_unconfigured():
     mock_bot = AsyncMock()
     mock_bot.is_authorized = AsyncMock(return_value=True)
 
-    settings_call_count = 0
-
-    def settings_factory(*args, **kwargs):
-        nonlocal settings_call_count
-        settings_call_count += 1
-        if settings_call_count == 1:
-            return mock_settings_initial
-        return mock_settings_reconfigured
-
     from better_telegram_mcp.credential_state import CredentialState
 
     with (
-        patch.object(srv, "Settings", side_effect=settings_factory),
+        patch.object(srv, "Settings") as mock_settings_cls,
         patch(
             "better_telegram_mcp.credential_state.resolve_credential_state",
             return_value=CredentialState.CONFIGURED,
+        ),
+        patch(
+            "better_telegram_mcp.credential_state._read_single_user_config",
+            return_value={"TELEGRAM_BOT_TOKEN": "resolved:token"},
         ),
         patch.dict(
             "sys.modules",
@@ -1017,8 +1043,15 @@ async def test_lifespan_resolves_credentials_when_unconfigured():
             },
         ),
     ):
+        # Bare Settings() -> unconfigured; explicit from_relay_config -> configured.
+        mock_settings_cls.return_value = mock_settings_initial
+        mock_settings_cls.from_relay_config.return_value = mock_settings_reconfigured
+
         async with _lifespan(mcp):
             assert srv._settings is mock_settings_reconfigured
+            mock_settings_cls.from_relay_config.assert_called_once_with(
+                {"TELEGRAM_BOT_TOKEN": "resolved:token"}
+            )
             mock_bot.connect.assert_awaited_once()
 
         mock_bot.disconnect.assert_awaited_once()


### PR DESCRIPTION
## Summary

Loads single-user credentials explicitly instead of injecting them into
`os.environ`. Exporting `TELEGRAM_BOT_TOKEN` / `TELEGRAM_PHONE` into the process
environment exposes them to every subprocess and third-party dependency, which
defeats the purpose of the encrypted config store.

This is the credential-hardening half of #926, split out on its own so it can
land independently of that PR's unrelated capability change.

## Changes

- `resolve_credential_state()`: drop the loop that copied saved config values
  into `os.environ`. The state resolution is unchanged (`CONFIGURED` is still
  returned from the config-file branch); only the env mutation is removed.
- `save_credentials()` single-user branch: drop the equivalent env-injection
  loop after `_write_single_user_config()`.
- `_ensure_settings()`: when credentials resolve from the saved config, build
  `Settings` via `Settings.from_relay_config(_read_single_user_config())` rather
  than re-reading env vars with a bare `Settings()`. `_read_single_user_config()`
  honours the active storage backend (local `config.enc` or CF KV), so the load
  reads from the same store `save_credentials` wrote to.

## Not included (vs #926)

- **Bot-token redaction** — already on `main` via `d6a09fe` ("centralize
  bot-token redaction in error messages"), which redacts inside the
  `TelegramAPIError` constructor. The per-call-site redaction #926 proposed is
  now redundant, so it is intentionally omitted.
- **Removal of the `TELEGRAM_ACCEPT_SHARED_SINGLE_USER` flag** — kept. That flag
  is a deployment safety toggle (single-user-on-private-network escape hatch),
  not part of this credential-load hardening.

## Tests

- New `test_ensure_settings_loads_config_without_env_injection` asserts the
  config loads via `Settings.from_relay_config` and that no credential leaks
  into `os.environ`.
- Existing credential-state / lifespan tests updated to the explicit-load path.
- Full suite green (`uv run pytest`): 662 passed, 17 skipped.
