### PR TITLE
feat: 🎨 palette: add password toggle to dynamic step inputs

### DIFF
--- a/src/better_telegram_mcp/relay_schema.py
+++ b/src/better_telegram_mcp/relay_schema.py
@@ -143,27 +143,42 @@ STABLE_SUB_ENABLED = True
 
 _PASSWORD_TOGGLE_JS = """<script>
 (function(){
-var i = document.getElementById("field-TELEGRAM_BOT_TOKEN");
-if(!i) return;
-var d = document.createElement("div"); d.style.position = "relative";
-i.parentNode.insertBefore(d, i); d.appendChild(i);
-var b = document.createElement("button"); b.type = "button";
-b.textContent = "SHOW"; b.setAttribute("aria-label", "Show password"); b.setAttribute("aria-pressed", "false");
-b.style.cssText = "position:absolute; right:0.5rem; top:50%; transform:translateY(-50%); background:none; border:none; color:inherit; font-size:0.75rem; cursor:pointer; padding:0.25rem; font-weight:bold;";
-if (i.disabled) { b.disabled = true; b.style.opacity = "0.5"; b.style.cursor = "not-allowed"; }
-d.appendChild(b); i.style.paddingRight = "3.5rem";
-b.addEventListener("click", function() {
-    var pwd = i.type === "password"; i.type = pwd ? "text" : "password";
-    b.textContent = pwd ? "HIDE" : "SHOW"; b.setAttribute("aria-label", pwd ? "Hide password" : "Show password"); b.setAttribute("aria-pressed", pwd ? "true" : "false");
-});
-new MutationObserver(function() {
-    b.disabled = i.disabled;
-    b.style.opacity = i.disabled ? "0.5" : "1";
-    b.style.cursor = i.disabled ? "not-allowed" : "pointer";
-    if(i.type === "password" && b.textContent !== "SHOW") {
-        b.textContent = "SHOW"; b.setAttribute("aria-label", "Show password"); b.setAttribute("aria-pressed", "false");
-    }
-}).observe(i, {attributes: true, attributeFilter: ["disabled", "type"]});
+function attach(i) {
+    if(!i || i.dataset.toggleAttached) return;
+    i.dataset.toggleAttached = "true";
+    var d = document.createElement("div"); d.style.position = "relative";
+    i.parentNode.insertBefore(d, i); d.appendChild(i);
+    var b = document.createElement("button"); b.type = "button";
+    b.textContent = "SHOW"; b.setAttribute("aria-label", "Show password"); b.setAttribute("aria-pressed", "false");
+    b.style.cssText = "position:absolute; right:0.5rem; top:50%; transform:translateY(-50%); background:none; border:none; color:inherit; font-size:0.75rem; cursor:pointer; padding:0.25rem; font-weight:bold;";
+    if (i.disabled) { b.disabled = true; b.style.opacity = "0.5"; b.style.cursor = "not-allowed"; }
+    d.appendChild(b);
+    if (i.type !== "password") { b.style.display = "none"; i.style.paddingRight = ""; }
+    else { i.style.paddingRight = "3.5rem"; }
+    b.addEventListener("click", function() {
+        var pwd = i.type === "password"; i.type = pwd ? "text" : "password";
+        b.textContent = pwd ? "HIDE" : "SHOW"; b.setAttribute("aria-label", pwd ? "Hide password" : "Show password"); b.setAttribute("aria-pressed", pwd ? "true" : "false");
+    });
+    new MutationObserver(function() {
+        b.disabled = i.disabled;
+        b.style.opacity = i.disabled ? "0.5" : "1";
+        b.style.cursor = i.disabled ? "not-allowed" : "pointer";
+        if (i.type !== "password" && b.textContent === "SHOW") { b.style.display = "none"; i.style.paddingRight = ""; }
+        else { b.style.display = "block"; i.style.paddingRight = "3.5rem"; }
+        if (i.type === "password" && b.textContent !== "SHOW") {
+            b.textContent = "SHOW"; b.setAttribute("aria-label", "Show password"); b.setAttribute("aria-pressed", "false");
+        }
+    }).observe(i, {attributes: true, attributeFilter: ["disabled", "type", "placeholder"]});
+}
+attach(document.getElementById("field-TELEGRAM_BOT_TOKEN"));
+new MutationObserver(function(mutations) {
+    mutations.forEach(function(m) {
+        if(m.addedNodes) m.addedNodes.forEach(function(n) {
+            if(n.id === "step-input") attach(n);
+            else if(n.querySelector) { var si = n.querySelector("#step-input"); if(si) attach(si); }
+        });
+    });
+}).observe(document.body, {childList: true, subtree: true});
 })();
 </script>"""
 

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.18.0b3"
+version = "4.18.0b6"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
**💡 What**: Added a global `MutationObserver` and refactored the toggle button code to dynamically attach to any injected `#step-input` fields.
**🎯 Why**: The form uses dynamic async `fetch` flows to inject multi-step prompts (like 2FA passwords). Without dynamic attachment, users had no way to verify their typed 2FA passwords before submission, causing frustration.
**📸 Before/After**: When a `password_required` step is triggered, the field now gracefully features a "SHOW/HIDE" button.
**♿ Accessibility**: Inherited the core attributes (`aria-pressed`, `aria-label`) and synchronization logic from the static implementation, ensuring screen readers receive the same clear feedback on dynamically recycled fields.

---
*PR created automatically by Jules for task [1640458974315648569](https://jules.google.com/task/1640458974315648569) started by @n24q02m*