### PR TITLE
feat: 🎨 palette: add show/hide toggle to password fields

### DIFF
--- a/src/better_telegram_mcp/relay_schema.py
+++ b/src/better_telegram_mcp/relay_schema.py
@@ -142,6 +142,68 @@ TELEGRAM_TABS: list[dict[str, Any]] = [
 STABLE_SUB_ENABLED = True
 
 
+_PASSWORD_TOGGLE_JS = """<script>
+(function() {
+    function addToggle(input) {
+        if (!input || input.type !== 'password' || input.dataset.hasToggle) return;
+        input.dataset.hasToggle = 'true';
+        var btn = document.createElement('button');
+        btn.type = 'button';
+        btn.textContent = 'Show';
+        btn.setAttribute('aria-label', 'Show password');
+        btn.setAttribute('aria-pressed', 'false');
+        btn.className = 'submit-btn';
+        btn.style.cssText = 'position: absolute; right: 8px; top: 50%; transform: translateY(-50%); padding: 4px 8px; font-size: 0.8em; min-width: auto; width: auto; margin: 0; background: transparent; color: inherit; border: 1px solid var(--border-color);';
+
+        var wrapper = document.createElement('div');
+        wrapper.style.position = 'relative';
+        input.parentNode.insertBefore(wrapper, input);
+        wrapper.appendChild(input);
+        wrapper.appendChild(btn);
+
+        btn.addEventListener('click', function() {
+            var isPassword = input.type === 'password';
+            input.type = isPassword ? 'text' : 'password';
+            btn.textContent = isPassword ? 'Hide' : 'Show';
+            btn.setAttribute('aria-label', isPassword ? 'Hide password' : 'Show password');
+            btn.setAttribute('aria-pressed', isPassword ? 'true' : 'false');
+        });
+
+        var observer = new MutationObserver(function(mutations) {
+            mutations.forEach(function(m) {
+                if (m.type === 'attributes') {
+                    if (m.attributeName === 'disabled') {
+                        btn.disabled = input.disabled;
+                    } else if (m.attributeName === 'type' && input.type === 'password') {
+                        btn.textContent = 'Show';
+                        btn.setAttribute('aria-label', 'Show password');
+                        btn.setAttribute('aria-pressed', 'false');
+                    }
+                }
+            });
+        });
+        observer.observe(input, { attributes: true, attributeFilter: ['disabled', 'type'] });
+    }
+
+    document.querySelectorAll('input[type="password"]').forEach(addToggle);
+
+    var stepContainer = document.getElementById('step-container');
+    if (stepContainer) {
+        new MutationObserver(function(mutations) {
+            mutations.forEach(function(m) {
+                m.addedNodes.forEach(function(node) {
+                    if (node.nodeType === 1) {
+                        if (node.tagName === 'INPUT' && node.type === 'password') addToggle(node);
+                        else node.querySelectorAll('input[type="password"]').forEach(addToggle);
+                    }
+                });
+            });
+        }).observe(stepContainer, { childList: true, subtree: true });
+    }
+})();
+</script>"""
+
+
 def render_telegram_form(
     schema: dict[str, Any],
     submit_url: str,
@@ -174,10 +236,11 @@ def render_telegram_form(
         "description": schema.get("description", ""),
         "tabs": TELEGRAM_TABS,
     }
-    return render_credential_form(
+    html = render_credential_form(
         render_schema,
         submit_url=submit_url,
         prefill=prefill,
         initial_tab=initial_tab,
         include_username_field=STABLE_SUB_ENABLED,
     )
+    return html.replace('</body>', _PASSWORD_TOGGLE_JS + '</body>')

--- a/src/better_telegram_mcp/relay_schema.py
+++ b/src/better_telegram_mcp/relay_schema.py
@@ -243,4 +243,4 @@ def render_telegram_form(
         initial_tab=initial_tab,
         include_username_field=STABLE_SUB_ENABLED,
     )
-    return html.replace('</body>', _PASSWORD_TOGGLE_JS + '</body>')
+    return html.replace("</body>", _PASSWORD_TOGGLE_JS + "</body>")

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.16.0"
+version = "4.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
Injected a `_PASSWORD_TOGGLE_JS` block into `relay_schema.py` that appends a Show/Hide button to password fields.

💡 **What:** Added a vanilla JS snippet injected into `render_telegram_form` to automatically render "Show/Hide" toggles next to `type="password"` inputs like the bot token and dynamic 2FA prompts.
🎯 **Why:** Long API keys and 2FA passwords are often pasted or prone to typos. Users need a way to visually verify them before hitting submit, especially on mobile or smaller screens, reducing auth failures.
📸 **Before/After:** Demonstrated in verification video/screenshot.
♿ **Accessibility:** Uses semantic `<button type="button">`, adds `aria-label` that flips ("Show password" / "Hide password"), implements `aria-pressed` state tracking, relies on existing inherited contrast colors, and keeps the button explicitly disabled when the parent input transitions to a loading/disabled state via a `MutationObserver`.

---
*PR created automatically by Jules for task [1146335719601607403](https://jules.google.com/task/1146335719601607403) started by @n24q02m*