### PR TITLE
feat: harden Telegram auth cleanup and relay form

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,21 @@ mcp-name: io.github.n24q02m/better-telegram-mcp
 
 ## Status
 
-Two clean transports: **stdio** (default, local single-user mode) and **HTTP** (bot + user mode, browser relay setup, optional multi-user). No daemon-bridge layer and no auto-spawn from stdio. See [Modes overview](https://mcp.n24q02m.com/get-started/modes-overview/) for the full transport model.
+The executable defaults to **stdio** for local single-user operation. HTTP is
+opted into with `--http`, `MCP_TRANSPORT=http`, or `TRANSPORT_MODE=http`; HTTP
+is the deployment mode for browser relay setup and optional multi-user access.
+The canonical stack mode matrix names **HTTP remote relay** as the deployed
+Telegram default, so changing the executable default requires a separate
+transport-contract decision and migration. This repository does not silently
+claim those two defaults are already reconciled.
 
-Sister MCP servers from the same author are listed in the [collapsible section above](#better-telegram-mcp) -- they share this architecture, so install patterns transfer.
+There are no daemon-bridge layers and no auto-spawn from stdio. See [Modes
+overview](https://mcp.n24q02m.com/get-started/modes-overview/) for the full
+transport model.
+
+Sister MCP servers from the same author are listed in the [collapsible section
+above](#better-telegram-mcp) -- they share this architecture, so install
+patterns transfer.
 
 ## Install
 

--- a/docs/HANDOVER.md
+++ b/docs/HANDOVER.md
@@ -1,0 +1,68 @@
+# Better Telegram MCP Handover
+
+## Current product
+
+Better Telegram MCP exposes Telegram messaging, chat, media, and contact operations through MCP. It supports Bot API and MTProto user-account modes, local stdio operation, and HTTP relay setup for self-hosted multi-user deployments.
+
+The public contract is defined by the repository README, `server.json`, package metadata, and the documented MCP tools. The credential form is rendered through the shared MCP core renderer; Telegram adds its Bot/User tabs and accessibility enhancements without maintaining a second form renderer.
+
+## Build and verify
+
+- Python: 3.13
+- Install: `uv sync --group dev --no-sources`
+
+- Lint: `uv run --no-sync ruff check .`
+- Format: `uv run --no-sync ruff format --check .`
+- Types: `uv run --no-sync ty check`
+- Tests: `uv run --no-sync pytest tests/`
+- Worker tests: `npm ci`, then `npm run test:worker`
+- Worker types: `npm run type-check`
+
+Integration, live, full, and end-to-end tests require Telegram credentials and an approved test account. A representative protocol check must call a domain operation such as listing chats or updates; configuration status alone is only a handshake.
+
+## Runtime and data boundaries
+
+Bot mode uses `TELEGRAM_BOT_TOKEN`. User mode uses the documented phone/OTP flow and stores the Telethon session in the configured data directory. HTTP deployments require the documented transport, public URL, and OAuth/relay settings. Remote credential state must remain isolated per authenticated subject.
+
+Pending OTP metadata is indexed by subject and bearer. The index supports an O(1) empty-state check; cleanup still applies the five-minute expiry policy and removes stale entries without scanning when the index is empty.
+
+Do not put credentials, OTPs, session files, or raw protocol transcripts in the repository. Do not use external infrastructure as a source of truth for local development or verification.
+
+## Transport-contract reconciliation
+
+The executable currently defaults to local stdio; HTTP is explicit through
+`--http`, `MCP_TRANSPORT=http`, or `TRANSPORT_MODE=http`. The canonical stack
+mode matrix names `http remote relay` as Telegram's deployed default. This is
+an explicit source-versus-canonical contract discrepancy, not a documentation
+claim of equivalence. Main must decide whether to migrate the executable
+default, update the canonical matrix, or retain separate local and deployed
+defaults before closing the global docs item.
+
+## Recent source decisions
+
+- Added the `color-scheme: light dark` form metadata so native browser controls follow the page's supported themes.
+- Added indexed pending-OTP existence checks and an early return in auth cleanup for the empty state.
+- Upgraded the Worker test dependency to Vitest 5 while retaining the repository's npm lockfile workflow.
+- Consolidated duplicate palette proposals into the single form metadata implementation. The view-transition proposal was not adopted because it added a second lockfile and animation behavior without a product acceptance requirement.
+
+## In-flight and release notes
+
+Source changes require repository-native checks and CI readback before merge. BETA/package publication and live protocol evidence are separate from source merge. Stable promotion is a separate release decision and is not implied by this handover.
+
+Rollback is the normal reviewed revert of the source commit and package dependency update. Preserve the prior lockfile and source revision in version control; do not delete local credential or session data as part of a code rollback.
+
+## Week-one operator checklist
+
+1. Confirm the intended transport and credential mode.
+2. Install with the documented `uv` and `npm` commands.
+3. Run lint, type, Python tests, Worker tests, and Worker type checks.
+4. Exercise one representative read-only Telegram domain operation with approved credentials.
+5. Confirm per-subject credential isolation and pending-OTP expiry behavior.
+6. Review the exact CI run and artifact identity before using a BETA package.
+
+## Triage
+
+- Form theme mismatch: inspect the rendered `<head>` and the shared renderer version.
+- OTP cleanup regression: inspect the shared pending-OTP index and run the auth-store tests with an in-memory backend.
+- Worker dependency mismatch: remove `node_modules`, run `npm ci`, and rerun the Worker tests; never edit the lockfile manually.
+- Authentication failures: distinguish missing credentials, malformed documented credential input, and provider rejection before rotating anything.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
         "@cloudflare/containers": "^0.3.7",
         "@cloudflare/workers-types": "^5.20260828.1",
         "typescript": "^7.0.2",
-        "vitest": "^4.1.11",
+        "vitest": "^5.0.0",
         "wrangler": "^4.127.1"
       }
     },
@@ -1213,6 +1213,7 @@
       "integrity": "sha512-Nm4s/jB+4FpFsPhWGEC4h7rzksesmtnMXomo6rCMcg/b8zLQuOziRgkCS1fxDCXOlJB/6Q8oABOZ/OP6RIPj9A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/oxc-project"
       }
@@ -1259,6 +1260,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1276,6 +1278,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1293,6 +1296,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1310,6 +1314,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1327,6 +1332,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1344,6 +1350,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1364,6 +1371,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1384,6 +1392,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1404,6 +1413,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1424,6 +1434,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1444,6 +1455,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1464,6 +1476,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1481,6 +1494,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1498,6 +1512,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1515,6 +1530,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1524,7 +1540,8 @@
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@sindresorhus/is": {
       "version": "7.2.0",
@@ -1545,13 +1562,6 @@
       "integrity": "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==",
       "dev": true,
       "license": "CC0-1.0"
-    },
-    "node_modules/@standard-schema/spec": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
-      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1918,34 +1928,17 @@
         "node": ">=16.20.0"
       }
     },
