### PR TITLE
fix: remove retired Telegram host claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,10 +314,11 @@ into a single credential bucket.
 
 This plugin implements **TC-NearZK** (in-memory, ephemeral). See [mcp-core trust model](https://mcp.n24q02m.com/servers/mcp-core/trust-model/) for full classification.
 
+The project no longer operates an n24q02m-hosted Telegram endpoint. HTTP mode is available only on infrastructure an operator deploys and controls.
+
 | Mode | Storage | Encryption | Who can read your data? |
 |---|---|---|---|
-| HTTP n24q02m-hosted (default) | In-memory `dict[sub] = MTProtoSession` | In-process only | Server process (cleared on restart) |
-| HTTP self-host | Same as hosted | Same | Only you (admin = user) |
+| HTTP self-host (opt-in) | In-memory `dict[sub] = MTProtoSession` | In-process only | Operator-controlled server process (cleared on restart) |
 | stdio | `~/.config/mcp/config.enc` (credentials) + `~/.better-telegram-mcp/<name>.session` (Telethon session) | AES-GCM, machine-bound key | Only your OS user (file perm 0600) |
 
 ### Workspace username (HTTP setup form)


### PR DESCRIPTION
## Summary
- remove the stale `HTTP n24q02m-hosted (default)` trust-model row
- state that HTTP mode is self-hosted/operator-controlled only
- keep local stdio, package, OCI, CI, security, and repository maintenance unchanged

## Verification
- exact hosted Worker/Container resources were removed from Cloudflare
- `telegram.n24q02m.com` no longer resolves
- README diff check passed

This is documentation parity for the already-completed hosted-runtime dehost; it does not archive the repository or remove self-host support.