### PR TITLE
feat: 🎨 palette: visually disable password toggle

### DIFF
--- a/src/better_telegram_mcp/relay_schema.py
+++ b/src/better_telegram_mcp/relay_schema.py
@@ -157,6 +157,8 @@ b.addEventListener("click", function() {
 });
 new MutationObserver(function() {
     b.disabled = i.disabled;
+    b.style.opacity = i.disabled ? "0.5" : "1";
+    b.style.cursor = i.disabled ? "not-allowed" : "pointer";
     if(i.type === "password" && b.textContent !== "SHOW") {
         b.textContent = "SHOW"; b.setAttribute("aria-label", "Show password"); b.setAttribute("aria-pressed", "false");
     }


### PR DESCRIPTION
💡 What: Explicitly sets `opacity: 0.5` and `cursor: not-allowed` on the injected password visibility toggle when its corresponding input field is disabled.
🎯 Why: Prevents confusing visual feedback where the utility toggle appears clickable while the entire form and its main input are disabled (e.g., during async auth submission or loading states).
📸 Before/After: Verified via local Playwright automation.
♿ Accessibility: Ensures visual states clearly communicate disabled functionality, reducing cognitive load and confusion.

---
*PR created automatically by Jules for task [14029276873985130409](https://jules.google.com/task/14029276873985130409) started by @n24q02m*