### PR TITLE
fix: 🛡️ sentinel: [critical] fix DoS via memory exhaustion in send_media

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -15,3 +15,7 @@
 **Vulnerability:** `BotBackend.download_media` used `httpx.AsyncClient.get` which loads the entire response into memory at once. If a bot is tricked into downloading a massive file, this could lead to Out-Of-Memory (OOM) Denial of Service (DoS).
 **Learning:** Even internal API wrappers (like Telegram Bot API wrappers) must treat large file downloads securely, especially if the input `file_id` is passed by users (e.g. from an MCP query).
 **Prevention:** Always stream media downloads using `httpx.stream`, check `Content-Length`, enforce a `max_size` limit, and iterate over the response chunks using `aiter_bytes()`. Avoid using `asyncio.to_thread` for every small chunk, relying instead on OS-level buffering to minimize overhead.
+## 2025-10-24 - Fix DoS via memory exhaustion in bot_backend send_media
+**Vulnerability:** `BotBackend.send_media` loaded entire local files into memory at once using `path.read_bytes()`. An attacker could exploit this by instructing the MCP bot to send an excessively large file, leading to an Out-Of-Memory (OOM) Denial of Service (DoS) attack that crashes the server.
+**Learning:** File read operations must enforce a strict size limit before loading contents into memory, even for local files validated for path traversal, as local files can be gigabytes in size.
+**Prevention:** Always check `path.stat().st_size` against a `max_size` limit (e.g., 50MB for Telegram Bot API) before reading the entire file into memory using `read_bytes()`.

--- a/src/better_telegram_mcp/backends/bot_backend.py
+++ b/src/better_telegram_mcp/backends/bot_backend.py
@@ -285,6 +285,12 @@ class BotBackend(TelegramBackend):
         path = validate_file_path(file_path_or_url)
         if not path.exists():
             raise FileNotFoundError(f"File not found: {file_path_or_url}")
+
+        max_size = 50 * 1024 * 1024  # 50MB
+        if path.stat().st_size > max_size:
+            msg = f"File size exceeds maximum allowed ({max_size} bytes)"
+            raise SecurityError(msg)
+
         field = media_type if media_type != "document" else "document"
         # ⚡ Bolt: Read file asynchronously to prevent blocking the event loop
         file_content = await asyncio.to_thread(path.read_bytes)

--- a/tests/test_backends/test_bot_backend.py
+++ b/tests/test_backends/test_bot_backend.py
@@ -685,6 +685,7 @@ async def test_call_form_http_error_direct():
     # Verify 'from None' (suppressed context)
     assert exc_info.value.__cause__ is None
 
+
 @pytest.mark.asyncio
 async def test_send_media_file_too_large(tmp_path):
     bot = BotBackend("test:token")

--- a/tests/test_backends/test_bot_backend.py
+++ b/tests/test_backends/test_bot_backend.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
@@ -12,6 +12,7 @@ from better_telegram_mcp.backends.bot_backend import (
     BotBackend,
     TelegramAPIError,
 )
+from better_telegram_mcp.backends.security import SecurityError
 
 
 def _make_transport(result: dict | list | bool, ok: bool = True):
@@ -683,3 +684,14 @@ async def test_call_form_http_error_direct():
     assert "<redacted>" in str(exc_info.value)
     # Verify 'from None' (suppressed context)
     assert exc_info.value.__cause__ is None
+
+@pytest.mark.asyncio
+async def test_send_media_file_too_large(tmp_path):
+    bot = BotBackend("test:token")
+    bot._client = httpx.AsyncClient(transport=_make_transport({"message_id": 42}))
+    f = tmp_path / "huge.txt"
+    f.write_text("X")
+    with patch("pathlib.Path.stat") as mock_stat:
+        mock_stat.return_value.st_size = 50 * 1024 * 1024 + 1
+        with pytest.raises(SecurityError, match="File size exceeds maximum allowed"):
+            await bot.send_media(123, "document", str(f))

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.17.0"
+version = "4.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.16.0"
+version = "4.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** `BotBackend.send_media` loaded entire local files into memory at once using `path.read_bytes()`. An attacker could exploit this by instructing the MCP bot to send an excessively large file, leading to an Out-Of-Memory (OOM) Denial of Service (DoS) attack that crashes the server.
🎯 **Impact:** Potential server crash and denial of service if an excessively large file is targeted for upload via the bot API.
🔧 **Fix:** Introduced a strict 50MB file size check using `path.stat().st_size` (matching the Telegram Bot API limit) before attempting to read the file contents into memory, raising a `SecurityError` if exceeded.
✅ **Verification:** Added `test_send_media_file_too_large` in `tests/test_backends/test_bot_backend.py` to assert that files larger than 50MB are rejected securely. Ran the full `pytest` suite successfully.

---
*PR created automatically by Jules for task [10669538064561792862](https://jules.google.com/task/10669538064561792862) started by @n24q02m*