-    "node_modules/@vitest/expect": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
-      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@standard-schema/spec": "^1.1.0",
-        "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.11",
-        "@vitest/utils": "4.1.11",
-        "chai": "^6.2.2",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
-      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-5.0.0.tgz",
+      "integrity": "sha512-66PGTMIiVJP3t4a5yxU9qPtf7MdTBs8jmToMvy+HVflB3Yy13WJZTtPePdvU+wjRV02SKK5doLbSA6o9pwOmiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.11",
+        "@jridgewell/trace-mapping": "0.3.31",
+        "@vitest/spy": "5.0.0",
         "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.21"
+        "magic-string": "^1.2.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -1963,70 +1956,23 @@
         }
       }
     },
-    "node_modules/@vitest/pretty-format": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
-      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
+    "node_modules/@vitest/mocker/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/runner": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
-      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/utils": "4.1.11",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/snapshot": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
-      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.11",
-        "@vitest/utils": "4.1.11",
-        "magic-string": "^0.30.21",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
-      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-5.0.0.tgz",
+      "integrity": "sha512-uy+luWBAPw9XfthoHi5AkfHUnuPYEESjl0p/r+meoBnU8bxg5GDQ3Ey8MjcJ6sqahkL4PFyrvfMJJBw7LbU06g==",
       "dev": true,
       "license": "MIT",
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/utils": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
-      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.11",
-        "convert-source-map": "^2.0.0",
-        "tinyrainbow": "^3.1.0"
-      },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
@@ -2057,13 +2003,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/convert-source-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "1.1.1",
@@ -2217,6 +2156,7 @@
       "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
       "dev": true,
       "license": "MPL-2.0",
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -2254,6 +2194,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -2275,6 +2216,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -2296,6 +2238,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -2317,6 +2260,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -2338,6 +2282,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -2362,6 +2307,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -2386,6 +2332,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -2410,6 +2357,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -2434,6 +2382,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -2455,6 +2404,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -2476,6 +2426,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -2485,9 +2436,9 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.21",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
-      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
+      "integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2524,6 +2475,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -2564,7 +2516,8 @@
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/picomatch": {
       "version": "4.0.7",
