### PR TITLE
feat: expose forum topic_id in serialized messages

### DIFF
--- a/src/better_telegram_mcp/backends/user_backend.py
+++ b/src/better_telegram_mcp/backends/user_backend.py
@@ -122,11 +122,24 @@ class UserBackend(TelegramBackend):
         sender_id = None
         if msg.sender_id is not None:
             sender_id = msg.sender_id
+        # Extract forum topic ID if present (Telegram forum/topic feature)
+        # Forum messages have reply_to.forum_topic=True and reply_to.reply_to_top_id
+        # Ordinary replies have reply_to.forum_topic=False (or no reply_to)
+        topic_id = None
+        if hasattr(msg, "reply_to") and msg.reply_to is not None:
+            # Check if this is a forum topic message
+            if getattr(msg.reply_to, "forum_topic", False):
+                # reply_to_top_id is the topic root; reply_to_msg_id is the replied-to message
+                topic_id = getattr(msg.reply_to, "reply_to_top_id", None)
+                # Fallback: if reply_to_top_id is None, use reply_to_msg_id (topic root)
+                if topic_id is None:
+                    topic_id = getattr(msg.reply_to, "reply_to_msg_id", None)
         return {
             "message_id": msg.id,
             "text": msg.text or "",
             "date": str(msg.date) if msg.date else None,
             "sender_id": sender_id,
+            "topic_id": topic_id,
         }
 
     @staticmethod

--- a/tests/test_backends/test_user_backend.py
+++ b/tests/test_backends/test_user_backend.py
@@ -1461,6 +1461,95 @@ class TestSerializeMessage:
         assert result["date"] is None
         assert result["sender_id"] is None
 
+    def test_serialize_message_topic_id_forum_message(self):
+        """Forum topic message should have topic_id from reply_to_top_id."""
+        from types import SimpleNamespace
+
+        from better_telegram_mcp.backends.user_backend import UserBackend
+
+        # Forum message with reply_to_top_id
+        reply_to = SimpleNamespace(
+            forum_topic=True,
+            reply_to_top_id=12345,
+            reply_to_msg_id=67890,  # replied-to message, not topic
+        )
+        msg = SimpleNamespace(
+            id=1,
+            text="test",
+            date=None,
+            sender_id=42,
+            reply_to=reply_to,
+        )
+
+        result = UserBackend._serialize_message(msg)
+
+        assert result["topic_id"] == 12345  # topic root, not replied-to message
+
+    def test_serialize_message_topic_id_forum_fallback(self):
+        """Forum message without reply_to_top_id falls back to reply_to_msg_id."""
+        from types import SimpleNamespace
+
+        from better_telegram_mcp.backends.user_backend import UserBackend
+
+        # Forum message where reply_to_top_id is None (topic root message)
+        reply_to = SimpleNamespace(
+            forum_topic=True,
+            reply_to_top_id=None,
+            reply_to_msg_id=12345,  # topic root when reply_to_top_id is None
+        )
+        msg = SimpleNamespace(
+            id=1,
+            text="test",
+            date=None,
+            sender_id=42,
+            reply_to=reply_to,
+        )
+
+        result = UserBackend._serialize_message(msg)
+
+        assert result["topic_id"] == 12345
+
+    def test_serialize_message_no_topic_for_ordinary_reply(self):
+        """Ordinary reply (forum_topic=False) should have topic_id=None."""
+        from types import SimpleNamespace
+
+        from better_telegram_mcp.backends.user_backend import UserBackend
+
+        # Ordinary reply, not in a forum topic
+        reply_to = SimpleNamespace(
+            forum_topic=False,
+            reply_to_msg_id=999,  # replied-to message, NOT a topic
+        )
+        msg = SimpleNamespace(
+            id=1,
+            text="test",
+            date=None,
+            sender_id=42,
+            reply_to=reply_to,
+        )
+
+        result = UserBackend._serialize_message(msg)
+
+        assert result["topic_id"] is None  # not a forum topic
+
+    def test_serialize_message_no_topic_no_reply(self):
+        """Message without reply_to should have topic_id=None."""
+        from types import SimpleNamespace
+
+        from better_telegram_mcp.backends.user_backend import UserBackend
+
+        msg = SimpleNamespace(
+            id=1,
+            text="test",
+            date=None,
+            sender_id=42,
+            reply_to=None,
+        )
+
+        result = UserBackend._serialize_message(msg)
+
+        assert result["topic_id"] is None
+
     def test_serialize_dialog_no_title(self):
         from better_telegram_mcp.backends.user_backend import UserBackend
 


