### PR TITLE
feat: config set key/value parity + auth subcommand alias

### DIFF
--- a/src/better_telegram_mcp/cli.py
+++ b/src/better_telegram_mcp/cli.py
@@ -2,9 +2,10 @@
 
 Bare invocation and any leading-dash argv (e.g. --http) start the server
 exactly as before; subcommands run one-shot operator actions. The
-``login``/``logout`` subcommands are single-user / local-machine only:
-they write the on-disk session and the encrypted single-user config, so
-running them makes sense on the machine that hosts the stdio server.
+``auth``/``logout`` subcommands (``login`` is a deprecated alias of ``auth``)
+are single-user / local-machine only: they write the on-disk session and the
+encrypted single-user config, so running them makes sense on the machine that
+hosts the stdio server.
 """
 
 from __future__ import annotations
@@ -27,15 +28,11 @@ def _serve(argv: list[str]) -> int | None:
     return 0
 
 
-# --- login ---
+# --- auth / login ---
 
 
-def _configure_login(p: argparse.ArgumentParser) -> None:
-    p.description = (
-        "Authenticate this local machine (single-user). Bot mode validates "
-        "the token; phone mode runs the interactive OTP/2FA flow and stores "
-        "the Telethon session on disk."
-    )
+def _add_credential_args(p: argparse.ArgumentParser) -> None:
+    """Add the mutually-exclusive bot-token / phone credential flags."""
     group = p.add_mutually_exclusive_group(required=True)
     group.add_argument(
         "--bot-token",
@@ -49,10 +46,41 @@ def _configure_login(p: argparse.ArgumentParser) -> None:
     )
 
 
-def _handle_login(args: argparse.Namespace) -> int:
+def _configure_auth(p: argparse.ArgumentParser) -> None:
+    p.description = (
+        "Authenticate this local machine (single-user). Bot mode validates "
+        "the token; phone mode runs the interactive OTP/2FA flow and stores "
+        "the Telethon session on disk."
+    )
+    # Optional provider positional for CLI parity with multi-provider servers;
+    # telegram has a single provider.
+    p.add_argument(
+        "provider",
+        nargs="?",
+        default="telegram",
+        choices=["telegram"],
+        help="Credential provider to authorize (only 'telegram')",
+    )
+    _add_credential_args(p)
+
+
+def _configure_login(p: argparse.ArgumentParser) -> None:
+    p.description = "Deprecated alias of `auth`; authenticate this local machine."
+    _add_credential_args(p)
+
+
+def _handle_auth(args: argparse.Namespace) -> int:
     if args.bot_token:
         return _login_bot(args.bot_token)
     return _login_phone(args.phone)
+
+
+def _handle_login(args: argparse.Namespace) -> int:
+    print(
+        "better-telegram-mcp: `login` is deprecated; use `auth` instead.",
+        file=sys.stderr,
+    )
+    return _handle_auth(args)
 
 
 def _login_bot(bot_token: str) -> int:
@@ -232,6 +260,8 @@ def _api_identity_store():
 
 def _extras() -> dict:
     return {
+        "auth": (_configure_auth, _handle_auth),
+        # `login` is a deprecated alias of `auth`, kept one release cycle.
         "login": (_configure_login, _handle_login),
         "logout": _handle_logout,
     }

--- a/src/better_telegram_mcp/server.py
+++ b/src/better_telegram_mcp/server.py
@@ -472,12 +472,15 @@ async def config(
     message_limit: int | None = None,
     timeout: int | None = None,
     key: str | None = None,
+    value: str | None = None,
 ) -> dict[str, Any]:
     """Server configuration and runtime settings.
 
     Actions (required params):
     - status: Show connection state, mode, and current config
-    - set (message_limit|timeout): Update runtime limits
+    - set (key+value, or message_limit|timeout): Update a runtime limit.
+      Generic form: set(key='message_limit', value='50'). Typed sugar:
+      set(message_limit=50).
     - cache_clear: Clear internal caches
     - setup_status: Show credential state and relay URL
     - setup_start (-> key='force'): Start relay setup via browser
@@ -586,6 +589,8 @@ async def config(
         action,
         message_limit=message_limit,
         timeout=timeout,
+        key=key,
+        value=value,
     )
 
 

