### PR TITLE
feat: ⚡ bolt: implement o(1) existence checks in kv session store

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,6 @@
 ## 2025-08-30 - Internalizing Thread Offloading for Blocking I/O
 **Learning:** In asynchronous backends, internal helper methods that perform blocking filesystem I/O (like `os.open`, `os.chmod`, or file-backed key-value lookups) can block the main asyncio event loop if not properly offloaded. While the offloading could be done at the call site, doing so clutters the call site and relies on callers to remember the implementation detail.
 **Action:** Always refactor internal helper methods that perform blocking I/O to be `async def`. Wrap their synchronous logic in a nested function and internally offload it using `await asyncio.to_thread()`. This improves API clarity and ensures non-blocking behavior wherever the method is invoked.
+## 2025-08-31 - O(1) existence checks for Cryptographic KV Stores
+**Learning:** When checking for the existence of records in encrypted Key-Value stores (e.g., `KvSessionStore`), using bulk data retrieval methods like `load_all()` incurs massive overhead from N+1 decryption operations (e.g., PBKDF2).
+**Action:** Always implement and utilize index-only checks (like `has_any()`) to achieve O(1) existence verification without paying the penalty of decrypting individual record values.

--- a/src/better_telegram_mcp/auth/in_memory_session_store.py
+++ b/src/better_telegram_mcp/auth/in_memory_session_store.py
@@ -62,6 +62,10 @@ class InMemorySessionStore:
         # are flat dictionaries of primitive types.
         return SessionInfo.from_dict(data.copy())
 
+    def has_any(self) -> bool:
+        """Check if any sessions exist."""
+        return len(self._store) > 0
+
     def load_all(self) -> dict[str, SessionInfo]:
         """Load all stored sessions."""
         return {

--- a/src/better_telegram_mcp/auth/kv_session_store.py
+++ b/src/better_telegram_mcp/auth/kv_session_store.py
@@ -88,6 +88,10 @@ class KvSessionStore:
             return None
         return SessionInfo.from_dict(data)
 
+    def has_any(self) -> bool:
+        """Check if any sessions exist."""
+        return len(self._load_index()) > 0
+
     def load_all(self) -> dict[str, SessionInfo]:
         """Load all stored sessions from the index.
 

--- a/src/better_telegram_mcp/relay_setup.py
+++ b/src/better_telegram_mcp/relay_setup.py
@@ -103,7 +103,7 @@ def check_saved_sessions(backend=None) -> bool:
     if cf_mode:
         from .auth.kv_session_store import KvSessionStore
 
-        return len(KvSessionStore(backend=backend).load_all()) > 0
+        return KvSessionStore(backend=backend).has_any()
 
     data_dir = Path.home() / ".better-telegram-mcp"
     if not data_dir.exists():


### PR DESCRIPTION
💡 What: Implements a `has_any()` method in both `InMemorySessionStore` and `KvSessionStore` to perform index-only existence checks. Updates `check_saved_sessions()` in `relay_setup.py` to use `has_any()` instead of `load_all()`.
🎯 Why: `KvSessionStore.load_all()` decrypts every stored session using a computationally expensive PBKDF2 key derivation. When only checking if *any* session exists, loading and decrypting the entire store creates a severe O(N) performance bottleneck.
📊 Impact: Reduces the time complexity of existence checks from O(N) to O(1), entirely skipping the decryption overhead.
🔬 Measurement: Verified by running `uv run pytest` (specifically `tests/test_relay_setup_cf.py`) and observing correct behavior without triggering N underlying decryption operations. Added a journal entry to document the learning.

---
*PR created automatically by Jules for task [7359610610108841688](https://jules.google.com/task/7359610610108841688) started by @n24q02m*