### PR TITLE
fix(deps): prevent pydantic settings startup warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,8 @@ dependencies = [
     "httpx>=0.28.1",
     "telethon>=1.44.0",
     "pydantic>=2.13.4,<2.14",
-    "pydantic-settings>=2.15.0",
+    # 2.15 warns while constructing MCP SDK Settings; lift after upstream rebuilds its model.
+    "pydantic-settings>=2.14.2,<2.15",
     "loguru>=0.7.3",
     "n24q02m-mcp-core>=1.23.0,<2",
     "cryptography>=50.0.0",

--- a/renovate.json
+++ b/renovate.json
@@ -99,6 +99,13 @@
       "allowedVersions": "<1.29"
     },
     {
+      "description": "Hold pydantic-settings below 2.15 until the MCP SDK rebuilds Settings",
+      "matchPackageNames": [
+        "pydantic-settings"
+      ],
+      "allowedVersions": "<2.15"
+    },
+    {
       "description": "Pin Python runtime to 3.13.x",
       "matchPackageNames": [
         "python"

--- a/tests/test_startup_warnings.py
+++ b/tests/test_startup_warnings.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+
+def test_server_import_emits_no_runtime_warnings() -> None:
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("TELEGRAM_")
+    }
+    result = subprocess.run(
+        [sys.executable, "-Werror", "-c", "import better_telegram_mcp.server"],
+        capture_output=True,
+        check=False,
+        env=env,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.18.0b2"
+version = "4.18.0b3"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },
@@ -114,7 +114,7 @@ requires-dist = [
     { name = "mcp", extras = ["cli"], specifier = ">=1.28.1,<1.29" },
     { name = "n24q02m-mcp-core", specifier = ">=1.23.0,<2" },
     { name = "pydantic", specifier = ">=2.13.4,<2.14" },
-    { name = "pydantic-settings", specifier = ">=2.15.0" },
+    { name = "pydantic-settings", specifier = ">=2.14.2,<2.15" },
     { name = "starlette", specifier = ">=1.6.0" },
     { name = "telethon", specifier = ">=1.44.0" },
     { name = "uvicorn", specifier = ">=0.52.4" },
@@ -924,16 +924,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.15.0"
+version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/68/ca/31c57507b13119d7d3cfa1576dad2911a4861e3be07b579395f4e9d393f9/pydantic_settings-2.15.0.tar.gz", hash = "sha256:694b793e84f766ba76a90ebdefc01d0a9a045dab0382bee70393da93712ad117", size = 261253, upload-time = "2026-08-07T09:24:57.419Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/a4/2bffa9f8e804325a09867f0e9d30795c80ea9f8d62560bd1b6ad6220eb2f/pydantic_settings-2.15.0-py3-none-any.whl", hash = "sha256:0ba092c291c94baceb5eff768aa0d56400a457585bc0175925a5a5510303da42", size = 69413, upload-time = "2026-08-07T09:24:55.839Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

`pydantic-settings` 2.15 emits `IncompleteFieldDefinitionWarning` while MCP SDK `Settings` resolves its `lifespan` forward reference. This is visible on every server startup and becomes fatal under `-Werror`.

## Fix

- hold `pydantic-settings` at the last warning-free 2.14 line
- encode the ceiling in Renovate so the broken update is not recreated
- add a subprocess regression that imports the real server with warnings promoted to errors

## Evidence

- reproduction before fix: the new regression fails at `FastMCP(...)` with `IncompleteFieldDefinitionWarning`
- targeted regression: 1 passed
- unit suite: 693 passed, 17 skipped, 129 deselected
- ruff check/format and ty: passed
- normal commit hooks: passed

Stable release is intentionally out of scope.