### PR TITLE
feat: 🎨 palette: add color-scheme meta tag to credential form

### DIFF
--- a/src/better_telegram_mcp/relay_schema.py
+++ b/src/better_telegram_mcp/relay_schema.py
@@ -264,6 +264,7 @@ def render_telegram_form(
         initial_tab=initial_tab,
         include_username_field=STABLE_SUB_ENABLED,
     )
+    html = html.replace("<head>", '<head>\n    <meta name="color-scheme" content="dark" />')
     return html.replace(
         "</body>",
         _PASSWORD_TOGGLE_JS

--- a/src/better_telegram_mcp/relay_schema.py
+++ b/src/better_telegram_mcp/relay_schema.py
@@ -264,7 +264,9 @@ def render_telegram_form(
         initial_tab=initial_tab,
         include_username_field=STABLE_SUB_ENABLED,
     )
-    html = html.replace("<head>", '<head>\n    <meta name="color-scheme" content="dark" />')
+    html = html.replace(
+        "<head>", '<head>\n    <meta name="color-scheme" content="dark" />'
+    )
     return html.replace(
         "</body>",
         _PASSWORD_TOGGLE_JS


### PR DESCRIPTION
What: Added `<meta name="color-scheme" content="dark">` to the HTML head of the rendered Telegram credential form.
Why: Ensures that native browser elements (like scrollbars and autofill dropdowns) correctly adapt to the dark aesthetic defined by the page's styling, improving visual consistency and accessibility in dark mode.
Accessibility: Helps prevent blinding light mode defaults for native UI elements within a dark-themed page.

---
*PR created automatically by Jules for task [7267025083585977344](https://jules.google.com/task/7267025083585977344) started by @n24q02m*