### PR TITLE
fix: drop code_quality from the main ruleset

### DIFF
--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -40,12 +40,6 @@
       "type": "update"
     },
     {
-      "type": "code_quality",
-      "parameters": {
-        "severity": "errors"
-      }
-    },
-    {
       "type": "code_scanning",
       "parameters": {
         "code_scanning_tools": [


### PR DESCRIPTION
Removes the `code_quality` rule from the checked-in ruleset definition, matching the live ruleset which was updated first.

## Why

The rule requires a `CodeQL - Code Quality` check. That check comes from GitHub Code Quality, a product distinct from CodeQL, and it has never run on this repository:

- `GET /repos/n24q02m/<repo>/code-quality` returns 404.
- Every entry under `code-scanning/analyses` is CodeQL.
- The product is available on Team and Enterprise Cloud plans only.

So the required check has no source that could ever report it. The rule is configuration debt rather than an active gate.

## Scope

Only the `code_quality` block is removed. `code_scanning` (real CodeQL), `pull_request`, `deletion`, `non_fast_forward`, `required_linear_history` and `update` are untouched, as are `bypass_actors` and the `pull_request` parameters.

The live ruleset was updated by a surgical `PUT` (current definition minus that one rule); a pre-change snapshot was kept so it can be restored in one call.

## Known drift, not addressed here

This file declares `required_approving_review_count: 1` and `require_code_owner_review: true`, while the live ruleset has `0` and `false`. It also declares one bypass actor where the live ruleset has three. Both predate this change and are left for the owner to reconcile.