### PR TITLE
fix: repair MCP registry publication

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -312,6 +312,8 @@ jobs:
       - name: Install MCP Publisher
         run: |
           curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+      - name: Validate MCP Registry manifest
+        run: ./mcp-publisher validate server.json
 
       - name: Login to MCP Registry
         run: ./mcp-publisher login github-oidc

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 mcp-name: io.github.n24q02m/better-telegram-mcp
 
-**Telegram for AI agents -- messages, chats, media, and contacts across both bot and full user-account modes.**
+**Telegram for AI agents: messages, chats, media, and contacts in bot and user-account modes.**
 
 <!-- Badge Row 1: Status -->
 [![CI](https://github.com/n24q02m/better-telegram-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/n24q02m/better-telegram-mcp/actions/workflows/ci.yml)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     # 2.15 warns while constructing MCP SDK Settings; lift after upstream rebuilds its model.
     "pydantic-settings>=2.14.2,<2.15",
     "loguru>=0.7.3",
-    "n24q02m-mcp-core>=1.23.0,<2",
+    "n24q02m-mcp-core>=1.23.1,<2",
     "cryptography>=50.0.0",
     "starlette>=1.6.0",
     "uvicorn>=0.52.4",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.n24q02m/better-telegram-mcp",
   "title": "Better Telegram MCP",
-  "description": "Telegram for AI agents -- messages, chats, media, and contacts across both bot and full user-account modes.",
+  "description": "Telegram for AI agents: messages, chats, media, and contacts in bot and user-account modes.",
   "repository": {
     "url": "https://github.com/n24q02m/better-telegram-mcp.git",
     "source": "github"

--- a/tests/test_server_metadata.py
+++ b/tests/test_server_metadata.py
@@ -1,0 +1,16 @@
+"""Regression tests for MCP Registry server metadata."""
+
+import json
+from pathlib import Path
+
+MCP_REGISTRY_MAX_DESCRIPTION_LENGTH = 100
+SERVER_MANIFEST = Path(__file__).resolve().parents[1] / "server.json"
+
+
+def test_server_description_respects_mcp_registry_limit() -> None:
+    """The published manifest must satisfy the registry's 100-character limit."""
+    manifest = json.loads(SERVER_MANIFEST.read_text(encoding="utf-8"))
+    description = manifest["description"]
+
+    assert isinstance(description, str)
+    assert 0 < len(description) <= MCP_REGISTRY_MAX_DESCRIPTION_LENGTH

--- a/uv.lock
+++ b/uv.lock
@@ -112,7 +112,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.28.1,<1.29" },
-    { name = "n24q02m-mcp-core", specifier = ">=1.23.0,<2" },
+    { name = "n24q02m-mcp-core", specifier = ">=1.23.1,<2" },
     { name = "pydantic", specifier = ">=2.13.4,<2.14" },
     { name = "pydantic-settings", specifier = ">=2.14.2,<2.15" },
     { name = "starlette", specifier = ">=1.6.0" },


### PR DESCRIPTION
## Problem
Stable run 33252965819 published package artifacts but MCP Registry rejected `server.json`: `description` exceeded the official 100-character limit. The downstream marketplace sync was skipped.

## Fix
- shorten and synchronize the canonical registry/README description
- validate `server.json` with the official `mcp-publisher` before login/publish
- add a regression test for the official description bound
- bump `n24q02m-mcp-core` to stable 1.23.1 and regenerate `uv.lock`

## Verification
- `uv run pytest -q tests/test_server_metadata.py` — 1 passed
- README sync verifier — 6 PASS
- `uv lock --check` — passed
- `git diff --check` — clean

Forward-only remediation; no published tag is rewritten.