### PR TITLE
feat: ⚡ bolt: o(1) existence checks

### DIFF
--- a/src/better_telegram_mcp/auth/in_memory_session_store.py
+++ b/src/better_telegram_mcp/auth/in_memory_session_store.py
@@ -69,6 +69,10 @@ class InMemorySessionStore:
             for bearer, data in self._store.items()
         }
 
+    def has_any(self) -> bool:
+        """Check if any sessions exist without loading their metadata."""
+        return bool(self._store)
+
     def delete(self, bearer: str) -> bool:
         """Delete a session. Returns True if it existed."""
         if bearer not in self._store:

--- a/src/better_telegram_mcp/auth/kv_session_store.py
+++ b/src/better_telegram_mcp/auth/kv_session_store.py
@@ -107,6 +107,13 @@ class KvSessionStore:
 
         return result
 
+    def has_any(self) -> bool:
+        """Check if any sessions exist without loading their metadata.
+
+        Resolves an N+1 PBKDF2 decryption bottleneck by only loading the index.
+        """
+        return bool(self._load_index())
+
     def delete(self, bearer: str) -> bool:
         """Delete session for bearer. Returns True if it existed."""
         existing = self.load(bearer)

--- a/src/better_telegram_mcp/relay_setup.py
+++ b/src/better_telegram_mcp/relay_setup.py
@@ -103,7 +103,7 @@ def check_saved_sessions(backend=None) -> bool:
     if cf_mode:
         from .auth.kv_session_store import KvSessionStore
 
-        return len(KvSessionStore(backend=backend).load_all()) > 0
+        return KvSessionStore(backend=backend).has_any()
 
     data_dir = Path.home() / ".better-telegram-mcp"
     if not data_dir.exists():

--- a/tests/auth/test_in_memory_session_store.py
+++ b/tests/auth/test_in_memory_session_store.py
@@ -128,6 +128,15 @@ class TestInMemorySessionStoreLoadAll:
         assert loaded.bot_token == "original"
 
 
+class TestInMemorySessionStoreHasAny:
+    def test_has_any(self) -> None:
+        store = InMemorySessionStore()
+        assert store.has_any() is False
+
+        store.store("b1", _bot_info("t1"))
+        assert store.has_any() is True
+
+
 class TestSessionInfo:
     def test_to_dict_roundtrip(self) -> None:
         """SessionInfo should serialize and deserialize correctly."""

--- a/tests/auth/test_kv_session_store.py
+++ b/tests/auth/test_kv_session_store.py
@@ -39,6 +39,15 @@ def test_survives_new_instance_same_backend():
     assert loaded.session_name == "bob_session"
 
 
+def test_has_any():
+    backend = InMemoryBackend()
+    store = KvSessionStore(backend=backend)
+    assert store.has_any() is False
+
+    store.store("sub-a", _info("sess_a", "+1"))
+    assert store.has_any() is True
+
+
 def test_load_all_returns_all():
     backend = InMemoryBackend()
     store = KvSessionStore(backend=backend)


### PR DESCRIPTION
💡 What: Implemented `has_any()` methods on `InMemorySessionStore` and `KvSessionStore` to perform O(1) existence checks, and updated `relay_setup.check_saved_sessions()` to use it.
🎯 Why: Calling `load_all()` in `check_saved_sessions()` just to check if any credentials existed incurred an N+1 PBKDF2 decryption overhead across all saved sessions.
📊 Impact: Checking credential status during startup or hot reload is now O(1) regarding decryption, avoiding the heavy `cryptography` CPU bound work that was happening on every load.
🔬 Measurement: Verify via automated tests, which run `uv run pytest tests/auth/test_kv_session_store.py` and `tests/auth/test_in_memory_session_store.py`.

---
*PR created automatically by Jules for task [14006947629535589283](https://jules.google.com/task/14006947629535589283) started by @n24q02m*