### PR DESCRIPTION
## TL;DR

Add `topic_id` field to serialized messages so consumers can distinguish forum topic messages from ordinary replies. Gates on `reply_to.forum_topic` and uses `reply_to_top_id` (topic root) with fallback to `reply_to_msg_id`.

Fixes the gap identified in miner issue evnchn/hkbus-telegram-miner#20: the group enabled Telegram Topics but the MCP couldn't see which topic a message came from.

## What changed

**File:** `src/better_telegram_mcp/backends/user_backend.py` (+13 lines)

```python
# Extract forum topic ID if present (Telegram forum/topic feature)
# Forum messages have reply_to.forum_topic=True and reply_to.reply_to_top_id
# Ordinary replies have reply_to.forum_topic=False (or no reply_to)
topic_id = None
if hasattr(msg, "reply_to") and msg.reply_to is not None:
    # Check if this is a forum topic message
    if getattr(msg.reply_to, "forum_topic", False):
        # reply_to_top_id is the topic root; reply_to_msg_id is the replied-to message
        topic_id = getattr(msg.reply_to, "reply_to_top_id", None)
        # Fallback: if reply_to_top_id is None, use reply_to_msg_id (topic root)
        if topic_id is None:
            topic_id = getattr(msg.reply_to, "reply_to_msg_id", None)
```

**Result:** Messages now include `topic_id` field:
- `null` for non-forum chats or ordinary replies
- Topic ID for forum topic messages

## Why this matters

Telegram forum topics are the "single highest-value triage signal" for groups that use them. A report filed under `#bug_report` and a joke filed under `#General` are indistinguishable without topic info, forcing consumers to re-derive the discrimination from message text.

This change exposes the topic membership that Telethon already provides, with zero breaking changes (new field, backward-compatible).

## Design decisions

**Why gate on `forum_topic`?**
`reply_to_msg_id` is the replied-to message ID for *any* reply, not just forum topics. Without the `forum_topic` gate, ordinary replies would be mislabeled as topic messages. The gate ensures we only extract topic info when the message is actually in a forum topic.

**Why `reply_to_top_id` instead of `reply_to_msg_id`?**
In forum topics:
- `reply_to_top_id` = the topic root (the thread ID)
- `reply_to_msg_id` = the specific message being replied to (if this is a reply within the topic)

For topic membership, we want the topic root, not the replied-to message. The fallback to `reply_to_msg_id` handles the case where a topic's root message has `reply_to_top_id=None`.

**Why not `message_thread_id`?**
That's a Bot API field, not a Telethon field. User mode uses Telethon's MTProto, which exposes topic info via `MessageReplyHeader.forum_topic` and `reply_to_top_id`.

## Tests

Added 4 focused tests using `SimpleNamespace` (not `MagicMock`, which makes `hasattr` always return true):

1. `test_serialize_message_topic_id_forum_message` — forum message with `reply_to_top_id`
2. `test_serialize_message_topic_id_forum_fallback` — forum message falling back to `reply_to_msg_id`
3. `test_serialize_message_no_topic_for_ordinary_reply` — ordinary reply (forum_topic=False) has `topic_id=None`
4. `test_serialize_message_no_topic_no_reply` — message without `reply_to` has `topic_id=None`

All 706 tests pass.

## Verification

- ✓ `uv run ruff check .` — All checks passed
- ✓ `uv run ruff format --check .` — 1 file already formatted
- ✓ `uv run pytest` — 706 passed, 144 deselected
- ✓ Codex adversarial review — "No findings" after fixing initial implementation (gated on `forum_topic`, uses `reply_to_top_id`)

## Scope

- **In scope:** User mode message serialization (Telethon MTProto)
- **Out of scope:** Bot mode (Bot API cannot read arbitrary chat history, returns empty list)
- **Out of scope:** Topic listing/management (already supported via `chats` tool with `topic_action`)

[※](https://zauberzeug.github.io/colophon/#m=qwen-code&t=PR%20body%20drafted%20by%20Qwen%20Code%3B%20implementation%20by%20Qwen%20Code%2C%20Codex-reviewed%2C%20tests%20added. "qwen-code: PR body drafted by Qwen Code; implementation by Qwen Code, Codex-reviewed, tests added.")