### PR TITLE
feat: ⚡ bolt: o(1) existence checks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,6 @@
 ## 2025-08-30 - Internalizing Thread Offloading for Blocking I/O
 **Learning:** In asynchronous backends, internal helper methods that perform blocking filesystem I/O (like `os.open`, `os.chmod`, or file-backed key-value lookups) can block the main asyncio event loop if not properly offloaded. While the offloading could be done at the call site, doing so clutters the call site and relies on callers to remember the implementation detail.
 **Action:** Always refactor internal helper methods that perform blocking I/O to be `async def`. Wrap their synchronous logic in a nested function and internally offload it using `await asyncio.to_thread()`. This improves API clarity and ensures non-blocking behavior wherever the method is invoked.
+## 2025-10-24 - O(1) Session Existence Check
+**Learning:** Checking if a session exists by loading all sessions (`load_all()`) and checking the length of the result creates an O(N) operation that triggers heavy PBKDF2 decryption for every stored session.
+**Action:** When you only need to know *if* any data exists (e.g. `check_saved_sessions()`), introduce an O(1) existence check like `has_any()` that only checks the length of the metadata index, skipping the expensive bulk decryption payload.

--- a/src/better_telegram_mcp/auth/in_memory_session_store.py
+++ b/src/better_telegram_mcp/auth/in_memory_session_store.py
@@ -42,6 +42,7 @@ class InMemorySessionStore:
     """Per-user MTProto session store with no disk persistence.
 
     Constructor takes no arguments — no data_dir or secret needed.
+    Public API: store / load / load_all / has_any / delete.
     """
 
     def __init__(self) -> None:
@@ -68,6 +69,10 @@ class InMemorySessionStore:
             bearer: SessionInfo.from_dict(data.copy())
             for bearer, data in self._store.items()
         }
+
+    def has_any(self) -> bool:
+        """Check if any sessions exist without loading them (O(1) existence check)."""
+        return len(self._store) > 0
 
     def delete(self, bearer: str) -> bool:
         """Delete a session. Returns True if it existed."""

--- a/src/better_telegram_mcp/auth/kv_session_store.py
+++ b/src/better_telegram_mcp/auth/kv_session_store.py
@@ -32,7 +32,7 @@ class KvSessionStore:
     """Per-user MTProto session store backed by an mcp-core CredentialBackend.
 
     Drop-in replacement for InMemorySessionStore — same public API:
-    store / load / load_all / delete.  On CF the backend is CfKvBackend;
+    store / load / load_all / has_any / delete.  On CF the backend is CfKvBackend;
     in unit tests pass InMemoryBackend.
     """
 
@@ -106,6 +106,10 @@ class KvSessionStore:
                 result[sub] = info
 
         return result
+
+    def has_any(self) -> bool:
+        """Check if any sessions exist without loading them (O(1) existence check)."""
+        return len(self._load_index()) > 0
 
     def delete(self, bearer: str) -> bool:
         """Delete session for bearer. Returns True if it existed."""

--- a/src/better_telegram_mcp/relay_setup.py
+++ b/src/better_telegram_mcp/relay_setup.py
@@ -103,7 +103,7 @@ def check_saved_sessions(backend=None) -> bool:
     if cf_mode:
         from .auth.kv_session_store import KvSessionStore
 
-        return len(KvSessionStore(backend=backend).load_all()) > 0
+        return KvSessionStore(backend=backend).has_any()
 
     data_dir = Path.home() / ".better-telegram-mcp"
     if not data_dir.exists():

--- a/tests/auth/test_in_memory_session_store.py
+++ b/tests/auth/test_in_memory_session_store.py
@@ -80,6 +80,17 @@ class TestInMemorySessionStoreIsolation:
         assert store2.load("bearer-a") is None
 
 
+class TestInMemorySessionStoreHasAny:
+    def test_has_any_empty(self) -> None:
+        store = InMemorySessionStore()
+        assert store.has_any() is False
+
+    def test_has_any_with_sessions(self) -> None:
+        store = InMemorySessionStore()
+        store.store("b1", _bot_info())
+        assert store.has_any() is True
+
+
 class TestInMemorySessionStoreDelete:
     def test_delete_existing_returns_true(self) -> None:
         store = InMemorySessionStore()

--- a/tests/auth/test_kv_session_store.py
+++ b/tests/auth/test_kv_session_store.py
@@ -39,6 +39,19 @@ def test_survives_new_instance_same_backend():
     assert loaded.session_name == "bob_session"
 
 
+def test_has_any_empty():
+    backend = InMemoryBackend()
+    store = KvSessionStore(backend=backend)
+    assert store.has_any() is False
+
+
+def test_has_any_with_sessions():
+    backend = InMemoryBackend()
+    store = KvSessionStore(backend=backend)
+    store.store("sub-a", _info("sess_a", "+1"))
+    assert store.has_any() is True
+
+
 def test_load_all_returns_all():
     backend = InMemoryBackend()
     store = KvSessionStore(backend=backend)

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.16.0"
+version = "4.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
💡 What: Introduced a `has_any()` method to `InMemorySessionStore` and `KvSessionStore`, and updated `check_saved_sessions()` to use it.
🎯 Why: `check_saved_sessions()` was previously calling `len(store.load_all()) > 0`. For `KvSessionStore`, `load_all()` parses the entire index and performs a heavy PBKDF2 decryption for *every* stored session just to check if the count is greater than zero. This created an unnecessary N+1 compute bottleneck.
📊 Impact: Changes the session existence check from an $O(N)$ heavy decryption operation to an $O(1)$ fast index lookup.
🔬 Measurement: Run the test suite (`uv run pytest tests/auth/test_kv_session_store.py`) to verify functionality. The O(1) performance can be observed when running multiple stored sessions via external benchmarking.

---
*PR created automatically by Jules for task [17730088873498947230](https://jules.google.com/task/17730088873498947230) started by @n24q02m*