--- a/src/better_telegram_mcp/tools/config_tool.py
+++ b/src/better_telegram_mcp/tools/config_tool.py
@@ -20,16 +20,46 @@ async def _handle_status(backend: TelegramBackend, **kwargs: Any) -> dict[str, A
     return ok(result)
 
 
+# Runtime limits settable via ``config(action="set")`` -- both as typed params
+# (message_limit=, timeout=) and generically (key=, value=) for parity with the
+# other servers' ``set`` action.
+_SETTABLE_KEYS = ("message_limit", "timeout")
+
+
 async def _handle_set(backend: TelegramBackend, **kwargs: Any) -> dict[str, Any]:
     from ..server import _runtime_config
 
     updated: dict[str, int] = {}
-    for key in {"message_limit", "timeout"}:
-        if key in kwargs and kwargs[key] is not None:
-            _runtime_config[key] = int(kwargs[key])
-            updated[key] = _runtime_config[key]
+
+    # Generic key/value form (parity with the other servers' ``set`` action).
+    key = kwargs.get("key")
+    value = kwargs.get("value")
+    if key is not None or value is not None:
+        if not key or value is None:
+            return err("set (generic form) requires both key and value")
+        if key not in _SETTABLE_KEYS:
+            import difflib
+
+            closest = difflib.get_close_matches(key, list(_SETTABLE_KEYS), n=1)
+            suggestion = f" Did you mean '{closest[0]}'?" if closest else ""
+            return err(
+                f"Invalid key: {key}.{suggestion} Valid: {'|'.join(_SETTABLE_KEYS)}"
+            )
+        try:
+            coerced = int(value)
+        except (TypeError, ValueError):
+            return err(f"'{key}' must be an integer, got: {value!r}")
+        _runtime_config[key] = coerced
+        updated[key] = coerced
+
+    # Typed sugar params (message_limit=, timeout=).
+    for typed_key in _SETTABLE_KEYS:
+        if kwargs.get(typed_key) is not None:
+            _runtime_config[typed_key] = int(kwargs[typed_key])
+            updated[typed_key] = _runtime_config[typed_key]
+
     if not updated:
-        return err("set requires at least one of: message_limit, timeout")
+        return err("set requires at least one of: key+value, message_limit, timeout")
     return ok({"updated": updated, "current": _runtime_config})
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -383,3 +383,106 @@ class TestLogout:
 
         assert rc == 0
         assert "Nothing to log out" in capsys.readouterr().out
+
+
+class TestAuth:
+    """`auth` is the standard name; same credential flags as `login`."""
+
+    def test_bot_token_persists_without_deprecation_notice(self, capsys):
+        from better_telegram_mcp import cli
+
+        mock_backend = MagicMock()
+        mock_backend.connect = AsyncMock()
+        mock_backend.disconnect = AsyncMock()
+
+        with (
+            patch.object(
+                sys, "argv", ["better-telegram-mcp", "auth", "--bot-token", "123:ABC"]
+            ),
+            patch(
+                "better_telegram_mcp.backends.bot_backend.BotBackend",
+                return_value=mock_backend,
+            ),
+            patch(
+                "better_telegram_mcp.credential_state._write_single_user_config"
+            ) as mock_write,
+        ):
+            rc = cli.main()
+
+        assert rc == 0
+        mock_write.assert_called_once_with({"TELEGRAM_BOT_TOKEN": "123:ABC"})
+        captured = capsys.readouterr()
+        assert "bot mode" in captured.out
+        assert "deprecated" not in captured.err
+
+    def test_provider_positional_accepted(self):
+        from better_telegram_mcp import cli
+
+        mock_backend = MagicMock()
+        mock_backend.connect = AsyncMock()
+        mock_backend.disconnect = AsyncMock()
+
+        with (
+            patch.object(
+                sys,
+                "argv",
+                ["better-telegram-mcp", "auth", "telegram", "--bot-token", "123:ABC"],
+            ),
+            patch(
+                "better_telegram_mcp.backends.bot_backend.BotBackend",
+                return_value=mock_backend,
+            ),
+            patch("better_telegram_mcp.credential_state._write_single_user_config"),
+        ):
+            rc = cli.main()
+
+        assert rc == 0
+
+    def test_rejects_unknown_provider(self):
+        from better_telegram_mcp import cli
+
+        with patch.object(
+            sys, "argv", ["better-telegram-mcp", "auth", "notion", "--bot-token", "x"]
+        ):
+            with pytest.raises(SystemExit) as exc:
+                cli.main()
+        assert exc.value.code == 2
+
+    def test_no_credential_errors(self):
+        from better_telegram_mcp import cli
+
+        with patch.object(sys, "argv", ["better-telegram-mcp", "auth"]):
+            with pytest.raises(SystemExit) as exc:
+                cli.main()
+        assert exc.value.code == 2
+
+
+class TestLoginDeprecated:
+    """`login` still works but warns and delegates to `auth`."""
+
+    def test_login_warns_and_persists(self, capsys):
+        from better_telegram_mcp import cli
+
+        mock_backend = MagicMock()
+        mock_backend.connect = AsyncMock()
+        mock_backend.disconnect = AsyncMock()
+
+        with (
+            patch.object(
+                sys, "argv", ["better-telegram-mcp", "login", "--bot-token", "123:ABC"]
+            ),
+            patch(
+                "better_telegram_mcp.backends.bot_backend.BotBackend",
+                return_value=mock_backend,
+            ),
+            patch(
+                "better_telegram_mcp.credential_state._write_single_user_config"
+            ) as mock_write,
+        ):
+            rc = cli.main()
+
+        assert rc == 0
+        mock_write.assert_called_once_with({"TELEGRAM_BOT_TOKEN": "123:ABC"})
+        err = capsys.readouterr().err
+        assert "deprecated" in err
+        assert "auth" in err

--- a/tests/test_tools/test_config_tool.py
+++ b/tests/test_tools/test_config_tool.py
@@ -80,6 +80,50 @@ async def test_set_persists_across_calls(mock_backend):
 
 
 @pytest.mark.asyncio
+async def test_set_generic_key_value(mock_backend):
+    """Generic key/value form (parity with the other servers' set)."""
+    result = await handle_config(mock_backend, "set", key="message_limit", value="55")
+    assert result["updated"]["message_limit"] == 55
+    assert result["current"]["message_limit"] == 55
+
+
+@pytest.mark.asyncio
+async def test_set_generic_timeout(mock_backend):
+    result = await handle_config(mock_backend, "set", key="timeout", value="75")
+    assert result["updated"]["timeout"] == 75
+
+
+@pytest.mark.asyncio
+async def test_set_generic_missing_value(mock_backend):
+    result = await handle_config(mock_backend, "set", key="message_limit")
+    assert "error" in result
+    assert "both key and value" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_set_generic_invalid_key(mock_backend):
+    result = await handle_config(mock_backend, "set", key="mesage_limit", value="10")
+    assert "error" in result
+    assert "Invalid key" in result["error"]
+    # Fuzzy suggestion points at the real key.
+    assert "message_limit" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_set_generic_non_int_value(mock_backend):
+    result = await handle_config(mock_backend, "set", key="timeout", value="abc")
+    assert "error" in result
+    assert "must be an integer" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_set_generic_persists_across_calls(mock_backend):
+    await handle_config(mock_backend, "set", key="message_limit", value="33")
+    result = await handle_config(mock_backend, "status")
+    assert result["config"]["message_limit"] == 33
+
+
+@pytest.mark.asyncio
 async def test_cache_clear(mock_backend):
     result = await handle_config(mock_backend, "cache_clear")
     assert "message" in result


### PR DESCRIPTION
Two CLI/tool taxonomy changes to converge better-telegram-mcp with the rest of the server fleet.

## W6.3 — `config set` generic key/value form

The `set` action only accepted typed params (`message_limit=`, `timeout=`). Add the generic `key`/`value` form used by the other servers, e.g. `config(action="set", key="message_limit", value="50")`, while keeping the typed params as sugar. Invalid keys get a fuzzy suggestion; non-integer values are rejected.

## W5.2 — `auth` subcommand (standard alias of `login`)

Add an `auth [<provider>]` CLI subcommand mirroring the other servers' auth naming; it accepts the same `--bot-token` / `--phone` flags as `login`. `login` is kept as a **deprecated alias** for one release cycle and now prints a deprecation notice pointing at `auth`. The optional `provider` positional (only `telegram`) exists for CLI parity with multi-provider servers.

## Verification

- New `test_config_tool.py` cases: generic key/value set, timeout via key/value, missing value, invalid key (with fuzzy suggestion), non-integer value, persistence.
- New `test_cli.py` cases: `auth --bot-token` persists without a deprecation notice, optional `provider` positional accepted, unknown provider rejected, missing credential errors, and `login` warns + delegates.
- `better-telegram-mcp -h` now lists `auth` alongside `login`/`logout`.
- Full suite: 673 passed, 17 skipped. Lint + format + type-check clean.