### PR TITLE
feat: derive a stable subject from the workspace username

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,24 @@ This plugin implements **TC-NearZK** (in-memory, ephemeral). See [mcp-core trust
 | HTTP self-host | Same as hosted | Same | Only you (admin = user) |
 | stdio | `~/.config/mcp/config.enc` (credentials) + `~/.better-telegram-mcp/<name>.session` (Telethon session) | AES-GCM, machine-bound key | Only your OS user (file perm 0600) |
 
+### Workspace username (HTTP setup form)
+
+The browser setup form has an optional **workspace username** field. Entering the
+same username always lands you in the same per-`sub` bucket, so your session stays
+reachable across a re-authorization and across devices, instead of being tied to
+the one-off subject minted for each `/authorize` round-trip. Leaving it blank
+keeps the previous per-authorize behaviour.
+
+Trust boundary: when the form is gated by a *shared* `MCP_RELAY_PASSWORD`, the
+username is a partition key, not a secret -- anyone who knows that password can
+type any username and reach that bucket. That is fine for a trusted group; an
+untrusted multi-tenant deployment needs a per-user secret or delegated OAuth
+instead.
+
+**One-time migration:** existing users must re-authenticate once after this
+change. Nothing is deleted; sessions stored under the old random subject are
+simply no longer addressed.
+
 ## License
 
 MIT -- See [LICENSE](LICENSE).

--- a/src/better_telegram_mcp/relay_schema.py
+++ b/src/better_telegram_mcp/relay_schema.py
@@ -131,6 +131,17 @@ TELEGRAM_TABS: list[dict[str, Any]] = [
 ]
 
 
+# Opt in to the username-derived stable subject, so a returning user reaches the
+# same per-``sub`` bucket instead of the random subject minted per ``/authorize``.
+#
+# This server supplies its own ``custom_credential_form_html``, and mcp-core's
+# local OAuth app only passes ``include_username_field`` to its *default*
+# renderer -- a custom renderer wins and never receives the flag. So the form
+# side has to opt in here while ``server.py`` opts in on the transport side.
+# Both read this one constant so they cannot drift apart.
+STABLE_SUB_ENABLED = True
+
+
 def render_telegram_form(
     schema: dict[str, Any],
     submit_url: str,
@@ -168,4 +179,5 @@ def render_telegram_form(
         submit_url=submit_url,
         prefill=prefill,
         initial_tab=initial_tab,
+        include_username_field=STABLE_SUB_ENABLED,
     )

--- a/src/better_telegram_mcp/server.py
+++ b/src/better_telegram_mcp/server.py
@@ -633,7 +633,7 @@ async def run_http(port: int = 0) -> None:
     from mcp_core.transport.local_server import run_http_server
 
     from .credential_state import on_step_submitted, save_credentials
-    from .relay_schema import RELAY_SCHEMA, render_telegram_form
+    from .relay_schema import RELAY_SCHEMA, STABLE_SUB_ENABLED, render_telegram_form
 
     host = os.environ.get("HOST")
 
@@ -646,6 +646,7 @@ async def run_http(port: int = 0) -> None:
         on_credentials_saved=save_credentials,
         on_step_submitted=on_step_submitted,
         custom_credential_form_html=render_telegram_form,
+        stable_sub_enabled=STABLE_SUB_ENABLED,
     )
 
 


### PR DESCRIPTION
Part of n24q02m/mcp-core#676.

Entering the same workspace username in the setup form now lands you in the same per-`sub` bucket, instead of the one-off subject minted for each `/authorize` round-trip. That is what makes credentials entered through a setup link reachable by a client that authorized earlier.

**Why this is two lines and not one:** this server passes its own `custom_credential_form_html`. mcp-core's local OAuth app only forwards `include_username_field` to its *default* renderer (`local_oauth_app.py` — the custom renderer wins and never receives the flag), so setting `stable_sub_enabled=True` on the transport alone would enable the server-side substitution while the form never rendered the field to fill in. Both sides now read a single `STABLE_SUB_ENABLED` constant.

**One-time migration:** existing users must re-authenticate once. Nothing is deleted; sessions stored under the old random subject are simply no longer addressed.

Gate: `ruff check` clean, `ruff format --check` clean, 681 passed / 17 skipped.