### PR TITLE
feat: ⚡ bolt: o(1) existence checks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,6 @@
 ## 2025-08-30 - Internalizing Thread Offloading for Blocking I/O
 **Learning:** In asynchronous backends, internal helper methods that perform blocking filesystem I/O (like `os.open`, `os.chmod`, or file-backed key-value lookups) can block the main asyncio event loop if not properly offloaded. While the offloading could be done at the call site, doing so clutters the call site and relies on callers to remember the implementation detail.
 **Action:** Always refactor internal helper methods that perform blocking I/O to be `async def`. Wrap their synchronous logic in a nested function and internally offload it using `await asyncio.to_thread()`. This improves API clarity and ensures non-blocking behavior wherever the method is invoked.
+## 2025-09-10 - O(1) existence checks for cryptographic KV Stores
+**Learning:** Using bulk data retrieval methods like `load_all()` just to check if *any* record exists incurs massive overhead from N+1 decryption operations (e.g. PBKDF2), even when parallelized, because every record in the index must be individually decrypted and deserialized.
+**Action:** When checking for existence in encrypted Key-Value stores, always implement and utilize an index-only check (like `has_any()`) to achieve O(1) performance instead of O(N).

--- a/src/better_telegram_mcp/auth/in_memory_session_store.py
+++ b/src/better_telegram_mcp/auth/in_memory_session_store.py
@@ -69,6 +69,10 @@ class InMemorySessionStore:
             for bearer, data in self._store.items()
         }
 
+    def has_any(self) -> bool:
+        """Check if any sessions exist."""
+        return bool(self._store)
+
     def delete(self, bearer: str) -> bool:
         """Delete a session. Returns True if it existed."""
         if bearer not in self._store:

--- a/src/better_telegram_mcp/auth/kv_session_store.py
+++ b/src/better_telegram_mcp/auth/kv_session_store.py
@@ -107,6 +107,10 @@ class KvSessionStore:
 
         return result
 
+    def has_any(self) -> bool:
+        """Check if any sessions exist without doing N+1 loads."""
+        return bool(self._load_index())
+
     def delete(self, bearer: str) -> bool:
         """Delete session for bearer. Returns True if it existed."""
         existing = self.load(bearer)

--- a/src/better_telegram_mcp/relay_setup.py
+++ b/src/better_telegram_mcp/relay_setup.py
@@ -103,7 +103,7 @@ def check_saved_sessions(backend=None) -> bool:
     if cf_mode:
         from .auth.kv_session_store import KvSessionStore
 
-        return len(KvSessionStore(backend=backend).load_all()) > 0
+        return KvSessionStore(backend=backend).has_any()
 
     data_dir = Path.home() / ".better-telegram-mcp"
     if not data_dir.exists():

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.16.0"
+version = "4.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
💡 **What:** Added `has_any()` method to `KvSessionStore` and `InMemorySessionStore` to perform an index-only lookup to check if any sessions exist, and updated `check_saved_sessions` to use this new method instead of `len(load_all()) > 0`.
🎯 **Why:** Previously, `check_saved_sessions` would call `load_all()`, which loops through every item in the index and performs expensive PBKDF2 cryptography operations to decrypt the session metadata just to verify if *any* sessions exist. This caused an N+1 query bottleneck. The new `has_any()` method achieves O(1) performance by avoiding the item decryption loop entirely.
📊 **Impact:** Massive reduction in CPU overhead and latency during startup/hot-reload for setups with many active users, as we no longer blindly decrypt all sessions when evaluating `_ensure_settings()`.
🔬 **Measurement:** Verify by running the test suite (`uv run pytest`), which passes flawlessly. The `KvSessionStore` tests explicitly test against `backend=None` ensuring the existence logic correctly falls back to index truthiness.

---
*PR created automatically by Jules for task [17749150784688030536](https://jules.google.com/task/17749150784688030536) started by @n24q02m*