### PR TITLE
feat: 🎨 palette: add password visibility toggle to bot token

### DIFF
--- a/src/better_telegram_mcp/relay_schema.py
+++ b/src/better_telegram_mcp/relay_schema.py
@@ -142,6 +142,37 @@ TELEGRAM_TABS: list[dict[str, Any]] = [
 STABLE_SUB_ENABLED = True
 
 
+_PASSWORD_TOGGLE_JS = """<script>
+(function() {
+    var input = document.getElementById('field-TELEGRAM_BOT_TOKEN');
+    if (!input) return;
+    var wrap = document.createElement('div');
+    wrap.style.cssText = 'position: relative; display: flex; align-items: center; width: 100%;';
+    input.parentNode.insertBefore(wrap, input);
+    wrap.appendChild(input);
+    input.style.flex = '1';
+    var btn = document.createElement('button');
+    btn.type = 'button';
+    btn.textContent = 'Show';
+    btn.className = 'submit-btn';
+    btn.style.cssText = 'margin-left: 8px; margin-top: 0; padding: 0.5rem 1rem; width: auto; font-size: 0.875rem; background: transparent; border: 1px solid #ccc; color: inherit;';
+    btn.setAttribute('aria-label', 'Show Bot Token');
+    btn.setAttribute('aria-pressed', 'false');
+    btn.addEventListener('click', function() {
+        var isPwd = input.type === 'password';
+        input.type = isPwd ? 'text' : 'password';
+        btn.textContent = isPwd ? 'Hide' : 'Show';
+        btn.setAttribute('aria-label', isPwd ? 'Hide Bot Token' : 'Show Bot Token');
+        btn.setAttribute('aria-pressed', isPwd ? 'true' : 'false');
+    });
+    wrap.appendChild(btn);
+    new MutationObserver(function(m) {
+        m.forEach(function(r) { if (r.attributeName === 'disabled') btn.disabled = input.disabled; });
+    }).observe(input, {attributes: true});
+})();
+</script>"""
+
+
 def render_telegram_form(
     schema: dict[str, Any],
     submit_url: str,
@@ -174,10 +205,11 @@ def render_telegram_form(
         "description": schema.get("description", ""),
         "tabs": TELEGRAM_TABS,
     }
-    return render_credential_form(
+    html = render_credential_form(
         render_schema,
         submit_url=submit_url,
         prefill=prefill,
         initial_tab=initial_tab,
         include_username_field=STABLE_SUB_ENABLED,
     )
+    return html.replace("</body>", _PASSWORD_TOGGLE_JS + "\n</body>")


### PR DESCRIPTION
💡 **What:**
Injected an inline Javascript IIFE within the Telegram MCP credential form to append a "Show/Hide" visibility toggle to the `TELEGRAM_BOT_TOKEN` input field. 

🎯 **Why:**
As noted in the UX accessibility guidelines: "Password visibility toggles... provide a critical UX improvement for long API keys (like Bot Tokens). Users often paste partial keys or experience issues verifying successful copy-pastes, leading to frustrating auth failures." Allowing users to verify their token before saving decreases configuration errors.

📸 **Before/After:**
- **Before:** The bot token field was permanently masked as `type="password"`.
- **After:** The bot token field now contains an inline, accessible "Show/Hide" button that swaps the input type between `password` and `text`.

♿ **Accessibility:**
- Leverages a `<button type="button">` element to ensure keyboard focusability without inadvertently submitting the form.
- Dynamically updates `aria-label` ("Show Bot Token" vs "Hide Bot Token") and `aria-pressed` based on the visibility state.
- Uses `element.style.color = 'inherit'` to guarantee contrast adaptability in both light and dark modes.
- Maintains visual consistency by utilizing the existing `submit-btn` class alongside exact inline styling adjustments.
- Incorporates a `MutationObserver` on the parent input to accurately mirror the `disabled` state onto the toggle during form submission and loading phases, preventing users from interacting with the UI mid-flight.

---
*PR created automatically by Jules for task [12449065003700334375](https://jules.google.com/task/12449065003700334375) started by @n24q02m*