### PR TITLE
feat: 🎨 palette: add show/hide toggle for dynamic 2fa password steps

### DIFF
--- a/src/better_telegram_mcp/relay_schema.py
+++ b/src/better_telegram_mcp/relay_schema.py
@@ -143,27 +143,37 @@ STABLE_SUB_ENABLED = True
 
 _PASSWORD_TOGGLE_JS = """<script>
 (function(){
-var i = document.getElementById("field-TELEGRAM_BOT_TOKEN");
-if(!i) return;
-var d = document.createElement("div"); d.style.position = "relative";
-i.parentNode.insertBefore(d, i); d.appendChild(i);
-var b = document.createElement("button"); b.type = "button";
-b.textContent = "SHOW"; b.setAttribute("aria-label", "Show password"); b.setAttribute("aria-pressed", "false");
-b.style.cssText = "position:absolute; right:0.5rem; top:50%; transform:translateY(-50%); background:none; border:none; color:inherit; font-size:0.75rem; cursor:pointer; padding:0.25rem; font-weight:bold;";
-if (i.disabled) { b.disabled = true; b.style.opacity = "0.5"; b.style.cursor = "not-allowed"; }
-d.appendChild(b); i.style.paddingRight = "3.5rem";
-b.addEventListener("click", function() {
-    var pwd = i.type === "password"; i.type = pwd ? "text" : "password";
-    b.textContent = pwd ? "HIDE" : "SHOW"; b.setAttribute("aria-label", pwd ? "Hide password" : "Show password"); b.setAttribute("aria-pressed", pwd ? "true" : "false");
-});
-new MutationObserver(function() {
-    b.disabled = i.disabled;
-    b.style.opacity = i.disabled ? "0.5" : "1";
-    b.style.cursor = i.disabled ? "not-allowed" : "pointer";
-    if(i.type === "password" && b.textContent !== "SHOW") {
-        b.textContent = "SHOW"; b.setAttribute("aria-label", "Show password"); b.setAttribute("aria-pressed", "false");
+function addToggle(i) {
+    if(!i || i.dataset.hasToggle) return;
+    i.dataset.hasToggle = "true";
+    var d = document.createElement("div"); d.style.position = "relative";
+    i.parentNode.insertBefore(d, i); d.appendChild(i);
+    var b = document.createElement("button"); b.type = "button";
+    b.style.cssText = "position:absolute; right:0.5rem; top:50%; transform:translateY(-50%); background:none; border:none; color:inherit; font-size:0.75rem; cursor:pointer; padding:0.25rem; font-weight:bold;";
+    d.appendChild(b);
+    function update(muts) {
+        if(muts) muts.forEach(m => {
+            if(m.attributeName === "data-field" || m.attributeName === "placeholder") {
+                b.textContent = "SHOW"; b.setAttribute("aria-label", "Show password"); b.setAttribute("aria-pressed", "false");
+            }
+        });
+        var isPwd = i.type === "password" || b.textContent === "HIDE";
+        b.style.display = isPwd ? "block" : "none";
+        i.style.paddingRight = isPwd ? "3.5rem" : "";
+        b.disabled = i.disabled; b.style.opacity = i.disabled ? "0.5" : "1"; b.style.cursor = i.disabled ? "not-allowed" : "pointer";
+        if(i.type === "password" && b.textContent !== "SHOW") {
+            b.textContent = "SHOW"; b.setAttribute("aria-label", "Show password"); b.setAttribute("aria-pressed", "false");
+        }
     }
-}).observe(i, {attributes: true, attributeFilter: ["disabled", "type"]});
+    b.addEventListener("click", function() {
+        var pwd = i.type === "password"; i.type = pwd ? "text" : "password";
+        b.textContent = pwd ? "HIDE" : "SHOW"; b.setAttribute("aria-label", pwd ? "Hide password" : "Show password"); b.setAttribute("aria-pressed", pwd ? "true" : "false");
+    });
+    new MutationObserver(update).observe(i, {attributes: true, attributeFilter: ["disabled", "type", "data-field", "placeholder"]});
+    update();
+}
+addToggle(document.getElementById("field-TELEGRAM_BOT_TOKEN"));
+new MutationObserver(() => addToggle(document.getElementById("step-input"))).observe(document.body, {childList: true, subtree: true});
 })();
 </script>"""
 

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.18.0b3"
+version = "4.18.0b6"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
💡 **What**: Refactored the custom JavaScript `_PASSWORD_TOGGLE_JS` in `relay_schema.py` to use a robust `MutationObserver` on `document.body` that automatically injects a "SHOW/HIDE" password toggle into any dynamic `#step-input` fields (such as 2FA prompts).

🎯 **Why**: When users are required to authenticate via MTProto and are prompted for their 2FA password in a dynamic `#step-input` generated by `mcp-core`, the field lacks a visibility toggle. 2FA passwords are often long or complex, and the lack of a toggle leads to errors or frustration when users paste or type without being able to verify.

📸 **Before/After**: Visually, dynamic password prompts now match the primary `TELEGRAM_BOT_TOKEN` field, including a native-looking "SHOW/HIDE" toggle.

♿ **Accessibility**: The injected toggle seamlessly tracks the state of the parent form, disabling itself and setting `opacity: 0.5; cursor: not-allowed` when the input is busy or disabled. `aria-label` and `aria-pressed` states are correctly synchronized, and the toggle gracefully hides if the `#step-input` is used for non-password fields (like text OTPs).

---
*PR created automatically by Jules for task [2929034250556424365](https://jules.google.com/task/2929034250556424365) started by @n24q02m*