### PR TITLE
feat: ⚡ bolt: o(1) existence checks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,6 @@
 ## 2025-08-30 - Internalizing Thread Offloading for Blocking I/O
 **Learning:** In asynchronous backends, internal helper methods that perform blocking filesystem I/O (like `os.open`, `os.chmod`, or file-backed key-value lookups) can block the main asyncio event loop if not properly offloaded. While the offloading could be done at the call site, doing so clutters the call site and relies on callers to remember the implementation detail.
 **Action:** Always refactor internal helper methods that perform blocking I/O to be `async def`. Wrap their synchronous logic in a nested function and internally offload it using `await asyncio.to_thread()`. This improves API clarity and ensures non-blocking behavior wherever the method is invoked.
+## 2025-10-25 - O(1) Existence Checks for Cryptographic KV Stores
+**Learning:** When checking for the existence of records in encrypted Key-Value stores (e.g., `KvSessionStore`), using bulk data retrieval methods like `load_all()` incurs massive overhead from N+1 decryption operations (e.g., PBKDF2).
+**Action:** Utilize or implement index-only checks (like `has_any()`) to achieve O(1) existence verification and avoid N+1 decryption overhead.

--- a/src/better_telegram_mcp/auth/in_memory_session_store.py
+++ b/src/better_telegram_mcp/auth/in_memory_session_store.py
@@ -62,6 +62,10 @@ class InMemorySessionStore:
         # are flat dictionaries of primitive types.
         return SessionInfo.from_dict(data.copy())
 
+    def has_any(self) -> bool:
+        """Check if any sessions exist."""
+        return len(self._store) > 0
+
     def load_all(self) -> dict[str, SessionInfo]:
         """Load all stored sessions."""
         return {

--- a/src/better_telegram_mcp/auth/kv_session_store.py
+++ b/src/better_telegram_mcp/auth/kv_session_store.py
@@ -88,6 +88,10 @@ class KvSessionStore:
             return None
         return SessionInfo.from_dict(data)
 
+    def has_any(self) -> bool:
+        """Check if any sessions exist using the index (O(1) lookups)."""
+        return len(self._load_index()) > 0
+
     def load_all(self) -> dict[str, SessionInfo]:
         """Load all stored sessions from the index.
 

--- a/src/better_telegram_mcp/relay_setup.py
+++ b/src/better_telegram_mcp/relay_setup.py
@@ -103,7 +103,7 @@ def check_saved_sessions(backend=None) -> bool:
     if cf_mode:
         from .auth.kv_session_store import KvSessionStore
 
-        return len(KvSessionStore(backend=backend).load_all()) > 0
+        return KvSessionStore(backend=backend).has_any()
 
     data_dir = Path.home() / ".better-telegram-mcp"
     if not data_dir.exists():

--- a/tests/auth/test_in_memory_session_store.py
+++ b/tests/auth/test_in_memory_session_store.py
@@ -101,6 +101,14 @@ class TestInMemorySessionStoreDelete:
         assert loaded is not None and loaded.bot_token == "t2"
 
 
+class TestInMemorySessionStoreHasAny:
+    def test_has_any_empty_and_populated(self) -> None:
+        store = InMemorySessionStore()
+        assert store.has_any() is False
+        store.store("b1", _bot_info())
+        assert store.has_any() is True
+
+
 class TestInMemorySessionStoreLoadAll:
     def test_load_all_empty(self) -> None:
         store = InMemorySessionStore()

--- a/tests/auth/test_kv_session_store.py
+++ b/tests/auth/test_kv_session_store.py
@@ -39,6 +39,16 @@ def test_survives_new_instance_same_backend():
     assert loaded.session_name == "bob_session"
 
 
+def test_has_any():
+    backend = InMemoryBackend()
+    store = KvSessionStore(backend=backend)
+
+    assert store.has_any() is False
+
+    store.store("sub-a", _info())
+    assert store.has_any() is True
+
+
 def test_load_all_returns_all():
     backend = InMemoryBackend()
     store = KvSessionStore(backend=backend)


### PR DESCRIPTION
**💡 What:** Implemented an O(1) `has_any()` method for both `InMemorySessionStore` and `KvSessionStore`. Refactored `check_saved_sessions` in `relay_setup.py` to use `has_any()` instead of `load_all()`.

**🎯 Why:** In cryptographic Key-Value stores (like `KvSessionStore` over Cloudflare KV), loading all items just to check if *any* items exist causes a severe N+1 decryption bottleneck (e.g., executing PBKDF2 derivations for every stored user). Checking the index directly avoids this expensive overhead.

**📊 Impact:** Reduces the startup/re-verification check from O(N) (linear to the number of stored sessions, with heavy crypto compute) to O(1) (a single, fast index check), resulting in substantially faster server initialization and connection validation, especially in deployments with many active users.

**🔬 Measurement:** Start the server with multiple stored Telegram sessions on a KV backend. Observe that the time taken by `check_saved_sessions` is constant regardless of the number of users, whereas previously it scaled linearly. Verify via `uv run pytest tests/auth/test_kv_session_store.py` and `tests/test_relay_setup.py`.

---
*PR created automatically by Jules for task [16675673636527207231](https://jules.google.com/task/16675673636527207231) started by @n24q02m*