### PR TITLE
feat(ui): clarify disabled password toggle

### DIFF
--- a/src/better_telegram_mcp/relay_schema.py
+++ b/src/better_telegram_mcp/relay_schema.py
@@ -150,6 +150,7 @@ i.parentNode.insertBefore(d, i); d.appendChild(i);
 var b = document.createElement("button"); b.type = "button";
 b.textContent = "SHOW"; b.setAttribute("aria-label", "Show password"); b.setAttribute("aria-pressed", "false");
 b.style.cssText = "position:absolute; right:0.5rem; top:50%; transform:translateY(-50%); background:none; border:none; color:inherit; font-size:0.75rem; cursor:pointer; padding:0.25rem; font-weight:bold;";
+if (i.disabled) { b.disabled = true; b.style.opacity = "0.5"; b.style.cursor = "not-allowed"; }
 d.appendChild(b); i.style.paddingRight = "3.5rem";
 b.addEventListener("click", function() {
     var pwd = i.type === "password"; i.type = pwd ? "text" : "password";
@@ -157,6 +158,8 @@ b.addEventListener("click", function() {
 });
 new MutationObserver(function() {
     b.disabled = i.disabled;
+    b.style.opacity = i.disabled ? "0.5" : "1";
+    b.style.cursor = i.disabled ? "not-allowed" : "pointer";
     if(i.type === "password" && b.textContent !== "SHOW") {
         b.textContent = "SHOW"; b.setAttribute("aria-label", "Show password"); b.setAttribute("aria-pressed", "false");
     }


### PR DESCRIPTION
💡 What: Synchronized the visual state of the password "SHOW/HIDE" toggle button with the disabled state of the Bot Token input field.
🎯 Why: Leaving auxiliary interactive elements (like the password visibility toggle) enabled and clickable while the primary input and submit button are disabled in a loading state creates an inconsistent UI state and can lead to confusing behavior during async operations.
📸 Before/After: The SHOW button now has `opacity: 0.5` and `cursor: not-allowed` applied when the input is disabled, providing clear visual feedback that matches the input.
♿ Accessibility: Improves visual accessibility by ensuring disabled utility controls do not look interactive, preventing user confusion.

---
*PR created automatically by Jules for task [16115232217121813032](https://jules.google.com/task/16115232217121813032) started by @n24q02m*