@@ -2599,6 +2552,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.18",
         "picocolors": "^1.1.1",
@@ -2614,6 +2568,7 @@
       "integrity": "sha512-g0EtLvBjTUB7jhyV0S/TCup3v/XSVl45vUIGbOGU4QPiyjTenCe4mKuFvW9fEgYmS2Fo42AUssRmNuMziXdrig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.148.0",
         "@rolldown/pluginutils": "^1.0.0"
@@ -2713,6 +2668,7 @@
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2745,16 +2701,19 @@
       }
     },
     "node_modules/tinybench": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
-      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-6.1.4.tgz",
+      "integrity": "sha512-9APumHG7r4yOk4X4WlkmE71aZcv1gvin1czO3OQ1U9iJcFA5Ja/ygyb0vPOVHTthFozUYs8CLoLUlM8grb2lTQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/tinyexec": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.1.tgz",
-      "integrity": "sha512-GCvB3aoys96IuDFBMcTB46JOR6mdMtAToqwiW8JlWhsoh1mhHi/xn9ss/Dg7N555GiJyEt2qzoG/NHCwM6h1EA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2776,16 +2735,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/tinyrainbow": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
-      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {
@@ -2857,6 +2806,7 @@
       "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",
@@ -2930,38 +2880,31 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
-      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-5.0.0.tgz",
+      "integrity": "sha512-gpsMNoRhMjMktVxPtstOH4/PJuPyovVaMDr4oDilXaGH1EcqM2OE96SoHT2VIQ6fTGtTjqmHDrEu2X9RQiXf8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.11",
-        "@vitest/mocker": "4.1.11",
-        "@vitest/pretty-format": "4.1.11",
-        "@vitest/runner": "4.1.11",
-        "@vitest/snapshot": "4.1.11",
-        "@vitest/spy": "4.1.11",
-        "@vitest/utils": "4.1.11",
-        "es-module-lexer": "^2.0.0",
-        "expect-type": "^1.3.0",
-        "magic-string": "^0.30.21",
-        "obug": "^2.1.1",
-        "pathe": "^2.0.3",
-        "picomatch": "^4.0.3",
-        "std-env": "^4.0.0-rc.1",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^1.0.2",
-        "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.1.0",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/mocker": "5.0.0",
+        "chai": "^6.2.2",
+        "es-module-lexer": "^2.3.2",
+        "expect-type": "^1.4.0",
+        "magic-string": "^1.2.3",
+        "obug": "^2.1.4",
+        "picomatch": "^4.0.7",
+        "std-env": "^4.2.0",
+        "tinybench": "6.1.4",
+        "tinyexec": "1.3.0",
+        "tinyglobby": "^0.2.17",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
         "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+        "node": "^22.12.0 || ^24.0.0 || >=26.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -2969,16 +2912,16 @@
       "peerDependencies": {
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
-        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.11",
-        "@vitest/browser-preview": "4.1.11",
-        "@vitest/browser-webdriverio": "4.1.11",
-        "@vitest/coverage-istanbul": "4.1.11",
-        "@vitest/coverage-v8": "4.1.11",
-        "@vitest/ui": "4.1.11",
+        "@types/node": "^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "5.0.0",
+        "@vitest/browser-preview": "5.0.0",
+        "@vitest/browser-webdriverio": "^5.0.0-beta.5 || >=5.0.0",
+        "@vitest/coverage-istanbul": "5.0.0",
+        "@vitest/coverage-v8": "5.0.0",
+        "@vitest/ui": "5.0.0",
         "happy-dom": "*",
         "jsdom": "*",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "vite": "^6.4.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@cloudflare/containers": "^0.3.7",
     "@cloudflare/workers-types": "^5.20260828.1",
     "typescript": "^7.0.2",
-    "vitest": "^4.1.11",
+    "vitest": "^5.0.0",
     "wrangler": "^4.127.1"
   }
 }

--- a/src/better_telegram_mcp/auth/pending_otp_store.py
+++ b/src/better_telegram_mcp/auth/pending_otp_store.py
@@ -74,6 +74,10 @@ class PendingOtpStore:
     def _save_index(self, subs: list[str]) -> None:
         self._index_store().save({"subs": subs})
 
+    def has_any(self) -> bool:
+        """Return whether the shared index contains any pending OTPs."""
+        return bool(self._load_index())
+
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------

--- a/src/better_telegram_mcp/auth/telegram_auth_provider.py
+++ b/src/better_telegram_mcp/auth/telegram_auth_provider.py
@@ -424,7 +424,15 @@ class TelegramAuthProvider:
         removed = 0
         now = time.time()
 
