### PR TITLE
feat: ⚡ bolt: o(1) existence checks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,6 @@
 ## 2025-08-30 - Internalizing Thread Offloading for Blocking I/O
 **Learning:** In asynchronous backends, internal helper methods that perform blocking filesystem I/O (like `os.open`, `os.chmod`, or file-backed key-value lookups) can block the main asyncio event loop if not properly offloaded. While the offloading could be done at the call site, doing so clutters the call site and relies on callers to remember the implementation detail.
 **Action:** Always refactor internal helper methods that perform blocking I/O to be `async def`. Wrap their synchronous logic in a nested function and internally offload it using `await asyncio.to_thread()`. This improves API clarity and ensures non-blocking behavior wherever the method is invoked.
+## 2025-09-15 - Cryptographic KV Store Existence Checks
+**Learning:** When checking for the existence of records in encrypted Key-Value stores (e.g., `KvSessionStore`), using bulk retrieval methods like `load_all()` incurs massive overhead due to N+1 decryption operations (e.g., PBKDF2).
+**Action:** Utilize or implement index-only checks (like `has_any()`) to achieve O(1) existence verification instead of loading entire datasets.

--- a/src/better_telegram_mcp/auth/in_memory_session_store.py
+++ b/src/better_telegram_mcp/auth/in_memory_session_store.py
@@ -51,6 +51,10 @@ class InMemorySessionStore:
         """Store a session for the given bearer token. Overwrites existing."""
         self._store[bearer] = info.to_dict()
 
+    def has_any(self) -> bool:
+        """Check if any sessions exist without loading their data."""
+        return len(self._store) > 0
+
     def load(self, bearer: str) -> SessionInfo | None:
         """Load session info for a bearer token. Returns None if not found."""
         data = self._store.get(bearer)

--- a/src/better_telegram_mcp/auth/kv_session_store.py
+++ b/src/better_telegram_mcp/auth/kv_session_store.py
@@ -81,6 +81,10 @@ class KvSessionStore:
             subs.append(bearer)
             self._save_index(subs)
 
+    def has_any(self) -> bool:
+        """Check if any sessions exist without loading their data."""
+        return len(self._load_index()) > 0
+
     def load(self, bearer: str) -> SessionInfo | None:
         """Load session info for bearer. Returns None if not found."""
         data = self._sub_store(bearer).load()

--- a/src/better_telegram_mcp/relay_setup.py
+++ b/src/better_telegram_mcp/relay_setup.py
@@ -103,7 +103,7 @@ def check_saved_sessions(backend=None) -> bool:
     if cf_mode:
         from .auth.kv_session_store import KvSessionStore
 
-        return len(KvSessionStore(backend=backend).load_all()) > 0
+        return KvSessionStore(backend=backend).has_any()
 
     data_dir = Path.home() / ".better-telegram-mcp"
     if not data_dir.exists():


### PR DESCRIPTION
💡 **What**: Replaced the expensive `load_all()` call inside `check_saved_sessions()` (in `relay_setup.py`) with a dedicated `has_any()` method that evaluates existence in `KvSessionStore` (via the raw index list length) and `InMemorySessionStore` (via the dictionary length) directly.

🎯 **Why**: When checking if any saved sessions existed, the system was previously using `KvSessionStore.load_all()`. This operation would pull down every stored record from the Cloudflare KV store and individually decrypt them using a heavy PBKDF2 key derivation operation. This caused massive unnecessary overhead (N+1 crypto problem) merely to answer a true/false existence question. 

📊 **Impact**: Reduces execution time for `check_saved_sessions` significantly (O(N) to O(1) performance), preventing heavy cryptography computations on the CPU and eliminating unnecessary KV database reads for individual payloads.

🔬 **Measurement**: Verified by ensuring the comprehensive test suite (`uv run pytest`) passes seamlessly, confirming that the new `has_any()` method performs properly when the store has entries or is empty.

---
*PR created automatically by Jules for task [16240888737100504649](https://jules.google.com/task/16240888737100504649) started by @n24q02m*