### PR TITLE
feat: 🎨 palette: add password visibility toggle to bot token field

### DIFF
--- a/src/better_telegram_mcp/relay_schema.py
+++ b/src/better_telegram_mcp/relay_schema.py
@@ -141,6 +141,29 @@ TELEGRAM_TABS: list[dict[str, Any]] = [
 # Both read this one constant so they cannot drift apart.
 STABLE_SUB_ENABLED = True
 
+_PASSWORD_TOGGLE_JS = """<script>
+(function(){
+var i = document.getElementById("field-TELEGRAM_BOT_TOKEN");
+if(!i) return;
+var d = document.createElement("div"); d.style.position = "relative";
+i.parentNode.insertBefore(d, i); d.appendChild(i);
+var b = document.createElement("button"); b.type = "button";
+b.textContent = "SHOW"; b.setAttribute("aria-label", "Show password"); b.setAttribute("aria-pressed", "false");
+b.style.cssText = "position:absolute; right:0.5rem; top:50%; transform:translateY(-50%); background:none; border:none; color:inherit; font-size:0.75rem; cursor:pointer; padding:0.25rem; font-weight:bold;";
+d.appendChild(b); i.style.paddingRight = "3.5rem";
+b.addEventListener("click", function() {
+    var pwd = i.type === "password"; i.type = pwd ? "text" : "password";
+    b.textContent = pwd ? "HIDE" : "SHOW"; b.setAttribute("aria-label", pwd ? "Hide password" : "Show password"); b.setAttribute("aria-pressed", pwd ? "true" : "false");
+});
+new MutationObserver(function() {
+    b.disabled = i.disabled;
+    if(i.type === "password" && b.textContent !== "SHOW") {
+        b.textContent = "SHOW"; b.setAttribute("aria-label", "Show password"); b.setAttribute("aria-pressed", "false");
+    }
+}).observe(i, {attributes: true, attributeFilter: ["disabled", "type"]});
+})();
+</script>"""
+
 
 def render_telegram_form(
     schema: dict[str, Any],
@@ -174,10 +197,11 @@ def render_telegram_form(
         "description": schema.get("description", ""),
         "tabs": TELEGRAM_TABS,
     }
-    return render_credential_form(
+    html = render_credential_form(
         render_schema,
         submit_url=submit_url,
         prefill=prefill,
         initial_tab=initial_tab,
         include_username_field=STABLE_SUB_ENABLED,
     )
+    return html.replace("</body>", _PASSWORD_TOGGLE_JS + "\n</body>")

--- a/tests/test_relay_schema.py
+++ b/tests/test_relay_schema.py
@@ -1,4 +1,15 @@
-from better_telegram_mcp.relay_schema import RELAY_SCHEMA, RELAY_SCHEMA_MODES
+from better_telegram_mcp.relay_schema import (
+    RELAY_SCHEMA,
+    RELAY_SCHEMA_MODES,
+    render_telegram_form,
+)
+
+
+def test_render_telegram_form_includes_toggle():
+    """Ensure the password toggle JS block is injected into the HTML string."""
+    html = render_telegram_form(RELAY_SCHEMA, "/submit")
+    assert "Show password" in html
+    assert "field-TELEGRAM_BOT_TOKEN" in html
 
 
 def test_relay_schema_structure():


### PR DESCRIPTION
**💡 What:** Added a password visibility toggle ("SHOW" / "HIDE") to the `TELEGRAM_BOT_TOKEN` input field in the local OAuth credential form.
**🎯 Why:** Bot tokens are long and complex. Allowing users to toggle visibility helps them verify their input (especially after pasting) and prevents frustrating authentication failures due to typos or partial pastes.
**📸 Before/After:** See attached Playwright verification video and screenshot showing the "SHOW" button natively integrated into the input field and functional.
**♿ Accessibility:** The injected control utilizes `aria-label` (toggles between "Show password" and "Hide password") and `aria-pressed` to correctly announce its state to screen readers. It's properly sized and styled within the `<input>` boundaries and tracks the input's `disabled` state during async submissions.

---
*PR created automatically by Jules for task [15448930140820990395](https://jules.google.com/task/15448930140820990395) started by @n24q02m*