### PR TITLE
🎨 Palette: Add password visibility toggle for Bot Token

### DIFF
--- a/src/better_telegram_mcp/relay_schema.py
+++ b/src/better_telegram_mcp/relay_schema.py
@@ -174,10 +174,40 @@ def render_telegram_form(
         "description": schema.get("description", ""),
         "tabs": TELEGRAM_TABS,
     }
-    return render_credential_form(
+    html = render_credential_form(
         render_schema,
         submit_url=submit_url,
         prefill=prefill,
         initial_tab=initial_tab,
         include_username_field=STABLE_SUB_ENABLED,
     )
+
+    injection = """
+    <script>
+    document.querySelectorAll('input[type="password"]').forEach(i => {
+        let b = document.createElement('button');
+        b.type = 'button'; b.textContent = 'Show'; b.className = 'field-input';
+        b.setAttribute('aria-label', 'Show password'); b.setAttribute('aria-pressed', 'false');
+        b.style.width = 'max-content'; b.style.marginLeft = '8px'; b.style.padding = '0 12px';
+        b.onclick = () => {
+            let p = i.type === 'password';
+            i.type = p ? 'text' : 'password';
+            b.textContent = p ? 'Hide' : 'Show';
+            b.setAttribute('aria-label', p ? 'Hide password' : 'Show password');
+            b.setAttribute('aria-pressed', p ? 'true' : 'false');
+        };
+        new MutationObserver(m => m.forEach(x => {
+            if (x.attributeName === 'disabled') b.disabled = i.disabled;
+            else if (x.attributeName === 'type') {
+                let p = i.type === 'password';
+                b.textContent = p ? 'Show' : 'Hide';
+                b.setAttribute('aria-label', p ? 'Show password' : 'Hide password');
+                b.setAttribute('aria-pressed', p ? 'false' : 'true');
+            }
+        })).observe(i, { attributes: true, attributeFilter: ['disabled', 'type'] });
+        let w = document.createElement('div'); w.style.display = 'flex';
+        i.parentNode.insertBefore(w, i); w.appendChild(i); w.appendChild(b);
+    });
+    </script>
+    """
+    return html.replace('</body>', injection + '</body>') if '</body>' in html else html + injection

--- a/src/better_telegram_mcp/relay_schema.py
+++ b/src/better_telegram_mcp/relay_schema.py
@@ -210,4 +210,8 @@ def render_telegram_form(
     });
     </script>
     """
-    return html.replace('</body>', injection + '</body>') if '</body>' in html else html + injection
+    return (
+        html.replace("</body>", injection + "</body>")
+        if "</body>" in html
+        else html + injection
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.16.0"
+version = "4.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
💡 **What**: Added an accessible "Show/Hide" toggle button to the Bot Token password field on the credential relay page.
🎯 **Why**: Long API keys like Bot Tokens are prone to typos or copy-paste errors. Allowing users to visually verify their token before submitting reduces failed authentication attempts and improves overall usability.
📸 **Before/After**: 
*Before:* Just a standard password field.
*After:* A standard password field with a subtle "Show" button on the right edge.
♿ **Accessibility**: 
- Added a `<button type="button">` explicitly.
- The button manages `aria-label` ("Show password" / "Hide password") and `aria-pressed` ("true" / "false") correctly.
- Uses `MutationObserver` to ensure the toggle disables and enables perfectly in sync with the parent form's asynchronous loading state, preventing disjointed interactive states.

---
*PR created automatically by Jules for task [6394188013215233190](https://jules.google.com/task/6394188013215233190) started by @n24q02m*