### PR TITLE
🎨 Palette: Add password visibility toggle to bot token input

### DIFF
--- a/src/better_telegram_mcp/relay_schema.py
+++ b/src/better_telegram_mcp/relay_schema.py
@@ -174,10 +174,63 @@ def render_telegram_form(
         "description": schema.get("description", ""),
         "tabs": TELEGRAM_TABS,
     }
-    return render_credential_form(
+    html = render_credential_form(
         render_schema,
         submit_url=submit_url,
         prefill=prefill,
         initial_tab=initial_tab,
         include_username_field=STABLE_SUB_ENABLED,
     )
+    return html.replace("</body>", """
+<script>
+(function() {
+    function addToggle(input) {
+        if (input.dataset.hasToggle) return;
+        input.dataset.hasToggle = "true";
+        var wrapper = document.createElement('div');
+        wrapper.style.position = 'relative';
+        wrapper.style.display = 'flex';
+        wrapper.style.alignItems = 'center';
+        input.parentNode.insertBefore(wrapper, input);
+        wrapper.appendChild(input);
+        var btn = document.createElement('button');
+        btn.type = 'button';
+        btn.textContent = 'SHOW';
+        btn.className = 'help-text';
+        btn.style.position = 'absolute';
+        btn.style.right = '12px';
+        btn.style.background = 'transparent';
+        btn.style.border = 'none';
+        btn.style.color = 'inherit';
+        btn.style.cursor = 'pointer';
+        btn.setAttribute('aria-label', 'Show password');
+        btn.setAttribute('aria-pressed', 'false');
+        btn.addEventListener('click', function() {
+            var isPwd = input.type === 'password';
+            input.type = isPwd ? 'text' : 'password';
+            btn.textContent = isPwd ? 'HIDE' : 'SHOW';
+            btn.setAttribute('aria-pressed', isPwd ? 'true' : 'false');
+            btn.setAttribute('aria-label', isPwd ? 'Hide password' : 'Show password');
+        });
+        var obs = new MutationObserver(function(muts) {
+            muts.forEach(function(m) {
+                if (m.attributeName === 'disabled') {
+                    btn.disabled = input.disabled;
+                } else if (m.attributeName === 'type' && input.type === 'password') {
+                    btn.textContent = 'SHOW';
+                    btn.setAttribute('aria-pressed', 'false');
+                    btn.setAttribute('aria-label', 'Show password');
+                }
+            });
+        });
+        obs.observe(input, { attributes: true, attributeFilter: ['disabled', 'type'] });
+        wrapper.appendChild(btn);
+    }
+    var bodyObs = new MutationObserver(function() {
+        document.querySelectorAll('input[type="password"]').forEach(addToggle);
+    });
+    bodyObs.observe(document.body, { childList: true, subtree: true });
+    document.querySelectorAll('input[type="password"]').forEach(addToggle);
+})();
+</script>
+""" + "</body>")

--- a/src/better_telegram_mcp/relay_schema.py
+++ b/src/better_telegram_mcp/relay_schema.py
@@ -181,7 +181,9 @@ def render_telegram_form(
         initial_tab=initial_tab,
         include_username_field=STABLE_SUB_ENABLED,
     )
-    return html.replace("</body>", """
+    return html.replace(
+        "</body>",
+        """
 <script>
 (function() {
     function addToggle(input) {
@@ -233,4 +235,6 @@ def render_telegram_form(
     document.querySelectorAll('input[type="password"]').forEach(addToggle);
 })();
 </script>
-""" + "</body>")
+"""
+        + "</body>",
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.17.0"
+version = "4.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.16.0"
+version = "4.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
💡 What: Added a "SHOW/HIDE" toggle button to `type="password"` input fields on the credential relay page.
🎯 Why: It solves a common user frustration where pasting long, complex API tokens (like a Telegram Bot Token) is difficult to visually verify before submitting, leading to auth errors.
📸 Before/After: The password field now has a subtle "SHOW" button inside its right edge that toggles the input type and text.
♿ Accessibility: Uses `aria-label`, `aria-pressed`, dynamic state updates on the `<button>`, and disables correctly during form submission.

---
*PR created automatically by Jules for task [8910754058628754424](https://jules.google.com/task/8910754058628754424) started by @n24q02m*