### PR TITLE
fix: isolate test HOME so per-plugin stores cannot reach the real home

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -182,6 +182,23 @@ def mock_webbrowser_open():
 
 
 @pytest.fixture(autouse=True)
+def _isolate_per_plugin_home(tmp_path_factory, monkeypatch):
+    """Redirect ~/ to a per-test tmp dir so PerPluginStore writes can never
+    reach the real ~/.telegram-mcp/ (or a shared one between parallel pytest
+    workers). Path.home() reads HOME on POSIX and USERPROFILE on Windows.
+
+    Defense-in-depth, not a bug fix: no test leaks today, because every one
+    passes an explicit backend and every sub is non-None. But
+    KvSessionStore(backend=None) -- the documented production default --
+    routes through backend_from_env() -> LocalFsBackend, which writes under
+    Path.home(). See tests/test_home_isolation_guard.py.
+    """
+    fake_home = tmp_path_factory.mktemp("telegram_test_home")
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setenv("USERPROFILE", str(fake_home))
+
+
+@pytest.fixture(autouse=True)
 def mock_fetch_url_safely():
     """Globally mock fetch_url_safely to avoid network requests during tests."""
 

--- a/tests/test_backends/test_security.py
+++ b/tests/test_backends/test_security.py
@@ -438,8 +438,12 @@ class TestValidateFilePath:
             validate_file_path("~/.ssh/id_rsa")
 
     @pytest.mark.skipif(_IS_WINDOWS, reason="Unix-only blocked paths")
-    def test_tilde_expansion_traversal_blocked(self):
+    def test_tilde_expansion_traversal_blocked(self, monkeypatch):
         """Test that paths like ~/../../etc/passwd are expanded and blocked."""
+        # Pin HOME: the traversal only lands on /etc/ if home is exactly two
+        # levels deep, so without this the assertion silently depends on the
+        # ambient HOME (real ~/ vs an isolated tmp one).
+        monkeypatch.setenv("HOME", "/home/testuser")
         with pytest.raises(SecurityError, match="/etc/"):
             validate_file_path("~/../../etc/passwd")
 
@@ -500,7 +504,9 @@ class TestValidateOutputDir:
             validate_output_dir("~/.ssh")
 
     @pytest.mark.skipif(_IS_WINDOWS, reason="Unix-only blocked paths")
-    def test_tilde_expansion_traversal_blocked(self):
+    def test_tilde_expansion_traversal_blocked(self, monkeypatch):
         """Test that paths like ~/../../etc/cron.d are expanded and blocked."""
+        # Pin HOME: see the matching note in TestValidateFilePath.
+        monkeypatch.setenv("HOME", "/home/testuser")
         with pytest.raises(SecurityError, match="/etc/"):
             validate_output_dir("~/../../etc/cron.d")

--- a/tests/test_backends/test_security.py
+++ b/tests/test_backends/test_security.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import socket
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -16,6 +17,23 @@ from better_telegram_mcp.backends.security import (
 )
 
 _IS_WINDOWS = sys.platform == "win32"
+
+
+def _tilde_traversal_to(target: str) -> str:
+    """Build a ``~/../..././<target>`` path that always lands on ``/<target>``.
+
+    The number of ``..`` segments is derived from the real depth of ``~`` so
+    the traversal reaches the filesystem root wherever home happens to be --
+    ``/home/runner``, ``/Users/runner``, or an isolated tmp dir. Hardcoding
+    two levels made these tests depend on the ambient HOME.
+
+    Takes the deeper of the raw and resolved home (macOS resolves /var and
+    /tmp through /private, so the two differ). Over-climbing is harmless:
+    ``/..`` is ``/``.
+    """
+    home = Path.home()
+    depth = max(len(home.parts), len(home.resolve().parts)) - 1
+    return "/".join(["~", *([".."] * depth), target])
 
 
 class TestValidateUrl:
@@ -438,14 +456,10 @@ class TestValidateFilePath:
             validate_file_path("~/.ssh/id_rsa")
 
     @pytest.mark.skipif(_IS_WINDOWS, reason="Unix-only blocked paths")
