### PR TITLE
feat: 🎨 palette: dual-channel validation for server errors

### DIFF
--- a/src/better_telegram_mcp/relay_schema.py
+++ b/src/better_telegram_mcp/relay_schema.py
@@ -159,6 +159,29 @@ new MutationObserver(function(muts) {
 </script>"""
 
 
+_SERVER_ERROR_VALIDATION_JS = """<script>
+(function(){
+var sb = document.getElementById("status-box");
+if(!sb) return;
+new MutationObserver(function(muts) {
+    muts.forEach(function(mut) {
+        if(sb.classList.contains("error") && sb.style.display !== "none") {
+            var p = document.querySelector(".tab-panel.active");
+            if(p) {
+                var i = p.querySelector(".field-input");
+                if(i && i.getAttribute("aria-invalid") !== "true") {
+                    i.setAttribute("aria-invalid", "true");
+                    i.setAttribute("aria-errormessage", "status-box");
+                    i.focus();
+                }
+            }
+        }
+    });
+}).observe(sb, {attributes: true, attributeFilter: ["class", "style"]});
+})();
+</script>"""
+
+
 _PASSWORD_TOGGLE_JS = """<script>
 (function(){
 function attach(i) {
@@ -242,5 +265,5 @@ def render_telegram_form(
         include_username_field=STABLE_SUB_ENABLED,
     )
     return html.replace(
-        "</body>", _PASSWORD_TOGGLE_JS + "\n" + _SHAKE_ANIMATION_JS + "\n</body>"
+        "</body>", _PASSWORD_TOGGLE_JS + "\n" + _SHAKE_ANIMATION_JS + "\n" + _SERVER_ERROR_VALIDATION_JS + "\n</body>"
     )

--- a/src/better_telegram_mcp/relay_schema.py
+++ b/src/better_telegram_mcp/relay_schema.py
@@ -265,5 +265,11 @@ def render_telegram_form(
         include_username_field=STABLE_SUB_ENABLED,
     )
     return html.replace(
-        "</body>", _PASSWORD_TOGGLE_JS + "\n" + _SHAKE_ANIMATION_JS + "\n" + _SERVER_ERROR_VALIDATION_JS + "\n</body>"
+        "</body>",
+        _PASSWORD_TOGGLE_JS
+        + "\n"
+        + _SHAKE_ANIMATION_JS
+        + "\n"
+        + _SERVER_ERROR_VALIDATION_JS
+        + "\n</body>",
     )


### PR DESCRIPTION
**What:** Adds dual-channel validation feedback (color + shake animation) and focus management to the credential form when server-side or network errors occur.

**Why:** Previously, client-side validation correctly applied dual-channel feedback via `aria-invalid="true"`. However, server-side and network errors simply showed a text error, which was inconsistent and lacked robust accessibility feedback. Users who hit a server error did not get the same clear focus and error state styling as those who hit a local validation error.

**Before/After:**
Before: Server errors only displayed text in the `#status-box`. The input remained unfocused and did not change visually.
After: Server errors now also set `aria-invalid="true"` on the relevant input, triggering the existing color/shake animation, and automatically focus the input so users can immediately correct it.

**Accessibility:**
- Ensures consistent use of `aria-invalid="true"` and `aria-errormessage="status-box"` across both client and server errors.
- Improves keyboard and screen reader accessibility by explicitly returning focus to the invalid field when a server error is returned.
- Complies with dual-channel feedback guidelines by triggering the existing accessible shake animation (which respects `prefers-reduced-motion`) alongside the error text.

---
*PR created automatically by Jules for task [7584462208504332510](https://jules.google.com/task/7584462208504332510) started by @n24q02m*