### PR TITLE
feat: dehost managed Cloudflare runtime

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -363,7 +363,7 @@ jobs:
     # this job (exit 1, no silent bad deploy). Live-image prev_ref for true CI
     # rollback is a tracked follow-up.
     needs: [readme-sync, release]
-    if: needs.release.outputs.released == 'true'
+    if: needs.release.outputs.released == 'true' && vars.CF_HOSTED_ENABLED != 'false'
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -40,6 +40,9 @@ export interface Env {
   MCP_DCR_SERVER_SECRET: string
   TELEGRAM_API_ID?: string
   TELEGRAM_API_HASH?: string
+  // Dehost / tombstone drill flag (W4)
+  DEHOSTED?: string
+  TOMBSTONE?: string
 }
 
 // Keys forwarded from the Worker env (wrangler vars + secrets) into the container
@@ -108,8 +111,30 @@ function unauthenticated(request: Request): Response {
   })
 }
 
+function tombstoneResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      error: 'hosted_runtime_dehosted',
+      status: 410,
+      message:
+        'The hosted Cloudflare endpoint for better-telegram-mcp has been retired. The package remains active via local stdio (uvx better-telegram-mcp / docker run -i n24q02m/better-telegram-mcp) and self-hosted HTTP. See https://mcp.n24q02m.com/servers/better-telegram-mcp/ for instructions.',
+      successor: 'https://mcp.n24q02m.com/servers/better-telegram-mcp/',
+    }),
+    {
+      status: 410,
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Dehosted-Successor': 'https://mcp.n24q02m.com/servers/better-telegram-mcp/',
+      },
+    }
+  )
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
+    if (env.DEHOSTED === 'true' || env.TOMBSTONE === 'true') {
+      return tombstoneResponse()
+    }
     // Edge auth gate. mcp-core's OAuth AS runs INSIDE the container, so before
     // this gate every anonymous /mcp request started the container and reset
     // its 5m idle timer -- an unauthenticated caller could pin it awake and

--- a/tests/test_deploy_cf_template.py
+++ b/tests/test_deploy_cf_template.py
@@ -70,3 +70,4 @@ def test_committed_template_renders_to_valid_json(monkeypatch):
     )
     assert cfg["kv_namespaces"][0]["id"] == "kvid"
     assert cfg["vars"]["PUBLIC_URL"] == "https://telegram.n24q02m.com"
+    assert cfg["vars"]["DEHOSTED"] == "true"

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -204,3 +204,60 @@ describe('edge declines the standing GET /mcp SSE stream (container never pinned
     expect(calls()).toBe(0)
   })
 })
+
+describe('tombstone contract (W4 dehost preparation & drill)', () => {
+  function makeEnv(flags: Record<string, string> = {}) {
+    let stubCalls = 0
+    const env = {
+      TELEGRAM: {
+        idFromName(n: string) { return { n } },
+        get() { return { fetch: async () => { stubCalls++; return new Response('ok') } } },
+      },
+      ...flags,
+    }
+    return { env: env as never, calls: () => stubCalls }
+  }
+
+  it('returns 410 Gone with non-sensitive successor message and headers before edge auth when DEHOSTED is true', async () => {
+    const { env, calls } = makeEnv({ DEHOSTED: 'true' })
+    const res = await worker.fetch(
+      new Request('https://telegram.n24q02m.com/mcp', {
+        method: 'POST',
+      }),
+      env
+    )
+
+    expect(res.status).toBe(410)
+    expect(res.headers.get('Content-Type')).toBe('application/json')
+    expect(res.headers.get('X-Dehosted-Successor')).toBe('https://mcp.n24q02m.com/servers/better-telegram-mcp/')
+
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body).toMatchObject({
+      error: 'hosted_runtime_dehosted',
+      status: 410,
+      successor: 'https://mcp.n24q02m.com/servers/better-telegram-mcp/',
+    })
+    expect(body.message).toContain('retired')
+    expect(body.message).toContain('stdio')
+
+    // CRITICAL: 0 requests reach the Container DO
+    expect(calls()).toBe(0)
+  })
+
+  it('returns 410 Gone on all routes before auth/DO for DEHOSTED and the existing TOMBSTONE drill alias', async () => {
+    for (const flag of ['DEHOSTED', 'TOMBSTONE'] as const) {
+      const { env, calls } = makeEnv({ [flag]: 'true' })
+
+      for (const path of ['/authorize', '/health', '/.well-known/jwks.json', '/mcp/v1']) {
+        const res = await worker.fetch(
+          new Request(`https://telegram.n24q02m.com${path}`, { method: 'GET' }),
+          env
+        )
+        expect(res.status).toBe(410)
+        expect(res.headers.get('X-Dehosted-Successor')).toBe('https://mcp.n24q02m.com/servers/better-telegram-mcp/')
+      }
+
+      expect(calls()).toBe(0)
+    }
+  })
+})

--- a/wrangler.deploy.template.jsonc
+++ b/wrangler.deploy.template.jsonc
@@ -25,6 +25,7 @@
   "migrations": [{ "tag": "v1", "new_sqlite_classes": ["TelegramContainer"] }],
   "kv_namespaces": [{ "binding": "KV", "id": "${CF_KV_ID}" }],
   "vars": {
+    "DEHOSTED": "true",
     "PUBLIC_URL": "${PUBLIC_URL}",
     "MCP_STORAGE_BACKEND": "cf-kv",
     "MCP_KV_BASE_URL": "http://kv.internal",


### PR DESCRIPTION
## Summary
- return deterministic HTTP 410 for every hosted route before auth or Durable Object access
- commit and verify `DEHOSTED=true` in the Cloudflare deployment template
- keep package/release/security maintenance active while allowing future hosted deploys to be disabled with `CF_HOSTED_ENABLED=false`
- preserve the domain, KV, secrets, image history, and self-hosted/local distribution surfaces

## Verification
- worker Vitest suite: 15 passed
- deployment-template pytest suite: 3 passed
- TypeScript check: passed
- repository pre-commit checks: passed
- encrypted KV backup and isolated restore drill recorded before this change

This is the hosted-runtime tombstone only. Stable promotion is intentionally out of scope.