### PR TITLE
feat: 🎨 palette: add color-scheme meta tag for native element theme adaptation

### DIFF
--- a/src/better_telegram_mcp/relay_schema.py
+++ b/src/better_telegram_mcp/relay_schema.py
@@ -264,7 +264,9 @@ def render_telegram_form(
         initial_tab=initial_tab,
         include_username_field=STABLE_SUB_ENABLED,
     )
-    html = html.replace("<head>", "<head>\n    <meta name=\"color-scheme\" content=\"light dark\" />")
+    html = html.replace(
+        "<head>", '<head>\n    <meta name="color-scheme" content="light dark" />'
+    )
     return html.replace(
         "</body>",
         _PASSWORD_TOGGLE_JS

--- a/src/better_telegram_mcp/relay_schema.py
+++ b/src/better_telegram_mcp/relay_schema.py
@@ -264,6 +264,7 @@ def render_telegram_form(
         initial_tab=initial_tab,
         include_username_field=STABLE_SUB_ENABLED,
     )
+    html = html.replace("<head>", "<head>\n    <meta name=\"color-scheme\" content=\"light dark\" />")
     return html.replace(
         "</body>",
         _PASSWORD_TOGGLE_JS


### PR DESCRIPTION
💡 **What:** Added `<meta name="color-scheme" content="light dark" />` to the `<head>` of the HTML template output.
🎯 **Why:** To ensure that native browser UI elements (such as scrollbars, autofill dropdowns, and default backgrounds) correctly adapt to the dark aesthetic when requested by the OS, instead of jarringly defaulting to a light mode appearance in dark mode.
📸 **Before/After:** The structure of the head tag is modified. Visually, the core light mode layout does not change, but dark mode OS-level scrollbars will render correctly.
♿ **Accessibility:** Enhances the dark-mode aesthetic compatibility by correctly communicating the document's supported color schemes to the browser engine, preventing accessibility issues stemming from high-contrast clashes between dark-themed CSS and default light-themed OS elements.

---
*PR created automatically by Jules for task [17908635299708436274](https://jules.google.com/task/17908635299708436274) started by @n24q02m*