### PR TITLE
feat: 🛡️ sentinel: enforce size limits on local files in user mode send_media

### DIFF
--- a/src/better_telegram_mcp/backends/user_backend.py
+++ b/src/better_telegram_mcp/backends/user_backend.py
@@ -17,6 +17,7 @@ from telethon.tl.types import Channel, Chat, InputPhoneContact, User
 from ..config import Settings
 from .base import TelegramBackend
 from .security import (
+    SecurityError,
     fetch_url_safely,
     validate_file_path,
     validate_output_dir,
@@ -567,6 +568,10 @@ class UserBackend(TelegramBackend):
             file_to_send = await fetch_url_safely(file_path_or_url.strip())
         else:
             file_to_send = validate_file_path(file_path_or_url)
+            max_size = 50 * 1024 * 1024  # 50MB
+            if file_to_send.stat().st_size > max_size:
+                msg_text = f"File size exceeds maximum allowed ({max_size} bytes)"
+                raise SecurityError(msg_text)
         msg = await client.send_file(chat_id, file_to_send, **kwargs)
         return self._serialize_message(msg)
 

--- a/tests/test_backends/test_user_backend.py
+++ b/tests/test_backends/test_user_backend.py
@@ -1024,6 +1024,11 @@ class TestSendMedia:
         result = await backend.send_media(123, "document", str(f))
 
         assert result["message_id"] == 1
+        from pathlib import Path
+
+        mock_client.send_file.assert_awaited_once_with(
+            123, Path(f).resolve()
+        )
 
     async def test_send_media_file_too_large(
         self, tmp_path, mock_client, mock_client_class

--- a/tests/test_backends/test_user_backend.py
+++ b/tests/test_backends/test_user_backend.py
@@ -1026,9 +1026,7 @@ class TestSendMedia:
         assert result["message_id"] == 1
         from pathlib import Path
 
-        mock_client.send_file.assert_awaited_once_with(
-            123, Path(f).resolve()
-        )
+        mock_client.send_file.assert_awaited_once_with(123, Path(f).resolve())
 
     async def test_send_media_file_too_large(
         self, tmp_path, mock_client, mock_client_class
@@ -1047,7 +1045,9 @@ class TestSendMedia:
 
         with patch("pathlib.Path.stat") as mock_stat:
             mock_stat.return_value.st_size = 50 * 1024 * 1024 + 1
-            with pytest.raises(SecurityError, match="File size exceeds maximum allowed"):
+            with pytest.raises(
+                SecurityError, match="File size exceeds maximum allowed"
+            ):
                 await backend.send_media(123, "document", str(f))
 
 

--- a/tests/test_backends/test_user_backend.py
+++ b/tests/test_backends/test_user_backend.py
@@ -976,13 +976,16 @@ class TestSendMedia:
         backend = UserBackend(settings)
         await backend.connect()
 
-        result = await backend.send_media(123, "voice", "/tmp/voice.ogg")
+        f = tmp_path / "voice.ogg"
+        f.write_text("X")
+
+        result = await backend.send_media(123, "voice", str(f))
 
         assert result["message_id"] == 1
         from pathlib import Path
 
         mock_client.send_file.assert_awaited_once_with(
-            123, Path("/tmp/voice.ogg").resolve(), voice_note=True
+            123, Path(f).resolve(), voice_note=True
         )
 
     async def test_send_video(self, tmp_path, mock_client, mock_client_class):
@@ -994,13 +997,16 @@ class TestSendMedia:
         backend = UserBackend(settings)
         await backend.connect()
 
-        result = await backend.send_media(123, "video", "/tmp/video.mp4")
+        f = tmp_path / "video.mp4"
+        f.write_text("X")
+
+        result = await backend.send_media(123, "video", str(f))
 
         assert result["message_id"] == 1
         from pathlib import Path
 
         mock_client.send_file.assert_awaited_once_with(
-            123, Path("/tmp/video.mp4").resolve(), video_note=False
+            123, Path(f).resolve(), video_note=False
         )
 
     async def test_send_document(self, tmp_path, mock_client, mock_client_class):
@@ -1012,9 +1018,32 @@ class TestSendMedia:
         backend = UserBackend(settings)
         await backend.connect()
 
-        result = await backend.send_media(123, "document", "/tmp/doc.pdf")
+        f = tmp_path / "doc.pdf"
+        f.write_text("X")
+
+        result = await backend.send_media(123, "document", str(f))
 
         assert result["message_id"] == 1
+
+    async def test_send_media_file_too_large(
+        self, tmp_path, mock_client, mock_client_class
+    ):
+        from unittest.mock import patch
+
+        from better_telegram_mcp.backends.security import SecurityError
+        from better_telegram_mcp.backends.user_backend import UserBackend
+
+        settings = _make_settings(tmp_path)
+        backend = UserBackend(settings)
+        await backend.connect()
+
+        f = tmp_path / "huge.pdf"
+        f.write_text("X")
+
+        with patch("pathlib.Path.stat") as mock_stat:
+            mock_stat.return_value.st_size = 50 * 1024 * 1024 + 1
+            with pytest.raises(SecurityError, match="File size exceeds maximum allowed"):
+                await backend.send_media(123, "document", str(f))
 
 
 class TestDownloadMedia:

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ wheels = [
 
 [[package]]
 name = "better-telegram-mcp"
-version = "4.18.0b3"
+version = "4.18.0b6"
 source = { editable = "." }
 dependencies = [
     { name = "cryptg" },


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: `UserBackend.send_media` loads entire local files into memory or processes them unbounded via Telethon, creating an Out-Of-Memory (OOM) or system resource exhaustion DoS vulnerability if a malicious or extremely large file path is supplied.
🎯 **Impact**: A malicious actor could provide a very large valid local file path (bypassing path traversal checks), causing the server process to crash or hang due to memory/CPU exhaustion.
🔧 **Fix**: Enforced a strict `50MB` size limit via `path.stat().st_size` in `UserBackend.send_media` before forwarding the path to the Telethon client, maintaining parity with `BotBackend` limits. Modified existing `test_send_media_file_too_large` in `test_user_backend.py` to capture and test this case.
✅ **Verification**: Run `uv run pytest tests/test_backends/test_user_backend.py` to verify the limit is strictly enforced and raises `SecurityError`.

---
*PR created automatically by Jules for task [16854421456948792249](https://jules.google.com/task/16854421456948792249) started by @n24q02m*