### PR TITLE
🎨 Palette: Add password visibility toggles to credential form

### DIFF
--- a/src/better_telegram_mcp/relay_schema.py
+++ b/src/better_telegram_mcp/relay_schema.py
@@ -141,6 +141,27 @@ TELEGRAM_TABS: list[dict[str, Any]] = [
 # Both read this one constant so they cannot drift apart.
 STABLE_SUB_ENABLED = True
 
+INJECTION = """<script>
+(function(){
+  function s(i) {
+    if(i.dataset.t) return; i.dataset.t='1';
+    let p=i.parentNode, b=document.createElement('button');
+    p.style.position='relative'; i.style.paddingRight='4rem';
+    b.type='button'; b.className='tab'; b.textContent='Show';
+    b.setAttribute('aria-label','Show password'); b.setAttribute('aria-pressed','false');
+    b.style.cssText='position:absolute;right:2px;bottom:2px;padding:0.5rem;border:none;background:0;width:auto;flex:none;font-size:0.85rem;';
+    b.onclick=e=>{ e.preventDefault(); let s=i.type==='password'; i.type=s?'text':'password'; b.textContent=s?'Hide':'Show'; b.setAttribute('aria-label',s?'Hide password':'Show password'); b.setAttribute('aria-pressed',s?'true':'false'); };
+    p.appendChild(b);
+    new MutationObserver(m=>{ m.forEach(x=>{
+      if(x.attributeName==='disabled') b.disabled=i.disabled;
+      if(x.attributeName==='type') { let p=i.type==='password'; b.style.display=(p||i.type==='text')?'block':'none'; if(p){ b.textContent='Show'; b.setAttribute('aria-label','Show password'); b.setAttribute('aria-pressed','false'); } }
+    })}).observe(i,{attributes:true,attributeFilter:['disabled','type']});
+    if(i.type!=='password') b.style.display='none';
+  }
+  document.querySelectorAll('input[type="password"]').forEach(s);
+  new MutationObserver(m=>m.forEach(x=>x.addedNodes.forEach(n=>{ if(n.nodeType===1) { if(n.id==='step-input') s(n); else { let i=n.querySelector('#step-input'); if(i) s(i); } } }))).observe(document.body,{childList:true,subtree:true});
+})();
+</script>"""
 
 def render_telegram_form(
     schema: dict[str, Any],
@@ -174,10 +195,11 @@ def render_telegram_form(
         "description": schema.get("description", ""),
         "tabs": TELEGRAM_TABS,
     }
-    return render_credential_form(
+    html = render_credential_form(
         render_schema,
         submit_url=submit_url,
         prefill=prefill,
         initial_tab=initial_tab,
         include_username_field=STABLE_SUB_ENABLED,
     )
+    return html.replace('</body>', INJECTION + '</body>')

--- a/src/better_telegram_mcp/relay_schema.py
+++ b/src/better_telegram_mcp/relay_schema.py
@@ -163,6 +163,7 @@ INJECTION = """<script>
 })();
 </script>"""
 
+
 def render_telegram_form(
     schema: dict[str, Any],
     submit_url: str,
@@ -202,4 +203,4 @@ def render_telegram_form(
         initial_tab=initial_tab,
         include_username_field=STABLE_SUB_ENABLED,
     )
-    return html.replace('</body>', INJECTION + '</body>')
+    return html.replace("</body>", INJECTION + "</body>")

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.17.0"
+version = "4.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.16.0"
+version = "4.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
💡 **What:** Adds an injected JavaScript toggle button ("Show/Hide") to all `type="password"` fields (including dynamic ones like `step-input`) in the web UI credential form returned by `mcp-core`.

🎯 **Why:** Providing visibility toggles for fields expecting long, complex strings (like Bot Tokens or 2FA passwords) directly solves the UX issue detailed in `.jules/palette.md`. It allows users to visually verify that they have pasted the correct API key in full before initiating a connection, heavily reducing frustrating auth failures from malformed tokens.

📸 **Before/After:** The original interface simply displayed standard, un-toggleable masked dots for the `TELEGRAM_BOT_TOKEN` input. Now, an inline "Show" button exists adjacent to the text, which when clicked morphs into "Hide" and unmasks the text.

♿ **Accessibility:**
- Added `aria-label="Show password"` and `aria-pressed="false"` properties to the toggle button.
- A `MutationObserver` actively synchronizes both the active state (`disabled` alignment with form state) and ARIA attributes (re-hiding and resetting to `aria-pressed="false"` when the underlying field resets to text from OTP challenges).
- The button relies on standard system focus states without interfering with the parent field.

---
*PR created automatically by Jules for task [4135933436754245773](https://jules.google.com/task/4135933436754245773) started by @n24q02m*