### PR TITLE
feat: ⚡ bolt: o(1) existence checks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,6 @@
 ## 2025-08-30 - Internalizing Thread Offloading for Blocking I/O
 **Learning:** In asynchronous backends, internal helper methods that perform blocking filesystem I/O (like `os.open`, `os.chmod`, or file-backed key-value lookups) can block the main asyncio event loop if not properly offloaded. While the offloading could be done at the call site, doing so clutters the call site and relies on callers to remember the implementation detail.
 **Action:** Always refactor internal helper methods that perform blocking I/O to be `async def`. Wrap their synchronous logic in a nested function and internally offload it using `await asyncio.to_thread()`. This improves API clarity and ensures non-blocking behavior wherever the method is invoked.
+## 2025-09-15 - O(1) Existence Checks for Cryptographic KV Stores
+**Learning:** When checking for the existence of records in encrypted Key-Value stores (like `KvSessionStore`), using bulk data retrieval methods like `load_all()` incurs massive overhead from N+1 decryption operations (e.g., PBKDF2). Even if parallelized, this is extremely wasteful when only existence (a boolean) is needed.
+**Action:** Never use `load_all()` for existence checks. Instead, utilize or implement index-only checks (like `has_any()`) to achieve O(1) existence verification without triggering bulk cryptography overhead.

--- a/src/better_telegram_mcp/auth/in_memory_session_store.py
+++ b/src/better_telegram_mcp/auth/in_memory_session_store.py
@@ -69,6 +69,10 @@ class InMemorySessionStore:
             for bearer, data in self._store.items()
         }
 
+    def has_any(self) -> bool:
+        """Check if any sessions exist without loading their data."""
+        return len(self._store) > 0
+
     def delete(self, bearer: str) -> bool:
         """Delete a session. Returns True if it existed."""
         if bearer not in self._store:

--- a/src/better_telegram_mcp/auth/kv_session_store.py
+++ b/src/better_telegram_mcp/auth/kv_session_store.py
@@ -107,6 +107,10 @@ class KvSessionStore:
 
         return result
 
+    def has_any(self) -> bool:
+        """Check if any sessions exist without loading or decrypting their data."""
+        return len(self._load_index()) > 0
+
     def delete(self, bearer: str) -> bool:
         """Delete session for bearer. Returns True if it existed."""
         existing = self.load(bearer)

--- a/src/better_telegram_mcp/relay_setup.py
+++ b/src/better_telegram_mcp/relay_setup.py
@@ -103,7 +103,7 @@ def check_saved_sessions(backend=None) -> bool:
     if cf_mode:
         from .auth.kv_session_store import KvSessionStore
 
-        return len(KvSessionStore(backend=backend).load_all()) > 0
+        return KvSessionStore(backend=backend).has_any()
 
     data_dir = Path.home() / ".better-telegram-mcp"
     if not data_dir.exists():

--- a/tests/auth/test_in_memory_session_store.py
+++ b/tests/auth/test_in_memory_session_store.py
@@ -128,6 +128,18 @@ class TestInMemorySessionStoreLoadAll:
         assert loaded.bot_token == "original"
 
 
+class TestInMemorySessionStoreHasAny:
+    def test_has_any(self) -> None:
+        store = InMemorySessionStore()
+        assert store.has_any() is False
+
+        store.store("b1", _bot_info())
+        assert store.has_any() is True
+
+        store.delete("b1")
+        assert store.has_any() is False
+
+
 class TestSessionInfo:
     def test_to_dict_roundtrip(self) -> None:
         """SessionInfo should serialize and deserialize correctly."""

--- a/tests/auth/test_kv_session_store.py
+++ b/tests/auth/test_kv_session_store.py
@@ -76,3 +76,16 @@ def test_delete():
     # load_all no longer returns deleted sub
     all_sessions = store.load_all()
     assert "sub-del" not in all_sessions
+
+
+def test_has_any():
+    backend = InMemoryBackend()
+    store = KvSessionStore(backend=backend)
+
+    assert store.has_any() is False
+
+    store.store("sub-a", _info())
+    assert store.has_any() is True
+
+    store.delete("sub-a")
+    assert store.has_any() is False


### PR DESCRIPTION
💡 What: Added `has_any()` method to `InMemorySessionStore` and `KvSessionStore`, and updated `check_saved_sessions` in `relay_setup.py` to use `has_any()` instead of `load_all()`.
🎯 Why: `load_all()` decrypts all stored sessions. In `check_saved_sessions` which only checks if *any* sessions exist, this resulted in an O(N) performance cost proportional to the number of stored sessions (due to PBKDF2 decryption overhead) when only a boolean check is needed.
📊 Impact: Existence checks for cryptographic KV stores are now O(1) by utilizing `len(index) > 0` instead of downloading and decrypting all stored session data.
🔬 Measurement: Verify tests run properly by executing `uv run pytest tests/auth/test_in_memory_session_store.py tests/auth/test_kv_session_store.py tests/test_relay_setup.py`.

---
*PR created automatically by Jules for task [4306814008547493016](https://jules.google.com/task/4306814008547493016) started by @n24q02m*