### PR TITLE
🎨 Palette: Add password visibility toggle for Bot Token field

### DIFF
--- a/src/better_telegram_mcp/relay_schema.py
+++ b/src/better_telegram_mcp/relay_schema.py
@@ -174,10 +174,62 @@ def render_telegram_form(
         "description": schema.get("description", ""),
         "tabs": TELEGRAM_TABS,
     }
-    return render_credential_form(
+    html = render_credential_form(
         render_schema,
         submit_url=submit_url,
         prefill=prefill,
         initial_tab=initial_tab,
         include_username_field=STABLE_SUB_ENABLED,
     )
+
+    toggle_script = """
+<script>
+(function() {
+    var botTokenInput = document.getElementById("field-TELEGRAM_BOT_TOKEN");
+    if (!botTokenInput) return;
+
+    var wrapper = document.createElement("div");
+    wrapper.style.position = "relative";
+    wrapper.style.display = "flex";
+    wrapper.style.alignItems = "center";
+
+    botTokenInput.parentNode.insertBefore(wrapper, botTokenInput);
+    wrapper.appendChild(botTokenInput);
+    botTokenInput.style.paddingRight = "60px";
+
+    var toggleBtn = document.createElement("button");
+    toggleBtn.type = "button";
+    toggleBtn.textContent = "Show";
+    toggleBtn.setAttribute("aria-label", "Show password");
+    toggleBtn.setAttribute("aria-pressed", "false");
+    toggleBtn.style.position = "absolute";
+    toggleBtn.style.right = "10px";
+    toggleBtn.style.background = "none";
+    toggleBtn.style.border = "none";
+    toggleBtn.style.color = "inherit";
+    toggleBtn.style.cursor = "pointer";
+    toggleBtn.style.padding = "0";
+    toggleBtn.style.fontSize = "0.9em";
+    toggleBtn.style.textDecoration = "underline";
+
+    toggleBtn.addEventListener("click", function() {
+        var isPassword = botTokenInput.type === "password";
+        botTokenInput.type = isPassword ? "text" : "password";
+        toggleBtn.textContent = isPassword ? "Hide" : "Show";
+        toggleBtn.setAttribute("aria-label", isPassword ? "Hide password" : "Show password");
+        toggleBtn.setAttribute("aria-pressed", isPassword ? "true" : "false");
+    });
+
+    wrapper.appendChild(toggleBtn);
+
+    var observer = new MutationObserver(function(mutations) {
+        mutations.forEach(function(mutation) {
+            if (mutation.type === "attributes" && mutation.attributeName === "disabled") {
+                toggleBtn.disabled = botTokenInput.disabled;
+            }
+        });
+    });
+    observer.observe(botTokenInput, { attributes: true });
+})();
+</script>"""
+    return html + toggle_script

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.16.0"
+version = "4.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
### 💡 What
Added a "Show/Hide" password visibility toggle to the `TELEGRAM_BOT_TOKEN` input field in the local setup form.

### 🎯 Why
Bot tokens are long and opaque, making it difficult to verify a successful copy-paste. Users often accidentally truncate the token or miss characters, leading to frustrating auth failures. This small toggle allows users to verify their input before submitting.

### ♿ Accessibility
- Uses a semantic `<button type="button">` to prevent accidental form submissions.
- Includes dynamic `aria-label` ("Show password" / "Hide password") and `aria-pressed` states for screen readers.
- Utilizes a `MutationObserver` to ensure the toggle button is appropriately disabled when the form enters a loading/disabled state.

### 📸 Before/After
(Demonstrated via Playwright verification video and screenshots)

---
*PR created automatically by Jules for task [10902112617467116756](https://jules.google.com/task/10902112617467116756) started by @n24q02m*