### PR TITLE
⚡ Bolt: Optimize check_saved_sessions with has_any

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,6 @@
 ## 2025-08-30 - Internalizing Thread Offloading for Blocking I/O
 **Learning:** In asynchronous backends, internal helper methods that perform blocking filesystem I/O (like `os.open`, `os.chmod`, or file-backed key-value lookups) can block the main asyncio event loop if not properly offloaded. While the offloading could be done at the call site, doing so clutters the call site and relies on callers to remember the implementation detail.
 **Action:** Always refactor internal helper methods that perform blocking I/O to be `async def`. Wrap their synchronous logic in a nested function and internally offload it using `await asyncio.to_thread()`. This improves API clarity and ensures non-blocking behavior wherever the method is invoked.
+## 2025-09-10 - O(1) Existence Check for Cryptographic KV Stores
+**Learning:** Checking if a record exists in an encrypted Key-Value store (like `KvSessionStore`) by using `len(store.load_all()) > 0` is extremely inefficient, as it triggers N+1 costly PBKDF2 decryption operations.
+**Action:** When a boolean existence check is all that's required, implement and use index-only checks (like `has_any()`) which achieve O(1) performance and completely avoid the bulk cryptographic overhead.

--- a/src/better_telegram_mcp/auth/in_memory_session_store.py
+++ b/src/better_telegram_mcp/auth/in_memory_session_store.py
@@ -69,6 +69,10 @@ class InMemorySessionStore:
             for bearer, data in self._store.items()
         }
 
+    def has_any(self) -> bool:
+        """Check if any sessions exist."""
+        return bool(self._store)
+
     def delete(self, bearer: str) -> bool:
         """Delete a session. Returns True if it existed."""
         if bearer not in self._store:

--- a/src/better_telegram_mcp/auth/kv_session_store.py
+++ b/src/better_telegram_mcp/auth/kv_session_store.py
@@ -32,7 +32,7 @@ class KvSessionStore:
     """Per-user MTProto session store backed by an mcp-core CredentialBackend.
 
     Drop-in replacement for InMemorySessionStore — same public API:
-    store / load / load_all / delete.  On CF the backend is CfKvBackend;
+    store / load / load_all / has_any / delete.  On CF the backend is CfKvBackend;
     in unit tests pass InMemoryBackend.
     """
 
@@ -106,6 +106,10 @@ class KvSessionStore:
                 result[sub] = info
 
         return result
+
+    def has_any(self) -> bool:
+        """Check if any sessions exist using the index to avoid N+1 PBKDF2 overhead."""
+        return bool(self._load_index())
 
     def delete(self, bearer: str) -> bool:
         """Delete session for bearer. Returns True if it existed."""

--- a/src/better_telegram_mcp/relay_setup.py
+++ b/src/better_telegram_mcp/relay_setup.py
@@ -103,7 +103,7 @@ def check_saved_sessions(backend=None) -> bool:
     if cf_mode:
         from .auth.kv_session_store import KvSessionStore
 
-        return len(KvSessionStore(backend=backend).load_all()) > 0
+        return KvSessionStore(backend=backend).has_any()
 
     data_dir = Path.home() / ".better-telegram-mcp"
     if not data_dir.exists():


### PR DESCRIPTION
💡 **What**: Added a `has_any()` method to both `KvSessionStore` and `InMemorySessionStore` and updated `check_saved_sessions` to use it instead of `load_all()`.

🎯 **Why**: When `check_saved_sessions()` was calling `load_all()`, it was inadvertently loading and decrypting every single user session stored in the Key-Value database (doing N PBKDF2 iterations) just to evaluate `len(sessions) > 0`. This is extremely inefficient and wasteful on heavy crypto bounds when all we care about is "is there at least 1 session?". By implementing `has_any()`, we can just check the boolean truthiness of the underlying index, skipping all decryption.

📊 **Impact**: Reduces existence checks on cryptographic KV stores from O(N) to O(1) time complexity. Avoids N costly PBKDF2 operations and bulk data retrieval.

🔬 **Measurement**: Server startup/initialization times and any credential re-evaluations via `relay_setup.py` should show reduced CPU usage and significantly faster execution when multiple user sessions are present. All `uv run pytest` tests pass seamlessly.

---
*PR created automatically by Jules for task [2159132846540761716](https://jules.google.com/task/2159132846540761716) started by @n24q02m*