### PR TITLE
feat: 🎨 palette: visually unambiguous disabled states for injected controls

### DIFF
--- a/src/better_telegram_mcp/relay_schema.py
+++ b/src/better_telegram_mcp/relay_schema.py
@@ -155,12 +155,18 @@ b.addEventListener("click", function() {
     var pwd = i.type === "password"; i.type = pwd ? "text" : "password";
     b.textContent = pwd ? "HIDE" : "SHOW"; b.setAttribute("aria-label", pwd ? "Hide password" : "Show password"); b.setAttribute("aria-pressed", pwd ? "true" : "false");
 });
-new MutationObserver(function() {
+var updateState = function() {
     b.disabled = i.disabled;
+    b.style.opacity = i.disabled ? "0.5" : "1";
+    b.style.cursor = i.disabled ? "not-allowed" : "pointer";
+};
+new MutationObserver(function() {
+    updateState();
     if(i.type === "password" && b.textContent !== "SHOW") {
         b.textContent = "SHOW"; b.setAttribute("aria-label", "Show password"); b.setAttribute("aria-pressed", "false");
     }
 }).observe(i, {attributes: true, attributeFilter: ["disabled", "type"]});
+updateState();
 })();
 </script>"""
 


### PR DESCRIPTION
💡 **What:** The UX enhancement added: Modified the injected `_PASSWORD_TOGGLE_JS` button in the credential form to dynamically lower its opacity and change its cursor to `not-allowed` when its associated input is disabled.

🎯 **Why:** The user problem it solves: Prevent confusing visual feedback when interactive elements like buttons are disabled, making the disabled status visually unambiguous to the user.

📸 **Before/After:** Previously, when clicking "Connect", the form inputs and buttons were disabled, but the "Show" toggle still had a `pointer` cursor and full opacity, making it look clickable. Now, it fades out to 50% opacity and changes the cursor to `not-allowed`.

♿ **Accessibility:** This makes the interface more predictable by accurately conveying state visually, rather than relying solely on the HTML `disabled` attribute which only halts functionality.

---
*PR created automatically by Jules for task [11613711970612594160](https://jules.google.com/task/11613711970612594160) started by @n24q02m*