-        if self._store.has_any():
+        has_sessions = self._store.has_any()
+        has_pending_kv = (
+            self._pending_store is not None and self._pending_store.has_any()
+        )
+
+        if not has_sessions and not self._pending_otps and not has_pending_kv:
+            return 0
+
+        if has_sessions:
             sessions = self._store.load_all()
             to_revoke = [
                 bearer
@@ -469,6 +477,12 @@ class TelegramAuthProvider:
                 return_exceptions=True,
             )
             removed += len(stale_otps)
+            if self._pending_store is not None:
+                for bearer, _ in stale_otps:
+                    self._pending_store.delete_pending_otp(sub=bearer, bearer=bearer)
+
+        if self._pending_store is not None and has_pending_kv:
+            removed += self._pending_store.cleanup_expired()
 
         return removed
 

--- a/src/better_telegram_mcp/relay_schema.py
+++ b/src/better_telegram_mcp/relay_schema.py
@@ -264,6 +264,9 @@ def render_telegram_form(
         initial_tab=initial_tab,
         include_username_field=STABLE_SUB_ENABLED,
     )
+    html = html.replace(
+        "<head>", '<head>\n    <meta name="color-scheme" content="light dark" />'
+    )
     return html.replace(
         "</body>",
         _PASSWORD_TOGGLE_JS

--- a/tests/auth/test_pending_otp_store.py
+++ b/tests/auth/test_pending_otp_store.py
@@ -206,6 +206,17 @@ def test_load_index_empty_when_unset():
     assert store._load_index() == []
 
 
+def test_has_any_tracks_shared_index():
+    store = PendingOtpStore(backend=InMemoryBackend())
+    assert store.has_any() is False
+
+    store.save_pending_otp("sub-a", "bearer-1", _data("+1"))
+    assert store.has_any() is True
+
+    assert store.delete_pending_otp("sub-a", "bearer-1") is True
+    assert store.has_any() is False
+
+
 def test_load_index_non_dict_returns_empty():
     """Defensive: a corrupted (non-dict) index payload yields []."""
     store = PendingOtpStore(backend=InMemoryBackend())

--- a/tests/test_relay_schema.py
+++ b/tests/test_relay_schema.py
@@ -10,6 +10,7 @@ def test_render_telegram_form_includes_toggle():
     html = render_telegram_form(RELAY_SCHEMA, "/submit")
     assert "Show password" in html
     assert "field-TELEGRAM_BOT_TOKEN" in html
+    assert '<meta name="color-scheme" content="light dark" />' in html
 
 
 def test_relay_schema_structure():

--- a/tests/test_telegram_auth_provider_cleanup.py
+++ b/tests/test_telegram_auth_provider_cleanup.py
@@ -51,3 +51,34 @@ async def test_shutdown_logs_pending_otp_disconnect_error(
         assert "Error disconnecting pending OTP backend test-bea" in caplog.text
     finally:
         logger.remove(handler_id)
+
+
+async def test_cleanup_expired_removes_persisted_pending_otp(
+    data_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CREDENTIAL_SECRET", "test-secret-32-bytes-padded-here!")
+    from mcp_core.storage.backends import InMemoryBackend
+
+    from better_telegram_mcp.auth.pending_otp_store import (
+        _OTP_TTL,
+        PendingOtpStore,
+    )
+
+    backend = InMemoryBackend()
+    pending_store = PendingOtpStore(backend=backend)
+    pending_store.save_pending_otp(
+        "bearer-expired",
+        "bearer-expired",
+        {
+            "phone": "+123",
+            "phone_code_hash": "hash",
+            "session_name": "session",
+            "created_at": time.time() - _OTP_TTL - 1,
+        },
+    )
+    provider = TelegramAuthProvider(
+        data_dir, api_id=12345, api_hash="test_hash", pending_store=pending_store
+    )
+
+    assert await provider.cleanup_expired() == 1
+    assert pending_store.has_any() is False


### PR DESCRIPTION
## Summary\n- add indexed pending-OTP existence checks and persisted-expiry cleanup\n- advertise light/dark support in the relay form\n- upgrade Worker tests to Vitest 5\n- document operational handover and verification commands\n\n## Verification\n- uv ruff check/format/ty check\n- pytest: 705 passed, 17 skipped, 129 deselected; 96.65% coverage\n- npm run test:worker: 15 passed\n- npm run type-check\n\nPalette view-transition proposals were reviewed and not adopted; duplicate color-scheme proposals are consolidated here.