### PR TITLE
⚡ Bolt: O(1) existence checks in KV store

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,6 @@
 ## 2025-08-30 - Internalizing Thread Offloading for Blocking I/O
 **Learning:** In asynchronous backends, internal helper methods that perform blocking filesystem I/O (like `os.open`, `os.chmod`, or file-backed key-value lookups) can block the main asyncio event loop if not properly offloaded. While the offloading could be done at the call site, doing so clutters the call site and relies on callers to remember the implementation detail.
 **Action:** Always refactor internal helper methods that perform blocking I/O to be `async def`. Wrap their synchronous logic in a nested function and internally offload it using `await asyncio.to_thread()`. This improves API clarity and ensures non-blocking behavior wherever the method is invoked.
+## 2025-08-31 - Fast existence checks in encrypted KV stores
+**Learning:** Checking for the existence of records in encrypted Key-Value stores using bulk data retrieval methods like `load_all()` incurs massive overhead from N+1 decryption operations (e.g., PBKDF2).
+**Action:** When checking for the existence of records in encrypted Key-Value stores (e.g., `KvSessionStore`), never use `load_all()`. Instead, implement index-only checks (like `has_any()`) to achieve O(1) existence verification.

--- a/src/better_telegram_mcp/auth/in_memory_session_store.py
+++ b/src/better_telegram_mcp/auth/in_memory_session_store.py
@@ -69,6 +69,10 @@ class InMemorySessionStore:
             for bearer, data in self._store.items()
         }
 
+    def has_any(self) -> bool:
+        """Check if any sessions exist."""
+        return len(self._store) > 0
+
     def delete(self, bearer: str) -> bool:
         """Delete a session. Returns True if it existed."""
         if bearer not in self._store:

--- a/src/better_telegram_mcp/auth/kv_session_store.py
+++ b/src/better_telegram_mcp/auth/kv_session_store.py
@@ -107,6 +107,10 @@ class KvSessionStore:
 
         return result
 
+    def has_any(self) -> bool:
+        """Check if any sessions exist using the index (O(1))."""
+        return len(self._load_index()) > 0
+
     def delete(self, bearer: str) -> bool:
         """Delete session for bearer. Returns True if it existed."""
         existing = self.load(bearer)

--- a/src/better_telegram_mcp/relay_setup.py
+++ b/src/better_telegram_mcp/relay_setup.py
@@ -103,7 +103,7 @@ def check_saved_sessions(backend=None) -> bool:
     if cf_mode:
         from .auth.kv_session_store import KvSessionStore
 
-        return len(KvSessionStore(backend=backend).load_all()) > 0
+        return KvSessionStore(backend=backend).has_any()
 
     data_dir = Path.home() / ".better-telegram-mcp"
     if not data_dir.exists():


### PR DESCRIPTION
💡 **What**: Replaced `len(store.load_all()) > 0` with a new `store.has_any()` method in `check_saved_sessions()`. For the `KvSessionStore`, it only checks the index (`len(self._load_index()) > 0`) instead of doing an N+1 fetch-and-decrypt loop on all sessions.
🎯 **Why**: `load_all` on encrypted credential backends forces heavy PBKDF2 cryptography operations for every existing session. For a simple boolean existence check, this is extremely wasteful and slow when many sessions exist.
📊 **Impact**: Reduces existence check time from O(N) to O(1) by entirely bypassing PBKDF2 decryption and N+1 network lookups.
🔬 **Measurement**: Run the unit test suite and verify no failures exist. In a real-world multi-user deploy, timing `check_saved_sessions()` before and after when N=100 sessions will show a massive latency improvement.

---
*PR created automatically by Jules for task [4798599694707770351](https://jules.google.com/task/4798599694707770351) started by @n24q02m*