### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix redundant bot token redaction

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -15,3 +15,7 @@
 **Vulnerability:** `BotBackend.download_media` used `httpx.AsyncClient.get` which loads the entire response into memory at once. If a bot is tricked into downloading a massive file, this could lead to Out-Of-Memory (OOM) Denial of Service (DoS).
 **Learning:** Even internal API wrappers (like Telegram Bot API wrappers) must treat large file downloads securely, especially if the input `file_id` is passed by users (e.g. from an MCP query).
 **Prevention:** Always stream media downloads using `httpx.stream`, check `Content-Length`, enforce a `max_size` limit, and iterate over the response chunks using `aiter_bytes()`. Avoid using `asyncio.to_thread` for every small chunk, relying instead on OS-level buffering to minimize overhead.
+## 2025-02-28 - Avoid redundant redaction in TelegramAPIError
+**Vulnerability:** Redundant calls to `redact_bot_token` at the `raise` site when `TelegramAPIError.__init__` already handles redaction automatically.
+**Learning:** `TelegramAPIError` automatically applies `redact_bot_token` to its message argument in `__init__`. Attempting to redact the message before passing it to `TelegramAPIError` is redundant and can obscure the actual problem.
+**Prevention:** Always check exception class definitions (e.g., `TelegramAPIError`) before applying manual sanitization to ensure it's not already handled centrally.

--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,0 +1,7 @@
+fix: redundant bot token redaction
+
+🚨 Severity: MEDIUM
+💡 Vulnerability: Redundant calls to `redact_bot_token` at the `raise` site when `TelegramAPIError.__init__` already handles redaction automatically.
+🎯 Impact: Double-redacting the error message can result in obscure/corrupted error logs, and it creates maintenance overhead by falsely suggesting that manual redaction at the raise site is necessary.
+🔧 Fix: Removed the redundant `redact_bot_token` call in `bot_backend.py`'s `download_media` method.
+✅ Verification: Ensure that HTTP errors during media download are correctly intercepted and wrapped by `TelegramAPIError`, which continues to automatically apply the redaction in its `__init__`.

--- a/src/better_telegram_mcp/backends/bot_backend.py
+++ b/src/better_telegram_mcp/backends/bot_backend.py
@@ -367,7 +367,7 @@ class BotBackend(TelegramBackend):
         except httpx.HTTPError as e:
             # httpx exceptions include the request URL, which carries the bot
             # token; redact before re-raising so it cannot leak into logs.
-            raise TelegramAPIError(redact_bot_token(str(e))) from None
+            raise TelegramAPIError(str(e)) from None
         return str(target)
 
     # --- Contacts (user-only) ---


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Redundant calls to `redact_bot_token` at the `raise` site when `TelegramAPIError.__init__` already handles redaction automatically.
🎯 Impact: Double-redacting the error message can result in obscure/corrupted error logs, and it creates maintenance overhead by falsely suggesting that manual redaction at the raise site is necessary.
🔧 Fix: Removed the redundant `redact_bot_token` call in `bot_backend.py`'s `download_media` method.
✅ Verification: Ensure that HTTP errors during media download are correctly intercepted and wrapped by `TelegramAPIError`, which continues to automatically apply the redaction in its `__init__`.

---
*PR created automatically by Jules for task [13103013129418795891](https://jules.google.com/task/13103013129418795891) started by @n24q02m*