### PR TITLE
feat: 🎨 palette: hide password toggle when field is recycled

### DIFF
--- a/src/better_telegram_mcp/relay_schema.py
+++ b/src/better_telegram_mcp/relay_schema.py
@@ -160,6 +160,9 @@ new MutationObserver(function() {
     b.disabled = i.disabled;
     b.style.opacity = i.disabled ? "0.5" : "1";
     b.style.cursor = i.disabled ? "not-allowed" : "pointer";
+    var isPwd = i.type === "password" || b.textContent === "HIDE";
+    b.style.display = isPwd ? "block" : "none";
+    i.style.paddingRight = isPwd ? "3.5rem" : "";
     if(i.type === "password" && b.textContent !== "SHOW") {
         b.textContent = "SHOW"; b.setAttribute("aria-label", "Show password"); b.setAttribute("aria-pressed", "false");
     }


### PR DESCRIPTION
**What**: Modified the `MutationObserver` in `_PASSWORD_TOGGLE_JS` to conditionally display the password visibility toggle (`SHOW`/`HIDE`) based on whether the input's type is `password` or the button's text is `HIDE`.

**Why**: Reusing DOM containers for dynamic form steps (e.g., recycling the password prompt into an OTP text input) led to desynchronized accessibility states and confusing visuals where a "SHOW" toggle would persist even when the input was already naturally a `text` field (not toggled by the user).

**Before/After**: Before, the "SHOW" button lingered when `mcp-core` updated the form element dynamically. Now, the toggle is hidden (and padding removed) if the input becomes `type="text"` externally.

**Accessibility**: Ensures the visual state and interactive capabilities match the logical purpose of the field. Eliminates a confusing "SHOW" button next to fields that aren't actually passwords.

---
*PR created automatically by Jules for task [2248076162497926789](https://jules.google.com/task/2248076162497926789) started by @n24q02m*