### PR TITLE
feat: 🎨 palette: fix password toggle state synchronization bug

### DIFF
--- a/src/better_telegram_mcp/relay_schema.py
+++ b/src/better_telegram_mcp/relay_schema.py
@@ -157,6 +157,8 @@ b.addEventListener("click", function() {
 });
 new MutationObserver(function() {
     b.disabled = i.disabled;
+    var isReallyPwd = i.type === "password" || b.textContent === "HIDE";
+    b.style.display = isReallyPwd ? "block" : "none";
     if(i.type === "password" && b.textContent !== "SHOW") {
         b.textContent = "SHOW"; b.setAttribute("aria-label", "Show password"); b.setAttribute("aria-pressed", "false");
     }


### PR DESCRIPTION
💡 What: Fixed a bug where the password SHOW/HIDE toggle button would disappear if the input field became disabled after the user clicked "SHOW".
🎯 Why: A brittle `dataset.toggling` flag was being used. When the form disables inputs during submission, the `MutationObserver` would hide the toggle button if the field was currently type "text", breaking the UI state. 
📸 Before/After: Visual behavior is unchanged in standard state, but the HIDE button now remains visible during async loading/disabled states.
♿ Accessibility: The fix ensures the button and its `aria-pressed` / `aria-label` states stay correctly synchronized rather than disappearing entirely.

---
*PR created automatically by Jules for task [2138182330001607316](https://jules.google.com/task/2138182330001607316) started by @n24q02m*