-    def test_tilde_expansion_traversal_blocked(self, monkeypatch):
+    def test_tilde_expansion_traversal_blocked(self):
         """Test that paths like ~/../../etc/passwd are expanded and blocked."""
-        # Pin HOME: the traversal only lands on /etc/ if home is exactly two
-        # levels deep, so without this the assertion silently depends on the
-        # ambient HOME (real ~/ vs an isolated tmp one).
-        monkeypatch.setenv("HOME", "/home/testuser")
         with pytest.raises(SecurityError, match="/etc/"):
-            validate_file_path("~/../../etc/passwd")
+            validate_file_path(_tilde_traversal_to("etc/passwd"))
 
 
 class TestValidateOutputDir:
@@ -504,9 +518,7 @@ class TestValidateOutputDir:
             validate_output_dir("~/.ssh")
 
     @pytest.mark.skipif(_IS_WINDOWS, reason="Unix-only blocked paths")
-    def test_tilde_expansion_traversal_blocked(self, monkeypatch):
+    def test_tilde_expansion_traversal_blocked(self):
         """Test that paths like ~/../../etc/cron.d are expanded and blocked."""
-        # Pin HOME: see the matching note in TestValidateFilePath.
-        monkeypatch.setenv("HOME", "/home/testuser")
         with pytest.raises(SecurityError, match="/etc/"):
-            validate_output_dir("~/../../etc/cron.d")
+            validate_output_dir(_tilde_traversal_to("etc/cron.d"))

--- a/tests/test_home_isolation_guard.py
+++ b/tests/test_home_isolation_guard.py
@@ -61,8 +61,17 @@ def test_per_plugin_store_path_is_not_in_the_real_store_dir():
 def test_single_user_write_stays_out_of_the_real_store(monkeypatch):
     """Drive the production write path that can reach the real home."""
     monkeypatch.delenv("MCP_STORAGE_BACKEND", raising=False)
-    before = _snapshot(_REAL_STORE_DIR)
 
+    # Resolve where the write would land BEFORE performing it. A guard that
+    # pollutes the real store when it fires is self-defeating: on a developer
+    # machine _write_single_user_config would overwrite real credentials.
+    cred_path = PerPluginStore(plugin_name="telegram").cred_path.resolve()
+    assert _REAL_STORE_DIR not in cred_path.parents, (
+        f"refusing to run the write probe: it would land in {cred_path}. "
+        "Restore _isolate_per_plugin_home in tests/conftest.py."
+    )
+
+    before = _snapshot(_REAL_STORE_DIR)
     _write_single_user_config({"TELEGRAM_BOT_TOKEN": "guard-token"})
 
     written = sorted(Path.home().glob(".telegram-mcp/*"))

