### PR TITLE
feat: 🎨 palette: add visual disabled state to password toggle

### DIFF
--- a/src/better_telegram_mcp/relay_schema.py
+++ b/src/better_telegram_mcp/relay_schema.py
@@ -157,6 +157,8 @@ b.addEventListener("click", function() {
 });
 new MutationObserver(function() {
     b.disabled = i.disabled;
+    b.style.opacity = i.disabled ? "0.5" : "1";
+    b.style.cursor = i.disabled ? "not-allowed" : "pointer";
     if(i.type === "password" && b.textContent !== "SHOW") {
         b.textContent = "SHOW"; b.setAttribute("aria-label", "Show password"); b.setAttribute("aria-pressed", "false");
     }


### PR DESCRIPTION
💡 What: Added explicit `:disabled` visual styling (`opacity: 0.5; cursor: not-allowed;`) to the password visibility toggle button when the input is disabled.
🎯 Why: To clearly indicate to the user that the toggle is inactive during loading/connecting states, preventing confusing interaction attempts.
📸 Before/After: Verified via local Playwright UI testing.
♿ Accessibility: Ensures the disabled status of interactive utility controls is visually unambiguous for all users.

---
*PR created automatically by Jules for task [11455310936537545159](https://jules.google.com/task/11455310936537545159) started by @n24q02m*