### PR TITLE
feat: 🎨 palette: server error validation feedback

### DIFF
--- a/src/better_telegram_mcp/relay_schema.py
+++ b/src/better_telegram_mcp/relay_schema.py
@@ -159,6 +159,29 @@ new MutationObserver(function(muts) {
 </script>"""
 
 
+_SERVER_ERROR_JS = """<script>
+(function(){
+var sb = document.getElementById("status-box");
+if(!sb) return;
+new MutationObserver(function() {
+    if(sb.style.display !== "none" && sb.classList.contains("error")) {
+        var active = document.querySelector(".tab-panel.active");
+        if(active) {
+            var inps = active.querySelectorAll(".field-input");
+            if(inps.length > 0) {
+                var i = inps[0];
+                if(i.getAttribute("aria-invalid") !== "true") {
+                    i.setAttribute("aria-invalid", "true");
+                    i.setAttribute("aria-errormessage", "status-box");
+                    i.focus();
+                }
+            }
+        }
+    }
+}).observe(sb, {attributes: true, attributeFilter: ["style", "class"]});
+})();
+</script>"""
+
 _PASSWORD_TOGGLE_JS = """<script>
 (function(){
 function attach(i) {
@@ -242,5 +265,5 @@ def render_telegram_form(
         include_username_field=STABLE_SUB_ENABLED,
     )
     return html.replace(
-        "</body>", _PASSWORD_TOGGLE_JS + "\n" + _SHAKE_ANIMATION_JS + "\n</body>"
+        "</body>", _PASSWORD_TOGGLE_JS + "\n" + _SHAKE_ANIMATION_JS + "\n" + _SERVER_ERROR_JS + "\n</body>"
     )

--- a/src/better_telegram_mcp/relay_schema.py
+++ b/src/better_telegram_mcp/relay_schema.py
@@ -265,5 +265,11 @@ def render_telegram_form(
         include_username_field=STABLE_SUB_ENABLED,
     )
     return html.replace(
-        "</body>", _PASSWORD_TOGGLE_JS + "\n" + _SHAKE_ANIMATION_JS + "\n" + _SERVER_ERROR_JS + "\n</body>"
+        "</body>",
+        _PASSWORD_TOGGLE_JS
+        + "\n"
+        + _SHAKE_ANIMATION_JS
+        + "\n"
+        + _SERVER_ERROR_JS
+        + "\n</body>",
     )


### PR DESCRIPTION
💡 **What**: Added `_SERVER_ERROR_JS` to `relay_schema.py` to observe `#status-box` and apply `aria-invalid="true"`, `aria-errormessage`, and keyboard focus to the active tab's input when a server or network error occurs during form submission.

🎯 **Why**: Previously, client-side validation correctly applied dual-channel feedback (color + shake animation) via `aria-invalid="true"`, but server-side and network errors simply showed a text error and sometimes focused the input without styling it. This inconsistency meant users bypassing client validation or hitting server errors didn't receive robust accessibility feedback.

📸 **Before/After**: 
- **Before**: Server errors simply populated `#status-box` text. No red border or shake animation was triggered for the input.
- **After**: Server errors trigger the same `aria-invalid="true"` attribute on the `.field-input`, which automatically triggers the existing CSS red borders and `@keyframes shake` animations, followed by an immediate `.focus()`.

♿ **Accessibility**: Implements consistent dual-channel validation feedback (color + motion) for server-side errors, ensuring screen reader announcements (`aria-invalid`, `aria-errormessage`) and keyboard focus are properly synchronized with network failures as outlined in `.jules/palette.md`.

---
*PR created automatically by Jules for task [3532114031733653558](https://jules.google.com/task/3532114031733653558) started by @n24q02m*