### PR TITLE
feat: 🎨 palette: improve password toggle disabled and recycled state UX

### DIFF
--- a/src/better_telegram_mcp/relay_schema.py
+++ b/src/better_telegram_mcp/relay_schema.py
@@ -157,6 +157,11 @@ b.addEventListener("click", function() {
 });
 new MutationObserver(function() {
     b.disabled = i.disabled;
+    b.style.opacity = b.disabled ? "0.5" : "1";
+    b.style.cursor = b.disabled ? "not-allowed" : "pointer";
+    var isPwdField = i.type === "password" || b.textContent === "HIDE";
+    b.style.display = isPwdField ? "" : "none";
+    i.style.paddingRight = isPwdField ? "3.5rem" : "";
     if(i.type === "password" && b.textContent !== "SHOW") {
         b.textContent = "SHOW"; b.setAttribute("aria-label", "Show password"); b.setAttribute("aria-pressed", "false");
     }


### PR DESCRIPTION
**What:**
Updated the injected JavaScript that creates the password visibility toggle in the `mcp-core` credential form. Added explicit `opacity` and `cursor` style updates to visually indicate when the button is disabled. Additionally, added logic to gracefully hide the button and reset the parent input's padding when the form container is recycled for non-password inputs (like an OTP step).

**Why:**
Previously, the password visibility toggle only synchronized the boolean `disabled` attribute, which didn't visually communicate its state to the user. Furthermore, because `mcp-core` reuses the same input elements for multi-step flows, the "SHOW" button remained awkwardly visible inside standard text fields (like OTPs), causing visual overlap and confusion.

**Before/After:**
*Before:*
- The toggle button remained visually fully opaque when disabled.
- The toggle button remained visible when swapping to the "User Mode" phone number tab or OTP prompts.
*After:*
- The toggle button fades to `0.5` opacity with a `not-allowed` cursor when disabled alongside the form.
- The toggle button dynamically hides itself (`display: none`) and resets the input's right padding when the input is no longer a password field, ensuring a clean UI during form step transitions.

**Accessibility:**
This change improves UI state clarity. Explicit disabled states prevent users from attempting interactions that will fail, and dynamically hiding irrelevant controls reduces cognitive load and prevents screen readers from encountering stale auxiliary buttons on unrelated input fields.

---
*PR created automatically by Jules for task [13717641189918719116](https://jules.google.com/task/13717641189918719116) started by @n24q02m*