### PR TITLE
fix: accept dehost tombstone canary

### DIFF
--- a/scripts/deploy_cf.py
+++ b/scripts/deploy_cf.py
@@ -66,6 +66,7 @@ for _stream in (sys.stdout, sys.stderr):
 
 DEPLOY_CONFIG = "wrangler.deploy.jsonc"
 TEMPLATE_CONFIG = "wrangler.deploy.template.jsonc"
+DEHOST_SUCCESSOR = "https://mcp.n24q02m.com/servers/better-telegram-mcp/"
 
 
 def render_template(path: str) -> str:
@@ -298,14 +299,36 @@ def _retry_gate(fn, public_url: str, *, tries: int = 10, delay: int = 6) -> bool
     return False
 
 
-def _canary(public_url: str, *, dry: bool) -> bool:
-    if dry:
-        print(
-            "  (dry-run) would run canary: Gate A /authorize->/login, "
-            "Gate B /mcp 401, JWKS kid-stable"
+def _gate_dehosted(public_url: str) -> bool:
+    """Every public route must expose the deterministic dehost tombstone."""
+    ok = True
+    for path in ("/authorize", "/mcp", "/.well-known/jwks.json", "/health"):
+        status, headers, _ = _get(f"{public_url}{path}")
+        successor = headers.get("x-dehosted-successor", "")
+        route_ok = status == 410 and successor == DEHOST_SUCCESSOR
+        detail = (
+            "OK"
+            if route_ok
+            else (f"FAIL (status={status}, successor={successor or 'missing'})")
         )
+        print(f"  [canary] Dehost {path} -> {status}  {detail}")
+        ok = ok and route_ok
+    return ok
+
+
+def _canary(public_url: str, *, dry: bool, dehosted: bool = False) -> bool:
+    if dry:
+        if dehosted:
+            print("  (dry-run) would require the 410 dehost tombstone on every route")
+        else:
+            print(
+                "  (dry-run) would run canary: Gate A /authorize->/login, "
+                "Gate B /mcp 401, JWKS kid-stable"
+            )
         return True
     print(f"Canary gate against {public_url} (credential-free):")
+    if dehosted:
+        return _retry_gate(_gate_dehosted, public_url)
     results = [
         _retry_gate(_gate_a, public_url),
         _retry_gate(_gate_b, public_url),
@@ -402,11 +425,17 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 0
 
-    if _canary(_public_url(cfg), dry=args.dry_run):
-        print(
-            f"DONE: {worker} deployed at tag {tag}, canary PASS. "
-            "Run scripts/cf_full_flow.py for the authenticated tool round-trip."
-        )
+    dehosted = str((cfg.get("vars") or {}).get("DEHOSTED", "")).lower() == "true"
+    if _canary(_public_url(cfg), dry=args.dry_run, dehosted=dehosted):
+        if dehosted:
+            print(
+                f"DONE: {worker} deployed at tag {tag}, dehost tombstone canary PASS."
+            )
+        else:
+            print(
+                f"DONE: {worker} deployed at tag {tag}, canary PASS. "
+                "Run scripts/cf_full_flow.py for the authenticated tool round-trip."
+            )
         return 0
 
     if prev_ref == full:

--- a/tests/test_deploy_cf_template.py
+++ b/tests/test_deploy_cf_template.py
@@ -1,9 +1,9 @@
-"""Tests for the CI CF-deploy template rendering in ``scripts/deploy_cf.py``.
+"""Tests for CI Cloudflare deployment rendering and post-deploy canaries.
 
 ``deploy_cf.py --from-template`` reconstructs the gitignored
-``wrangler.deploy.jsonc`` from the committed placeholder template + env (CI
-provides the real IDs as GitHub Actions secrets). These tests exercise the pure
-``render_template`` substitution without touching docker/wrangler.
+``wrangler.deploy.jsonc`` from the committed placeholder template + env. The
+canary tests stay credential-free and never touch Docker, Wrangler, or the
+network.
 """
 
 from __future__ import annotations
@@ -71,3 +71,60 @@ def test_committed_template_renders_to_valid_json(monkeypatch):
     assert cfg["kv_namespaces"][0]["id"] == "kvid"
     assert cfg["vars"]["PUBLIC_URL"] == "https://telegram.n24q02m.com"
     assert cfg["vars"]["DEHOSTED"] == "true"
+
+
+def test_dehosted_canary_accepts_only_the_tombstone_contract(monkeypatch):
+    requested: list[str] = []
+
+    def fake_get(url: str, *, timeout: int = 12):
+        requested.append(url)
+        return (
+            410,
+            {
+                "x-dehosted-successor": (
+                    "https://mcp.n24q02m.com/servers/better-telegram-mcp/"
+                )
+            },
+            url,
+        )
+
+    monkeypatch.setattr(deploy_cf, "_get", fake_get)
+    monkeypatch.setattr(
+        deploy_cf,
+        "_retry_gate",
+        lambda gate, public_url: gate(public_url),
+    )
+    monkeypatch.setattr(
+        deploy_cf,
+        "_gate_a",
+        lambda _public_url: pytest.fail("active Gate A must not run after dehost"),
+    )
+    monkeypatch.setattr(
+        deploy_cf,
+        "_gate_b",
+        lambda _public_url: pytest.fail("active Gate B must not run after dehost"),
+    )
+    monkeypatch.setattr(
+        deploy_cf,
+        "_gate_kid_stable",
+        lambda _public_url: pytest.fail("JWKS must not run after dehost"),
+    )
+
+    assert deploy_cf._canary("https://telegram.n24q02m.com", dry=False, dehosted=True)
+    assert requested == [
+        "https://telegram.n24q02m.com/authorize",
+        "https://telegram.n24q02m.com/mcp",
+        "https://telegram.n24q02m.com/.well-known/jwks.json",
+        "https://telegram.n24q02m.com/health",
+    ]
+
+
+def test_dehosted_gate_rejects_a_route_that_is_not_tombstoned(monkeypatch):
+    def fake_get(url: str, *, timeout: int = 12):
+        if url.endswith("/health"):
+            return 200, {}, url
+        return 410, {"x-dehosted-successor": "successor"}, url
+
+    monkeypatch.setattr(deploy_cf, "_get", fake_get)
+
+    assert not deploy_cf._gate_dehosted("https://telegram.n24q02m.com")

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.17.0"
+version = "4.18.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
## Problem
The first beta tombstone deployment succeeded and the live endpoint returned the intended 410, but the active-runtime canary still required `/login`, a bearer challenge, and JWKS. That made CD run 32706491179 fail after a successful dehost deployment.

## Change
- select a dehost-aware canary from the rendered `DEHOSTED=true` deployment config
- require HTTP 410 plus the exact successor header on `/authorize`, `/mcp`, JWKS, and `/health`
- retain the existing active-runtime Gate A/Gate B/JWKS canary when dehost mode is absent
- synchronize `uv.lock` with the published 4.18.0 beta package version

## Verification
- TDD: new dehost tests failed before implementation, then passed
- focused deploy tests: 5 passed
- Ruff lint/format and ty: passed
- repository pre-commit suite: passed
- live credential-free smoke: all four routes returned 410 with the expected successor
- Cloudflare application readback: version 19, image 4.18.0-beta.1, active=0, failed=0

Stable promotion is intentionally out of scope.