### PR TITLE
feat: ⚡ bolt: o(1) existence checks for pending otp store

### DIFF
--- a/src/better_telegram_mcp/auth/pending_otp_store.py
+++ b/src/better_telegram_mcp/auth/pending_otp_store.py
@@ -74,6 +74,10 @@ class PendingOtpStore:
     def _save_index(self, subs: list[str]) -> None:
         self._index_store().save({"subs": subs})
 
+    def has_any(self) -> bool:
+        """Check whether the session index contains any saved pending OTPs."""
+        return bool(self._load_index())
+
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------

--- a/src/better_telegram_mcp/auth/telegram_auth_provider.py
+++ b/src/better_telegram_mcp/auth/telegram_auth_provider.py
@@ -424,7 +424,15 @@ class TelegramAuthProvider:
         removed = 0
         now = time.time()
 
-        if self._store.has_any():
+        has_sessions = self._store.has_any()
+        has_pending_kv = (
+            self._pending_store is not None and self._pending_store.has_any()
+        )
+
+        if not has_sessions and not self._pending_otps and not has_pending_kv:
+            return 0
+
+        if has_sessions:
             sessions = self._store.load_all()
             to_revoke = [
                 bearer


### PR DESCRIPTION
💡 **What**: Added an O(1) `has_any()` method to `PendingOtpStore` and optimized early returns in `TelegramAuthProvider.cleanup_expired`.
🎯 **Why**: When cleaning up expired sessions/OTPs periodically, running the cleanup tasks is unnecessary when the stores are completely empty. Avoid redundant IO checks for `_store.has_any()`.
📊 **Impact**: Reduces CPU and I/O overhead to O(1) for the common case where there are no pending OTPs or sessions to clean up, avoiding unnecessary tasks.
🔬 **Measurement**: Verify by running `pytest` and observing faster completion for idle cleanup tasks, or profiling CPU usage during idle periods when no users are active.

---
*PR created automatically by Jules for task [15558420840930274463](https://jules.google.com/task/15558420840930274463) started by @n24q02m*