### PR TITLE
feat: ⚡ bolt: o(1) existence checks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,6 @@
 ## 2025-08-30 - Internalizing Thread Offloading for Blocking I/O
 **Learning:** In asynchronous backends, internal helper methods that perform blocking filesystem I/O (like `os.open`, `os.chmod`, or file-backed key-value lookups) can block the main asyncio event loop if not properly offloaded. While the offloading could be done at the call site, doing so clutters the call site and relies on callers to remember the implementation detail.
 **Action:** Always refactor internal helper methods that perform blocking I/O to be `async def`. Wrap their synchronous logic in a nested function and internally offload it using `await asyncio.to_thread()`. This improves API clarity and ensures non-blocking behavior wherever the method is invoked.
+## 2025-08-31 - O(1) Existence Checks for Encrypted Stores
+**Learning:** Checking for session existence using bulk data retrieval methods like `load_all()` incurs massive overhead from N+1 decryption operations (e.g., PBKDF2) in the Cryptographic KV Store, even when no sessions exist, due to ThreadPoolExecutor initialization and index iteration.
+**Action:** When checking if any records exist or before processing bulk operations like `restore_sessions` or `cleanup_expired`, always implement and utilize index-only checks like `has_any()` to achieve O(1) existence verification and skip expensive bulk loads when empty.

--- a/src/better_telegram_mcp/auth/telegram_auth_provider.py
+++ b/src/better_telegram_mcp/auth/telegram_auth_provider.py
@@ -111,6 +111,9 @@ class TelegramAuthProvider:
         """
         import asyncio
 
+        if not self._store.has_any():
+            return 0
+
         sessions = self._store.load_all()
         now = time.time()
 
@@ -418,26 +421,27 @@ class TelegramAuthProvider:
 
     async def cleanup_expired(self) -> int:
         """Remove expired sessions. Returns count of removed sessions."""
-        sessions = self._store.load_all()
         removed = 0
         now = time.time()
 
-        to_revoke = [
-            bearer
-            for bearer, info in sessions.items()
-            if now - info.created_at > _SESSION_TTL
-        ]
+        if self._store.has_any():
+            sessions = self._store.load_all()
+            to_revoke = [
+                bearer
+                for bearer, info in sessions.items()
+                if now - info.created_at > _SESSION_TTL
+            ]
 
-        if to_revoke:
-            results = await asyncio.gather(
-                *(self.revoke_session(b) for b in to_revoke),
-                return_exceptions=True,
-            )
-            for res in results:
-                if isinstance(res, Exception):
-                    logger.warning("Error revoking session during cleanup: {}", res)
-                elif res is True:
-                    removed += 1
+            if to_revoke:
+                results = await asyncio.gather(
+                    *(self.revoke_session(b) for b in to_revoke),
+                    return_exceptions=True,
+                )
+                for res in results:
+                    if isinstance(res, Exception):
+                        logger.warning("Error revoking session during cleanup: {}", res)
+                    elif res is True:
+                        removed += 1
 
         # Clean up stale pending OTPs (5 min TTL) using chronological insertion order.
         # Since start_user_auth pops-then-reinserts each bearer, the oldest entries


### PR DESCRIPTION
💡 **What:** Added short-circuit returns to `restore_sessions` and `cleanup_expired` in `TelegramAuthProvider` by calling `self._store.has_any()` before initiating bulk session loads.

🎯 **Why:** The `KvSessionStore` uses a PBKDF2-encrypted Key-Value store on Cloudflare. Calling `load_all()` when the store is empty still spins up a ThreadPoolExecutor and iterates the index, which incurs massive unnecessary overhead. An empty check avoids this completely.

📊 **Impact:** Reduces server startup time (via `restore_sessions`) and periodic CPU blocking overhead (via `cleanup_expired`) to virtually zero (O(1) list check) when there are no active sessions.

🔬 **Measurement:** Verify by running the test suite (`uv run pytest`), which asserts both methods complete successfully on an empty store, and observe the `auth` module's benchmark tests (if applicable) for the removed N+1 overhead on empty sets.

---
*PR created automatically by Jules for task [7438055428650137372](https://jules.google.com/task/7438055428650137372) started by @n24q02m*