### PR TITLE
feat: 🎨 palette: add color-scheme meta tag for dark theme consistency

### DIFF
--- a/src/better_telegram_mcp/relay_schema.py
+++ b/src/better_telegram_mcp/relay_schema.py
@@ -264,6 +264,7 @@ def render_telegram_form(
         initial_tab=initial_tab,
         include_username_field=STABLE_SUB_ENABLED,
     )
+    html = html.replace("<head>", "<head>\n    <meta name=\"color-scheme\" content=\"dark\">")
     return html.replace(
         "</body>",
         _PASSWORD_TOGGLE_JS

--- a/src/better_telegram_mcp/relay_schema.py
+++ b/src/better_telegram_mcp/relay_schema.py
@@ -264,7 +264,9 @@ def render_telegram_form(
         initial_tab=initial_tab,
         include_username_field=STABLE_SUB_ENABLED,
     )
-    html = html.replace("<head>", "<head>\n    <meta name=\"color-scheme\" content=\"dark\">")
+    html = html.replace(
+        "<head>", '<head>\n    <meta name="color-scheme" content="dark">'
+    )
     return html.replace(
         "</body>",
         _PASSWORD_TOGGLE_JS


### PR DESCRIPTION
**💡 What:** Added the `<meta name="color-scheme" content="dark">` tag to the `<head>` of the Telegram MCP credential form rendered by `mcp-core`.
**🎯 Why:** The form uses a custom dark theme (`#0f0f0f` background), but without explicitly telling the browser the color scheme is dark, native interactive elements like scrollbars, autofill dropdowns, and date pickers fall back to the operating system's default or light mode, which creates a jarring user experience.
**📸 Before/After:** Native browser elements will now align with the dark aesthetic instead of flashing light colors against the dark background.
**♿ Accessibility:** Maintains contrast and visual consistency across the entire UI surface, including native browser components outside the direct DOM styling control.

---
*PR created automatically by Jules for task [13183387726110275845](https://jules.google.com/task/13183387726110275845) started by @n24q02m*