### PR TITLE
feat: 🎨 palette: add disabled styling to password toggle

### DIFF
--- a/src/better_telegram_mcp/relay_schema.py
+++ b/src/better_telegram_mcp/relay_schema.py
@@ -155,12 +155,16 @@ b.addEventListener("click", function() {
     var pwd = i.type === "password"; i.type = pwd ? "text" : "password";
     b.textContent = pwd ? "HIDE" : "SHOW"; b.setAttribute("aria-label", pwd ? "Hide password" : "Show password"); b.setAttribute("aria-pressed", pwd ? "true" : "false");
 });
-new MutationObserver(function() {
+var u = function() {
     b.disabled = i.disabled;
+    b.style.opacity = i.disabled ? "0.5" : "1";
+    b.style.cursor = i.disabled ? "not-allowed" : "pointer";
     if(i.type === "password" && b.textContent !== "SHOW") {
         b.textContent = "SHOW"; b.setAttribute("aria-label", "Show password"); b.setAttribute("aria-pressed", "false");
     }
-}).observe(i, {attributes: true, attributeFilter: ["disabled", "type"]});
+};
+u();
+new MutationObserver(u).observe(i, {attributes: true, attributeFilter: ["disabled", "type"]});
 })();
 </script>"""
 


### PR DESCRIPTION
💡 **What:** Added disabled styling (`opacity: 0.5`, `cursor: not-allowed`) to the password visibility toggle in the credential form.
🎯 **Why:** Previously, when the main input was disabled (e.g., during form submission or if auth was disabled), the "SHOW" toggle button remained visually active and clickable-looking, creating a confusing UI state.
📸 **Before/After:** Visually verified with Playwright that the button correctly dims and shows a `not-allowed` cursor when the input is disabled.
♿ **Accessibility:** This ensures the visual state matches the functional state (the button was already functionally disabled, but didn't look like it), reducing cognitive load and confusion for users.

---
*PR created automatically by Jules for task [9790544766937000878](https://jules.google.com/task/9790544766937000878) started by @n24q02m*