### PR TITLE
feat: expose forum topic ID in serialized messages

### DIFF
--- a/src/better_telegram_mcp/backends/user_backend.py
+++ b/src/better_telegram_mcp/backends/user_backend.py
@@ -122,11 +122,24 @@ class UserBackend(TelegramBackend):
         sender_id = None
         if msg.sender_id is not None:
             sender_id = msg.sender_id
+        # Extract forum topic ID if present (Telegram forum/topic feature)
+        # Forum messages have reply_to.forum_topic=True and reply_to.reply_to_top_id
+        # Ordinary replies have reply_to.forum_topic=False (or no reply_to)
+        topic_id = None
+        if hasattr(msg, "reply_to") and msg.reply_to is not None:
+            # Check if this is a forum topic message
+            if getattr(msg.reply_to, "forum_topic", False):
+                # reply_to_top_id is the topic root; reply_to_msg_id is the replied-to message
+                topic_id = getattr(msg.reply_to, "reply_to_top_id", None)
+                # Fallback: if reply_to_top_id is None, use reply_to_msg_id (topic root)
+                if topic_id is None:
+                    topic_id = getattr(msg.reply_to, "reply_to_msg_id", None)
         return {
             "message_id": msg.id,
             "text": msg.text or "",
             "date": str(msg.date) if msg.date else None,
             "sender_id": sender_id,
+            "topic_id": topic_id,
         }
 
     @staticmethod

--- a/tests/test_backends/test_user_backend.py
+++ b/tests/test_backends/test_user_backend.py
@@ -1461,6 +1461,95 @@ class TestSerializeMessage:
         assert result["date"] is None
         assert result["sender_id"] is None
 
+    def test_serialize_message_topic_id_forum_message(self):
+        """Forum topic message should have topic_id from reply_to_top_id."""
+        from types import SimpleNamespace
+
+        from better_telegram_mcp.backends.user_backend import UserBackend
+
+        # Forum message with reply_to_top_id
+        reply_to = SimpleNamespace(
+            forum_topic=True,
+            reply_to_top_id=12345,
+            reply_to_msg_id=67890,  # replied-to message, not topic
+        )
+        msg = SimpleNamespace(
+            id=1,
+            text="test",
+            date=None,
+            sender_id=42,
+            reply_to=reply_to,
+        )
+
+        result = UserBackend._serialize_message(msg)
+
+        assert result["topic_id"] == 12345  # topic root, not replied-to message
+
+    def test_serialize_message_topic_id_forum_fallback(self):
+        """Forum message without reply_to_top_id falls back to reply_to_msg_id."""
+        from types import SimpleNamespace
+
+        from better_telegram_mcp.backends.user_backend import UserBackend
+
+        # Forum message where reply_to_top_id is None (topic root message)
+        reply_to = SimpleNamespace(
+            forum_topic=True,
+            reply_to_top_id=None,
+            reply_to_msg_id=12345,  # topic root when reply_to_top_id is None
+        )
+        msg = SimpleNamespace(
+            id=1,
+            text="test",
+            date=None,
+            sender_id=42,
+            reply_to=reply_to,
+        )
+
+        result = UserBackend._serialize_message(msg)
+
+        assert result["topic_id"] == 12345
+
+    def test_serialize_message_no_topic_for_ordinary_reply(self):
+        """Ordinary reply (forum_topic=False) should have topic_id=None."""
+        from types import SimpleNamespace
+
+        from better_telegram_mcp.backends.user_backend import UserBackend
+
+        # Ordinary reply, not in a forum topic
+        reply_to = SimpleNamespace(
+            forum_topic=False,
+            reply_to_msg_id=999,  # replied-to message, NOT a topic
+        )
+        msg = SimpleNamespace(
+            id=1,
+            text="test",
+            date=None,
+            sender_id=42,
+            reply_to=reply_to,
+        )
+
+        result = UserBackend._serialize_message(msg)
+
+        assert result["topic_id"] is None  # not a forum topic
+
+    def test_serialize_message_no_topic_no_reply(self):
+        """Message without reply_to should have topic_id=None."""
+        from types import SimpleNamespace
+
+        from better_telegram_mcp.backends.user_backend import UserBackend
+
+        msg = SimpleNamespace(
+            id=1,
+            text="test",
+            date=None,
+            sender_id=42,
+            reply_to=None,
+        )
+
+        result = UserBackend._serialize_message(msg)
+
+        assert result["topic_id"] is None
+
     def test_serialize_dialog_no_title(self):
         from better_telegram_mcp.backends.user_backend import UserBackend
 


### PR DESCRIPTION
## Summary

Maintainer integration of #1005 by @evnchn.

- expose Telegram forum `topic_id` in serialized message payloads
- preserve the contributor's exact implementation and authorship
- apply it on current main after the hosted-runtime retirement and password-toggle fixes

## Verification

- 27 focused serialization tests passed during review
- normal repository commit hooks passed on current main

Supersedes #1005 after this integration merges. Stable release remains intentionally out of scope; this change targets the next beta.