### PR TITLE
feat: 🎨 palette: add password visibility toggle

### DIFF
--- a/src/better_telegram_mcp/relay_schema.py
+++ b/src/better_telegram_mcp/relay_schema.py
@@ -141,6 +141,92 @@ TELEGRAM_TABS: list[dict[str, Any]] = [
 # Both read this one constant so they cannot drift apart.
 STABLE_SUB_ENABLED = True
 
+_PASSWORD_TOGGLE_JS = """
+<script>
+(function() {
+    function addToggle(input) {
+        if (input.dataset.hasToggle) return;
+        input.dataset.hasToggle = 'true';
+
+        var wrapper = document.createElement('div');
+        wrapper.style.position = 'relative';
+        wrapper.style.display = 'flex';
+        wrapper.style.alignItems = 'center';
+
+        input.parentNode.insertBefore(wrapper, input);
+        wrapper.appendChild(input);
+
+        var btn = document.createElement('button');
+        btn.type = 'button';
+        btn.textContent = 'Show';
+        btn.setAttribute('aria-label', 'Show password');
+        btn.setAttribute('aria-pressed', 'false');
+        btn.className = 'submit-btn';
+        btn.style.position = 'absolute';
+        btn.style.right = '8px';
+        btn.style.width = 'auto';
+        btn.style.minHeight = '0';
+        btn.style.height = '24px';
+        btn.style.padding = '0 8px';
+        btn.style.fontSize = '12px';
+        btn.style.background = 'transparent';
+        btn.style.border = '1px solid #444';
+        btn.style.color = 'inherit';
+        btn.style.cursor = 'pointer';
+
+        btn.addEventListener('click', function(e) {
+            e.preventDefault();
+            var isPassword = input.type === 'password';
+            input.type = isPassword ? 'text' : 'password';
+            btn.textContent = isPassword ? 'Hide' : 'Show';
+            btn.setAttribute('aria-label', isPassword ? 'Hide password' : 'Show password');
+            btn.setAttribute('aria-pressed', isPassword ? 'true' : 'false');
+        });
+
+        wrapper.appendChild(btn);
+
+        var observer = new MutationObserver(function(mutations) {
+            mutations.forEach(function(m) {
+                if (m.attributeName === 'disabled') {
+                    btn.disabled = input.disabled;
+                }
+                if (m.attributeName === 'type' && input.type === 'password') {
+                    btn.textContent = 'Show';
+                    btn.setAttribute('aria-label', 'Show password');
+                    btn.setAttribute('aria-pressed', 'false');
+                }
+            });
+        });
+        observer.observe(input, { attributes: true });
+    }
+
+    function init() {
+        document.querySelectorAll('input[type="password"]').forEach(addToggle);
+
+        var bodyObserver = new MutationObserver(function(mutations) {
+            mutations.forEach(function(m) {
+                m.addedNodes.forEach(function(n) {
+                    if (n.nodeType === Node.ELEMENT_NODE) {
+                        var newInputs = n.querySelectorAll('input[type="password"]');
+                        newInputs.forEach(addToggle);
+                        if (n.tagName === 'INPUT' && n.type === 'password') {
+                            addToggle(n);
+                        }
+                    }
+                });
+            });
+        });
+        bodyObserver.observe(document.body, { childList: true, subtree: true });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();
+</script>
+"""
 
 def render_telegram_form(
     schema: dict[str, Any],
@@ -174,10 +260,11 @@ def render_telegram_form(
         "description": schema.get("description", ""),
         "tabs": TELEGRAM_TABS,
     }
-    return render_credential_form(
+    html = render_credential_form(
         render_schema,
         submit_url=submit_url,
         prefill=prefill,
         initial_tab=initial_tab,
         include_username_field=STABLE_SUB_ENABLED,
     )
+    return html.replace("</body>", _PASSWORD_TOGGLE_JS + "</body>")

--- a/src/better_telegram_mcp/relay_schema.py
+++ b/src/better_telegram_mcp/relay_schema.py
@@ -228,6 +228,7 @@ _PASSWORD_TOGGLE_JS = """
 </script>
 """
 
+
 def render_telegram_form(
     schema: dict[str, Any],
     submit_url: str,

--- a/tests/test_relay_schema.py
+++ b/tests/test_relay_schema.py
@@ -1,4 +1,8 @@
-from better_telegram_mcp.relay_schema import RELAY_SCHEMA, RELAY_SCHEMA_MODES, render_telegram_form
+from better_telegram_mcp.relay_schema import (
+    RELAY_SCHEMA,
+    RELAY_SCHEMA_MODES,
+    render_telegram_form,
+)
 
 
 def test_render_telegram_form_injects_password_toggle():

--- a/tests/test_relay_schema.py
+++ b/tests/test_relay_schema.py
@@ -1,4 +1,11 @@
-from better_telegram_mcp.relay_schema import RELAY_SCHEMA, RELAY_SCHEMA_MODES
+from better_telegram_mcp.relay_schema import RELAY_SCHEMA, RELAY_SCHEMA_MODES, render_telegram_form
+
+
+def test_render_telegram_form_injects_password_toggle():
+    """Verify that render_telegram_form injects _PASSWORD_TOGGLE_JS."""
+    html = render_telegram_form(RELAY_SCHEMA, "/submit")
+    assert "addToggle(input)" in html
+    assert "input.dataset.hasToggle" in html
 
 
 def test_relay_schema_structure():

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.16.0"
+version = "4.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
### 💡 What
Added a "Show/Hide" password visibility toggle to the `TELEGRAM_BOT_TOKEN` field (and any subsequent dynamically generated password fields like 2FA) in the credential setup form.

### 🎯 Why
Bot tokens are long, complex strings (e.g., `123456:ABC-DEF...`). Users often paste partial keys or have trouble verifying if their copy-paste was successful, which leads to frustrating authentication failures. Adding a visibility toggle allows them to visually confirm their input before hitting Connect.

### 📸 Before/After
*(Verified locally using Playwright)*
* **Before**: Users only saw `•••••••••••••••••••••` when pasting their Bot Token.
* **After**: A small, theme-adaptive "Show" button sits inside the right edge of the input. Clicking it reveals the token and changes the button text to "Hide", while updating accessibility attributes.

### ♿ Accessibility
* The toggle button uses `aria-label="Show password"` and `aria-label="Hide password"`.
* The state is communicated to screen readers via `aria-pressed="true/false"`.
* Inherits color via `inherit` to gracefully support both dark and light modes without failing contrast constraints.
* Focus states remain clear.
* The button is appropriately disabled when the form enters its loading state (`MutationObserver` keeps the state synced).

---
*PR created automatically by Jules for task [3744525808635041965](https://jules.google.com/task/3744525808635041965) started by @n24q02m*