--- a/tests/test_home_isolation_guard.py
+++ b/tests/test_home_isolation_guard.py
@@ -1,0 +1,72 @@
+"""Guard: the autouse ``_isolate_per_plugin_home`` fixture must stay in place.
+
+The fixture in conftest.py is defense-in-depth -- no test leaks into the real
+home today. These tests exist so that if someone deletes the fixture, the
+suite goes red immediately instead of silently starting to write into the
+developer's (or the CI runner's) real ~/.telegram-mcp/.
+
+``test_single_user_write_stays_out_of_the_real_store`` is the load-bearing
+one. It drives the production path that can genuinely write there:
+``credential_state._write_single_user_config`` -> ``PerPluginStore("telegram")``
+with ``sub=None`` -> ``backend_from_env()`` -> ``LocalFsBackend`` ->
+``~/.telegram-mcp/config.json`` plus the ``.secret`` machine key. Today every
+test of that surface opts into the local ``isolated_home`` fixture by hand; a
+new one that forgets would hit the real directory.
+
+Note the asserts compare against the real *store* directory, not the real
+home. On Windows pytest's tmp_path lives under ``~\\AppData\\Local\\Temp``,
+so "is not under the real home" is false for a correctly isolated path.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from mcp_core.storage.per_plugin_store import PerPluginStore
+
+from better_telegram_mcp.credential_state import _write_single_user_config
+
+# Captured at import time: collection runs before any fixture, so this is the
+# genuine home directory, whatever the fixture later redirects Path.home() to.
+_REAL_HOME = Path(os.path.expanduser("~")).resolve()
+_REAL_STORE_DIR = _REAL_HOME / ".telegram-mcp"
+
+
+def _snapshot(directory: Path) -> set[tuple[str, int, int]]:
+    """Identify every file under directory by path, size and mtime.
+
+    Works whether or not the directory exists, so this never assumes the
+    developer has no real ~/.telegram-mcp/ of their own.
+    """
+    if not directory.exists():
+        return set()
+    return {
+        (str(path), path.stat().st_size, path.stat().st_mtime_ns)
+        for path in directory.rglob("*")
+        if path.is_file()
+    }
+
+
+def test_home_is_redirected_away_from_the_real_home():
+    assert Path.home().resolve() != _REAL_HOME
+
+
+def test_per_plugin_store_path_is_not_in_the_real_store_dir():
+    cred_path = PerPluginStore(plugin_name="telegram").cred_path.resolve()
+    assert _REAL_STORE_DIR != cred_path
+    assert _REAL_STORE_DIR not in cred_path.parents
+
+
+def test_single_user_write_stays_out_of_the_real_store(monkeypatch):
+    """Drive the production write path that can reach the real home."""
+    monkeypatch.delenv("MCP_STORAGE_BACKEND", raising=False)
+    before = _snapshot(_REAL_STORE_DIR)
+
+    _write_single_user_config({"TELEGRAM_BOT_TOKEN": "guard-token"})
+
+    written = sorted(Path.home().glob(".telegram-mcp/*"))
+    assert written, "expected the LocalFsBackend write to land in the tmp home"
+    for path in written:
+        assert _REAL_STORE_DIR not in path.resolve().parents
+    assert _snapshot(_REAL_STORE_DIR) == before


### PR DESCRIPTION
## What this is

Defense-in-depth. **No leak reproduces today** — this PR does not fix a bug, and nobody reading it later should think it did.

I measured before patching. Full suite on `origin/main` (`681 passed, 17 skipped, 144 deselected`), with a byte-level before/after snapshot of the real home: **identical**. Same sha256, same mtimes, and `~/.telegram-mcp/` did not exist before the run or after it. I also re-ran the suite under a probe hooking `builtins.open`/`io.open` (write modes), `Path.mkdir`, `Path.write_bytes`, `Path.write_text` and `Path.home`: **zero writes to the real home**. The only hits were pytest's own tmp dir and `.pytest_cache`. (On Windows `%TEMP%` lives under `~\AppData\Local\Temp`, so a naive "is it under home" check false-positives on correctly isolated paths — worth knowing before writing this kind of assertion.)

## Why nothing leaks today

- Every test touching `PerPluginStore` passes an explicit `InMemoryBackend`, so `save`/`load`/`clear` go to the backend and the computed `cred_path` is never written.
- Every `sub` in `KvSessionStore` / `PendingOtpStore` is non-None, so `_load_or_generate_machine_key` — the only thing that writes `~/.<plugin>-mcp/.secret` — is never reached from there.
- `tests/test_relay_setup.py` already patches `relay_setup.Path.home` to `tmp_path`, so the real-home `*.session` glob at `relay_setup.py:108` is never hit.
- `test_config_status_storage.py`, `test_credential_state.py` and `test_credential_state_cf.py` each set `HOME`/`USERPROFILE` to `tmp_path` in their own local `isolated_home` fixture.

That last point is the reason for this PR: the discipline is real but **per-file and opt-in**. `isolated_home` is a plain fixture each test has to request by name. A new test of the same surface that forgets it writes into the real home.

## The path that can actually write

`Path.home()/".telegram-mcp"` is resolved **336 times per suite run** (260 via `PerPluginStore._cred_path`, 76 via `backends._key_to_path`) — currently harmless, since nothing writes through it.

One correction worth recording, because I had this wrong earlier and verified it only when the guard test failed: **`KvSessionStore(backend=None)` is not the leak path.** It uses `sub_key="session_meta"`/`"session_index"`, and `LocalFsBackend._key_to_path` only accepts the `config` and `tokens/<provider>` leaves — anything else raises `ValueError: Invalid backend key`. Same for `StringSessionStore` (`sub_key="session"`). Those stores are CF-KV-only in practice.

The path that *does* write is the single-user credential store:

```
credential_state._write_single_user_config()
  -> PerPluginStore("telegram")          # sub=None, leaf "config"
  -> backend_from_env() -> LocalFsBackend  # the default; MCP_STORAGE_BACKEND unset
  -> ~/.telegram-mcp/config.json + ~/.telegram-mcp/.secret
```

Proven, not argued: a deliberate one-off probe with the fixture removed wrote `.secret` (32 B machine key) and `config.json` (65 B) into the real `~/.telegram-mcp/`. That is the measurement behind the claim above. I deleted the directory afterwards to restore the machine to its exact prior state (it had not existed).

**The committed guard does not do that.** The first draft did — it called `_write_single_user_config` unconditionally and only then compared snapshots, so with the fixture missing (exactly when the guard fires) the guard inflicted the damage it watches for. Harmless on a CI runner; on a developer machine it would overwrite real credentials. Fixed in the second commit: the probe resolves its destination first and refuses to write when that would land in the real store. The invariant now holds by measurement — fixture removed gives 3 red tests and `~/.telegram-mcp/` stays absent.

## Changes (tests/ only)

- `tests/conftest.py` — autouse `_isolate_per_plugin_home`, mirroring mnemo's: points `HOME` + `USERPROFILE` at a per-test `tmp_path_factory` dir. `Path.home()` reads `HOME` on POSIX and `USERPROFILE` on Windows.
- `tests/test_home_isolation_guard.py` — three guards, so deleting the fixture turns the suite red instead of silently starting to pollute. The load-bearing one drives `_write_single_user_config` (the real writer above) and asserts nothing landed in the real store dir, comparing a before/after file snapshot so it works whether or not the developer has a genuine `~/.telegram-mcp/` of their own.

- `tests/test_backends/test_security.py` — the two `test_tilde_expansion_traversal_blocked` cases asserted that `~/../../etc/passwd` reaches `/etc/`, which only holds when home is exactly two levels deep. They were silently relying on the runner's ambient HOME, so isolating HOME broke them on Linux while they kept passing on Windows (where they are skipped). The traversal depth is now derived from the real depth of `~`, taking the deeper of the raw and resolved home because macOS resolves `/var` and `/tmp` through `/private`. They now test tilde expansion rather than how deep the runner's home happens to be.

`684 passed, 17 skipped, 144 deselected` locally with the fixture in place, and green on ubuntu, macos and windows in CI.

## Deliberately untouched

`~/.better-telegram-mcp/` is **not** the per-plugin store and is not what this PR isolates. It is the Telethon runtime session directory (`CLAUDE.md`: "Session persist: `~/.better-telegram-mcp/<name>.session`, permission 600"). It holds real session state — please do not "clean it up" as test residue. It was untouched across every run here (`default.session`, sha256 `b942680e…`, mtime unchanged).

## Known gap, stated plainly

`Settings.data_dir` (`config.py:59`) is a class-level default evaluated at **import** time, so it is frozen to the real home before any fixture runs. This fixture does not cover it. It is not currently a leak — `data_dir` writes only happen in the deselected `integration`/`live` markers — but the fixture should not be read as blanket protection.

## Not covered by CI's blast radius

CI runs a single `pytest` (`.github/workflows/ci.yml:101`) with no `-n`/`--dist`; `pytest-xdist` is installed but never invoked. So the "parallel workers sharing one real home" scenario does not exist today. The fixture makes it safe if that changes.


