### PR TITLE
feat: 🎨 palette: add dual-channel validation feedback (shake animation)

### DIFF
--- a/src/better_telegram_mcp/relay_schema.py
+++ b/src/better_telegram_mcp/relay_schema.py
@@ -241,4 +241,6 @@ def render_telegram_form(
         initial_tab=initial_tab,
         include_username_field=STABLE_SUB_ENABLED,
     )
-    return html.replace("</body>", _PASSWORD_TOGGLE_JS + "\n" + _SHAKE_ANIMATION_JS + "\n</body>")
+    return html.replace(
+        "</body>", _PASSWORD_TOGGLE_JS + "\n" + _SHAKE_ANIMATION_JS + "\n</body>"
+    )

--- a/src/better_telegram_mcp/relay_schema.py
+++ b/src/better_telegram_mcp/relay_schema.py
@@ -141,6 +141,24 @@ TELEGRAM_TABS: list[dict[str, Any]] = [
 # Both read this one constant so they cannot drift apart.
 STABLE_SUB_ENABLED = True
 
+_SHAKE_ANIMATION_JS = """<script>
+(function(){
+var m = window.matchMedia("(prefers-reduced-motion: reduce)");
+new MutationObserver(function(muts) {
+    if(m.matches) return;
+    muts.forEach(function(mut) {
+        var el = mut.target;
+        if(mut.attributeName === "aria-invalid" && el.getAttribute("aria-invalid") === "true" && el.classList.contains("field-input")) {
+            el.animate([
+                {transform:"translateX(0)"},{transform:"translateX(-4px)"},{transform:"translateX(4px)"},{transform:"translateX(-4px)"},{transform:"translateX(4px)"},{transform:"translateX(0)"}
+            ], {duration: 400, easing: "ease-in-out"});
+        }
+    });
+}).observe(document.body, {attributes: true, subtree: true, attributeFilter: ["aria-invalid"]});
+})();
+</script>"""
+
+
 _PASSWORD_TOGGLE_JS = """<script>
 (function(){
 function attach(i) {
@@ -223,4 +241,4 @@ def render_telegram_form(
         initial_tab=initial_tab,
         include_username_field=STABLE_SUB_ENABLED,
     )
-    return html.replace("</body>", _PASSWORD_TOGGLE_JS + "\n</body>")
+    return html.replace("</body>", _PASSWORD_TOGGLE_JS + "\n" + _SHAKE_ANIMATION_JS + "\n</body>")


### PR DESCRIPTION
### 💡 What
Adds a subtle JavaScript-driven shake animation for dynamically invalid form fields (`aria-invalid="true"`) in the connection form, while respecting OS-level reduced motion preferences.

### 🎯 Why
Currently, form fields only show a red border when validation fails (e.g., submitting empty required fields). This relies exclusively on color to convey information, which can be easily missed by users with color vision deficiencies. Providing a secondary channel of feedback (motion) improves error discoverability and overall user experience. 

### 📸 Before/After
**Before:** Clicking "Connect" with an empty "Bot Token" field only changes the border color to red.
**After:** Clicking "Connect" with an empty "Bot Token" field changes the border color to red *and* applies a brief, subtle horizontal shake animation to draw attention to the specific field that requires correction.

### ♿ Accessibility
*   **Dual-Channel Feedback:** Users no longer have to rely solely on color (`#f87171`) to identify which input triggered the validation error.
*   **Prefers-Reduced-Motion:** The JavaScript explicitly checks `window.matchMedia('(prefers-reduced-motion: reduce)').matches` before executing the Web Animations API sequence. If a user has vestibular disorders or requests reduced motion via their OS settings, the animation is seamlessly bypassed, leaving only the color change and standard ARIA live region announcements.

---
*PR created automatically by Jules for task [331769063869124280](https://jules.google.com/task/331769063869124280) started by @n24q02m*