### PR TITLE
⚡ Bolt: O(1) saved session existence check

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,6 @@
 ## 2025-08-30 - Internalizing Thread Offloading for Blocking I/O
 **Learning:** In asynchronous backends, internal helper methods that perform blocking filesystem I/O (like `os.open`, `os.chmod`, or file-backed key-value lookups) can block the main asyncio event loop if not properly offloaded. While the offloading could be done at the call site, doing so clutters the call site and relies on callers to remember the implementation detail.
 **Action:** Always refactor internal helper methods that perform blocking I/O to be `async def`. Wrap their synchronous logic in a nested function and internally offload it using `await asyncio.to_thread()`. This improves API clarity and ensures non-blocking behavior wherever the method is invoked.
+## 2025-09-12 - Avoiding O(N+1) Decryption for Existence Checks
+**Learning:** Using `load_all()` simply to check if any sessions exist (e.g. `len(store.load_all()) > 0`) is a severe anti-pattern in encrypted KV stores. It forces the application to load and decrypt every single item (N+1 PBKDF2 operations) just to verify existence, which can massively delay server startup times.
+**Action:** Always implement and use an O(1) `has_any()` method (which only loads the shared index without decrypting the payload) when merely checking for existence in an encrypted storage layer.

--- a/src/better_telegram_mcp/auth/in_memory_session_store.py
+++ b/src/better_telegram_mcp/auth/in_memory_session_store.py
@@ -47,6 +47,10 @@ class InMemorySessionStore:
     def __init__(self) -> None:
         self._store: dict[str, dict] = {}
 
+    def has_any(self) -> bool:
+        """Check if any sessions exist."""
+        return len(self._store) > 0
+
     def store(self, bearer: str, info: SessionInfo) -> None:
         """Store a session for the given bearer token. Overwrites existing."""
         self._store[bearer] = info.to_dict()

--- a/src/better_telegram_mcp/auth/kv_session_store.py
+++ b/src/better_telegram_mcp/auth/kv_session_store.py
@@ -72,6 +72,14 @@ class KvSessionStore:
     # Public API (mirrors InMemorySessionStore)
     # ------------------------------------------------------------------
 
+    def has_any(self) -> bool:
+        """Check if any sessions exist without loading/decrypting them.
+
+        This turns an O(N+1) PBKDF2 cryptography bottleneck into an O(1)
+        check by only loading the shared index.
+        """
+        return len(self._load_index()) > 0
+
     def store(self, bearer: str, info: SessionInfo) -> None:
         """Persist encrypted session info for bearer. Updates index."""
         self._sub_store(bearer).save(info.to_dict())

--- a/src/better_telegram_mcp/relay_setup.py
+++ b/src/better_telegram_mcp/relay_setup.py
@@ -103,7 +103,7 @@ def check_saved_sessions(backend=None) -> bool:
     if cf_mode:
         from .auth.kv_session_store import KvSessionStore
 
-        return len(KvSessionStore(backend=backend).load_all()) > 0
+        return KvSessionStore(backend=backend).has_any()
 
     data_dir = Path.home() / ".better-telegram-mcp"
     if not data_dir.exists():


### PR DESCRIPTION
**💡 What:** 
Added a `has_any()` method to `KvSessionStore` and `InMemorySessionStore` to provide an O(1) existence check, and updated `check_saved_sessions()` in `relay_setup.py` to use it instead of `load_all()`.

**🎯 Why:**
Previously, `check_saved_sessions()` was using `load_all()` simply to check if the count of sessions was greater than zero. Because `KvSessionStore` is an encrypted store, calling `load_all()` forces the application to load and decrypt every single saved session (performing N+1 heavy PBKDF2 key derivations) just to verify existence. This creates a severe cryptographic bottleneck that significantly delays server startup times. 

**📊 Impact:** 
Turns an O(N) cryptographic bottleneck into an O(1) index read, drastically improving startup times for servers with multiple configured sessions.

**🔬 Measurement:**
Tested locally. Code passes `uv run ruff check .`, `uv run ruff format --check .`, and `uv run pytest`.

---
*PR created automatically by Jules for task [15343642218432303072](https://jules.google.com/task/15343642218432303072) started by @n24q02m*