### PR TITLE
feat: 🎨 palette: add disabled state tooltip to password toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -68,3 +68,7 @@
 ## 2024-11-21 - Synchronize ARIA Labels When Reusing DOM Containers
 **Learning:** Reusing DOM containers for dynamic form steps (e.g., OTP or password prompts) can lead to desynchronized accessibility states if all associated attributes are not reset. While visual properties like `textContent` might be reset when re-initializing the view, missing updates to attributes like `aria-label` can leave screen readers announcing stale and confusing states (e.g., a button displaying "Show" but announcing "Hide password").
 **Action:** When dynamically resetting or reusing stateful UI components, ensure that invisible attributes like `aria-label` are explicitly reset alongside their visible counterparts (like `textContent` and `aria-pressed`) to prevent out-of-sync UI states.
+
+## 2025-02-09 - Disabled State Tooltips for Utility Controls
+**Learning:** When utility controls (like a password visibility toggle) are dynamically disabled alongside a main form submission, users relying on screen readers or mouse hover can be confused as to why the control is suddenly unresponsive. Adding a dynamic `title` attribute (e.g., "Disabled during submission") provides immediate, helpful context for the disabled state, improving discoverability.
+**Action:** Always provide explanatory `title` tooltips for auxiliary buttons when their disabled state is tied to a broader async operation (like form submission), and dynamically swap the tooltip text back to the action description when re-enabled.

--- a/src/better_telegram_mcp/relay_schema.py
+++ b/src/better_telegram_mcp/relay_schema.py
@@ -161,6 +161,7 @@ function attach(i) {
         b.style.display = isPwd ? "block" : "none";
         i.style.paddingRight = isPwd ? "3.5rem" : "";
         b.disabled = i.disabled; b.style.opacity = i.disabled ? "0.5" : "1"; b.style.cursor = i.disabled ? "not-allowed" : "pointer";
+        b.title = i.disabled ? "Disabled during submission" : (i.type === "password" ? "Show password" : "Hide password");
         if(i.type === "password" && b.textContent !== "SHOW") {
             b.textContent = "SHOW"; b.setAttribute("aria-label", "Show password"); b.setAttribute("aria-pressed", "false");
         }
@@ -169,6 +170,7 @@ function attach(i) {
     b.addEventListener("click", function() {
         var pwd = i.type === "password"; i.type = pwd ? "text" : "password";
         b.textContent = pwd ? "HIDE" : "SHOW"; b.setAttribute("aria-label", pwd ? "Hide password" : "Show password"); b.setAttribute("aria-pressed", pwd ? "true" : "false");
+        b.title = pwd ? "Hide password" : "Show password";
     });
     new MutationObserver(sync).observe(i, {attributes: true, attributeFilter: ["disabled", "type", "data-field"]});
 }


### PR DESCRIPTION
💡 **What**: Added dynamic `title` tooltips to the password visibility toggle button to explain its disabled state and describe its action.
🎯 **Why**: When the form is submitted, utility controls like the password toggle are disabled. Without a tooltip, it can be confusing why the button became unresponsive.
📸 **Before/After**: Before, the button had no tooltip. Now, it shows "Disabled during submission" when disabled, and "Show password" or "Hide password" when active.
♿ **Accessibility**: Improves accessibility and discoverability by providing explicit context for the disabled state and the current action via the `title` attribute, assisting users relying on mouse hover or specific screen reader configurations.

---
*PR created automatically by Jules for task [5212601104157946766](https://jules.google.com/task/5212601104157946766) started by @n24q02m*