### PR TITLE
⚡ Bolt: Optimize check_saved_sessions with O(1) index check

### DIFF
--- a/src/better_telegram_mcp/auth/in_memory_session_store.py
+++ b/src/better_telegram_mcp/auth/in_memory_session_store.py
@@ -47,6 +47,10 @@ class InMemorySessionStore:
     def __init__(self) -> None:
         self._store: dict[str, dict] = {}
 
+    def has_any(self) -> bool:
+        """Check if any stored sessions exist."""
+        return len(self._store) > 0
+
     def store(self, bearer: str, info: SessionInfo) -> None:
         """Store a session for the given bearer token. Overwrites existing."""
         self._store[bearer] = info.to_dict()

--- a/src/better_telegram_mcp/auth/kv_session_store.py
+++ b/src/better_telegram_mcp/auth/kv_session_store.py
@@ -72,6 +72,10 @@ class KvSessionStore:
     # Public API (mirrors InMemorySessionStore)
     # ------------------------------------------------------------------
 
+    def has_any(self) -> bool:
+        """Check if any stored sessions exist using the index (O(1))."""
+        return len(self._load_index()) > 0
+
     def store(self, bearer: str, info: SessionInfo) -> None:
         """Persist encrypted session info for bearer. Updates index."""
         self._sub_store(bearer).save(info.to_dict())

--- a/src/better_telegram_mcp/relay_setup.py
+++ b/src/better_telegram_mcp/relay_setup.py
@@ -103,7 +103,7 @@ def check_saved_sessions(backend=None) -> bool:
     if cf_mode:
         from .auth.kv_session_store import KvSessionStore
 
-        return len(KvSessionStore(backend=backend).load_all()) > 0
+        return KvSessionStore(backend=backend).has_any()
 
     data_dir = Path.home() / ".better-telegram-mcp"
     if not data_dir.exists():


### PR DESCRIPTION
💡 What: Added a `has_any()` method to `KvSessionStore` (and `InMemorySessionStore`) to perform an $O(1)$ index check instead of relying on `load_all()`.
🎯 Why: `check_saved_sessions` was previously calling `load_all()` to check if any sessions existed. In `KvSessionStore`, `load_all()` decrypts every single stored session. While it is parallelized across sessions, deriving the PBKDF2 keys and decrypting the payloads for $N$ sessions just to check if $N > 0$ is extremely wasteful and blocks the CPU unnecessarily.
📊 Impact: Reduces the time complexity of checking for saved sessions in a Cloudflare KV backend from $O(N)$ (where $N$ is the number of stored sessions, bounded by PBKDF2 key derivation) to $O(1)$ (a single index length check).
🔬 Measurement: Run the test suite (`uv run pytest`) and benchmark server initialization with many sessions before and after this change.

---
*PR created automatically by Jules for task [5961139720852518588](https://jules.google.com/task/5961139720852518588) started by @n24q02m*