### PR TITLE
feat: ⚡ bolt: o(1) existence checks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,6 @@
 ## 2025-08-30 - Internalizing Thread Offloading for Blocking I/O
 **Learning:** In asynchronous backends, internal helper methods that perform blocking filesystem I/O (like `os.open`, `os.chmod`, or file-backed key-value lookups) can block the main asyncio event loop if not properly offloaded. While the offloading could be done at the call site, doing so clutters the call site and relies on callers to remember the implementation detail.
 **Action:** Always refactor internal helper methods that perform blocking I/O to be `async def`. Wrap their synchronous logic in a nested function and internally offload it using `await asyncio.to_thread()`. This improves API clarity and ensures non-blocking behavior wherever the method is invoked.
+## 2025-09-10 - O(1) Existence Checks in Cryptographic KV Stores
+**Learning:** When checking for the existence of records in encrypted Key-Value stores (e.g., `KvSessionStore`), using bulk data retrieval methods like `load_all()` incurs massive overhead due to the N+1 PBKDF2 decryption operations per session.
+**Action:** Always utilize or implement index-only checking methods (like `has_any()`) to achieve O(1) existence verification without loading the actual encrypted data.

--- a/src/better_telegram_mcp/auth/in_memory_session_store.py
+++ b/src/better_telegram_mcp/auth/in_memory_session_store.py
@@ -69,6 +69,10 @@ class InMemorySessionStore:
             for bearer, data in self._store.items()
         }
 
+    def has_any(self) -> bool:
+        """Check if any sessions exist without loading them."""
+        return len(self._store) > 0
+
     def delete(self, bearer: str) -> bool:
         """Delete a session. Returns True if it existed."""
         if bearer not in self._store:

--- a/src/better_telegram_mcp/auth/kv_session_store.py
+++ b/src/better_telegram_mcp/auth/kv_session_store.py
@@ -107,6 +107,14 @@ class KvSessionStore:
 
         return result
 
+    def has_any(self) -> bool:
+        """Check if any sessions exist without loading them.
+
+        Optimized O(1) existence check that reads only the index and avoids
+        the N+1 PBKDF2 decryption overhead of load_all().
+        """
+        return len(self._load_index()) > 0
+
     def delete(self, bearer: str) -> bool:
         """Delete session for bearer. Returns True if it existed."""
         existing = self.load(bearer)

--- a/src/better_telegram_mcp/relay_setup.py
+++ b/src/better_telegram_mcp/relay_setup.py
@@ -103,7 +103,7 @@ def check_saved_sessions(backend=None) -> bool:
     if cf_mode:
         from .auth.kv_session_store import KvSessionStore
 
-        return len(KvSessionStore(backend=backend).load_all()) > 0
+        return KvSessionStore(backend=backend).has_any()
 
     data_dir = Path.home() / ".better-telegram-mcp"
     if not data_dir.exists():

--- a/tests/auth/test_in_memory_session_store.py
+++ b/tests/auth/test_in_memory_session_store.py
@@ -128,6 +128,17 @@ class TestInMemorySessionStoreLoadAll:
         assert loaded.bot_token == "original"
 
 
+class TestInMemorySessionStoreHasAny:
+    def test_has_any_empty(self) -> None:
+        store = InMemorySessionStore()
+        assert store.has_any() is False
+
+    def test_has_any_with_sessions(self) -> None:
+        store = InMemorySessionStore()
+        store.store("b1", _bot_info("t1"))
+        assert store.has_any() is True
+
+
 class TestSessionInfo:
     def test_to_dict_roundtrip(self) -> None:
         """SessionInfo should serialize and deserialize correctly."""

--- a/tests/auth/test_kv_session_store.py
+++ b/tests/auth/test_kv_session_store.py
@@ -63,6 +63,18 @@ def test_per_sub_isolation():
     assert store.load("sub-z") is None
 
 
+def test_has_any():
+    backend = InMemoryBackend()
+    store = KvSessionStore(backend=backend)
+    assert store.has_any() is False
+
+    store.store("sub-a", _info("sess_a", "+1"))
+    assert store.has_any() is True
+
+    store.delete("sub-a")
+    assert store.has_any() is False
+
+
 def test_delete():
     backend = InMemoryBackend()
     store = KvSessionStore(backend=backend)


### PR DESCRIPTION
💡 **What:** Added `has_any()` methods to `KvSessionStore` and `InMemorySessionStore` and updated `check_saved_sessions` in `relay_setup.py` to use `has_any()` instead of `load_all()`.

🎯 **Why:** Previously, checking if any sessions existed during startup or state resolution called `load_all()`. On a `KvSessionStore`, `load_all` suffers from an N+1 PBKDF2 decryption bottleneck, massively slowing down execution. Checking an index instead skips decryption entirely.

📊 **Impact:** Provides an O(1) existence check, dramatically speeding up server startup and credential state resolution when many users exist. Eliminates all PBKDF2 decryption overhead during this check.

🔬 **Measurement:** Verified via full test suite pass. The startup latency difference is observable dynamically as the user count scales.

---
*PR created automatically by Jules for task [14496894361098284259](https://jules.google.com/task/14496894361098284259) started by @n24q02m*