### PR TITLE
feat: 🎨 palette: add light dark color scheme meta tag

### DIFF
--- a/src/better_telegram_mcp/relay_schema.py
+++ b/src/better_telegram_mcp/relay_schema.py
@@ -265,6 +265,9 @@ def render_telegram_form(
         include_username_field=STABLE_SUB_ENABLED,
     )
     return html.replace(
+        "<head>",
+        '<head>\n    <meta name="color-scheme" content="light dark">',
+    ).replace(
         "</body>",
         _PASSWORD_TOGGLE_JS
         + "\n"

--- a/tests/test_relay_schema.py
+++ b/tests/test_relay_schema.py
@@ -12,6 +12,12 @@ def test_render_telegram_form_includes_toggle():
     assert "field-TELEGRAM_BOT_TOKEN" in html
 
 
+def test_render_telegram_form_includes_color_scheme():
+    """Ensure the color-scheme meta tag is injected into the head."""
+    html = render_telegram_form(RELAY_SCHEMA, "/submit")
+    assert '<meta name="color-scheme" content="light dark">' in html
+
+
 def test_relay_schema_structure():
     """Flat schema: server metadata + fields array covering both modes.
 


### PR DESCRIPTION
- **What:** Injects `<meta name="color-scheme" content="light dark">` into the head of the HTML credential form.
- **Why:** The existing CSS explicitly declares `:root { color-scheme: light dark; }` and contains a `@media (prefers-color-scheme: light)` block. However, without the explicit `meta` tag in the `<head>`, native browser UI elements (like form autofill backgrounds, default tooltips, and scrollbars) might not correctly synchronize with the document's dark mode defaults or light mode media queries, depending on the user's OS and browser configurations.
- **Before/After:** Before, the browser could default native elements to light mode even if the dark theme was active, leading to jarring contrast issues (e.g., a white autofill dropdown on a black background). After, native UI elements explicitly adhere to the `light dark` color scheme matching the app's CSS.
- **Accessibility:** Ensures visual consistency across the entire UI surface, including native browser components, which prevents potentially inaccessible contrast ratios in autofill popups or scrollbars.

---
*PR created automatically by Jules for task [12185310253033075446](https://jules.google.com/task/12185310253033075446) started by @n24q02m*